### PR TITLE
Ensure that ReadVector runs after WriteVector

### DIFF
--- a/test/form/CMakeLists.txt
+++ b/test/form/CMakeLists.txt
@@ -20,3 +20,4 @@ target_link_libraries(phlex_reader form form_test_data_products)
 
 add_test(NAME WriteVector COMMAND phlex_writer)
 add_test(NAME ReadVector COMMAND phlex_reader)
+set_tests_properties(ReadVector PROPERTIES DEPENDS WriteVector)


### PR DESCRIPTION
I'm encountering occasional test failures whenever the `ReadVector` CTest executes (something about `toy.root` not existing).  I *think* this is because the `ReadVector` test requires `toy.root` to have first been produced by the `WriteVector` test.  When invoking`ctest -j<N>`, this ordering is not guaranteed unless the dependency between the two tests is expressed.  This PR adds that dependency.