### PR TITLE
Place form subdirectory at the top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,10 @@ endif ()
 
 add_subdirectory(phlex)
 
+if (PHLEX_USE_FORM)
+  add_subdirectory(form)
+endif()
+
 include(CTest)
 if (BUILD_TESTING)
   add_subdirectory(test)

--- a/phlex/CMakeLists.txt
+++ b/phlex/CMakeLists.txt
@@ -5,10 +5,6 @@ add_subdirectory(metaprogramming)
 add_subdirectory(model)
 add_subdirectory(utilities)
 
-if (PHLEX_USE_FORM)
-  add_subdirectory(form)
-endif()
-
 # Interface library
 add_library(phlex_int INTERFACE)
 target_include_directories(


### PR DESCRIPTION
The `add_subdirectory(form)` call is in `phlex/phlex/CMakelists.txt`, and it should be  `phlex/CMakeLists.txt`.