### PR TITLE
Warn only once per build directory about missing DOT

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,19 +1,17 @@
 find_package(Catch2 REQUIRED)
 
 find_program(DOT dot)
+if (NOT DOT)
+  message (
+    WARNING
+    "dot program not found; all TEST_DOT_GRAPH options will be ignored."
+  )
+endif()
 
 add_definitions("-UNDEBUG")
 
 function (dot_test BASENAME)
-  if (NOT DOT)
-    if (NOT DEFINED DONE_DOT_WARNING)
-      message(
-        WARNING
-          "dot program not found; all TEST_DOT_GRAPH options will be ignored."
-        )
-      set(DONE_DOT_WARNING TRUE CACHE BOOL "suppress silly warning")
-    endif()
-  else ()
+  if (DOT)
     set(ORIG_TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/${BASENAME}.d)
     set(TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/dot_${BASENAME}.d)
     file(MAKE_DIRECTORY ${TEST_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(Catch2 REQUIRED)
 find_program(DOT dot)
 if (NOT DOT)
   message (
-    WARNING
+    STATUS
     "dot program not found; all TEST_DOT_GRAPH options will be ignored."
   )
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,10 +6,13 @@ add_definitions("-UNDEBUG")
 
 function (dot_test BASENAME)
   if (NOT DOT)
-    message(
-      WARNING
-        "dot program not found; all TEST_DOT_GRAPH options will be ignored."
-      )
+    if (NOT DEFINED DONE_DOT_WARNING)
+      message(
+        WARNING
+          "dot program not found; all TEST_DOT_GRAPH options will be ignored."
+        )
+      set(DONE_DOT_WARNING TRUE CACHE BOOL "suppress silly warning")
+    endif()
   else ()
     set(ORIG_TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/${BASENAME}.d)
     set(TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/dot_${BASENAME}.d)


### PR DESCRIPTION
This mitigates #29  ... 