### PR TITLE
Adjust registration API for predicates and observers

### DIFF
--- a/phlex/core/CMakeLists.txt
+++ b/phlex/core/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(
   end_of_message.cpp
   filter.cpp
   framework_graph.cpp
+  glue.cpp
   message.cpp
   message_sender.cpp
   multiplexer.cpp
@@ -35,7 +36,7 @@ endif ()
 
 target_link_libraries(
   phlex_core PRIVATE TBB::tbb phlex::graph phlex::metaprogramming phlex::model
-                     phlex::utilities PUBLIC spdlog::spdlog
+                     phlex::utilities Boost::json PUBLIC spdlog::spdlog
   )
 
 # Interface library

--- a/phlex/core/bound_function.hpp
+++ b/phlex/core/bound_function.hpp
@@ -20,6 +20,74 @@
 
 namespace phlex::experimental {
 
+  template <typename T, is_observer_like FT>
+  class observer_api : public node_options<observer_api<T, FT>> {
+    using node_options_t = node_options<observer_api<T, FT>>;
+    using input_parameter_types = function_parameter_types<FT>;
+
+  public:
+    static constexpr auto N = number_parameters<FT>;
+
+    observer_api(configuration const* config,
+                 std::string name,
+                 std::shared_ptr<T> obj,
+                 FT f,
+                 concurrency c,
+                 tbb::flow::graph& g,
+                 node_catalog& nodes,
+                 std::vector<std::string>& errors) :
+      node_options_t{config},
+      name_{config ? config->get<std::string>("module_label") : "", std::move(name)},
+      obj_{obj},
+      ft_{std::move(f)},
+      concurrency_{c},
+      graph_{g},
+      nodes_{nodes},
+      errors_{errors}
+    {
+    }
+
+    auto family(std::array<specified_label, N> input_args)
+    {
+      nodes_.register_observer(errors_).set([this, in = std::move(input_args)] {
+        auto inputs = form_input_arguments<input_parameter_types>(name_.full(), std::move(in));
+        auto input_product_labels = detail::port_names(inputs);
+        auto delegated_function = delegate(obj_, ft_);
+        return std::make_unique<observer<decltype(delegated_function), decltype(inputs)>>(
+          std::move(name_),
+          concurrency_.value,
+          node_options_t::release_predicates(),
+          graph_,
+          std::move(delegated_function),
+          std::move(inputs),
+          std::move(input_product_labels));
+      });
+    }
+
+    template <label_compatible L>
+    auto family(std::array<L, N> input_args)
+    {
+      return family(to_labels(input_args));
+    }
+
+    auto family(label_compatible auto... input_args)
+    {
+      static_assert(N == sizeof...(input_args),
+                    "The number of function parameters is not the same as the number of specified "
+                    "input arguments.");
+      return family({specified_label::create(std::forward<decltype(input_args)>(input_args))...});
+    }
+
+  private:
+    algorithm_name name_;
+    std::shared_ptr<T> obj_;
+    FT ft_;
+    concurrency concurrency_;
+    tbb::flow::graph& graph_;
+    node_catalog& nodes_;
+    std::vector<std::string>& errors_;
+  };
+
   template <typename T, typename FT>
   class bound_function : public node_options<bound_function<T, FT>> {
     using node_options_t = node_options<bound_function<T, FT>>;
@@ -61,20 +129,6 @@ namespace phlex::experimental {
                            std::move(inputs)};
     }
 
-    auto observe(std::array<specified_label, N> input_args)
-      requires is_observer_like<FT>
-    {
-      auto inputs =
-        form_input_arguments<input_parameter_types>(name_.full(), std::move(input_args));
-      return pre_observer{nodes_.register_observer(errors_),
-                          std::move(name_),
-                          concurrency_.value,
-                          node_options_t::release_predicates(),
-                          graph_,
-                          delegate(obj_, ft_),
-                          std::move(inputs)};
-    }
-
     auto transform(std::array<specified_label, N> input_args)
       requires is_transform_like<FT>
     {
@@ -110,12 +164,6 @@ namespace phlex::experimental {
     }
 
     template <label_compatible L>
-    auto observe(std::array<L, N> input_args)
-    {
-      return observe(to_labels(input_args));
-    }
-
-    template <label_compatible L>
     auto transform(std::array<L, N> input_args)
     {
       return transform(to_labels(input_args));
@@ -133,14 +181,6 @@ namespace phlex::experimental {
                     "The number of function parameters is not the same as the number of specified "
                     "input arguments.");
       return evaluate({specified_label::create(std::forward<decltype(input_args)>(input_args))...});
-    }
-
-    auto observe(label_compatible auto... input_args)
-    {
-      static_assert(N == sizeof...(input_args),
-                    "The number of function parameters is not the same as the number of specified "
-                    "input arguments.");
-      return observe({specified_label::create(std::forward<decltype(input_args)>(input_args))...});
     }
 
     auto transform(label_compatible auto... input_args)

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -65,7 +65,7 @@ namespace phlex::experimental {
     class total_fold;
 
   public:
-    pre_fold(registrar<declared_folds> reg,
+    pre_fold(registrar<declared_fold_ptr> reg,
              algorithm_name name,
              std::size_t concurrency,
              std::vector<std::string> predicates,
@@ -144,7 +144,7 @@ namespace phlex::experimental {
     std::array<specified_label, N> product_labels_;
     std::string fold_interval_{level_id::base().level_name()};
     std::array<qualified_name, M> output_names_;
-    registrar<declared_folds> reg_;
+    registrar<declared_fold_ptr> reg_;
   };
 
   template <is_fold_like FT, typename InputArgs>

--- a/phlex/core/declared_output.hpp
+++ b/phlex/core/declared_output.hpp
@@ -46,7 +46,7 @@ namespace phlex::experimental {
     using node_options_t = node_options<output_creator>;
 
   public:
-    output_creator(registrar<declared_outputs> reg,
+    output_creator(registrar<declared_output_ptr> reg,
                    configuration const* config,
                    std::string name,
                    tbb::flow::graph& g,
@@ -76,7 +76,7 @@ namespace phlex::experimental {
     tbb::flow::graph& graph_;
     detail::output_function_t ft_;
     concurrency concurrency_;
-    registrar<declared_outputs> reg_;
+    registrar<declared_output_ptr> reg_;
   };
 }
 

--- a/phlex/core/declared_predicate.hpp
+++ b/phlex/core/declared_predicate.hpp
@@ -61,16 +61,17 @@ namespace phlex::experimental {
     using const_accessor = results_t::const_accessor;
 
   public:
+    using node_ptr_type = declared_predicate_ptr;
+
     predicate(algorithm_name name,
               std::size_t concurrency,
               std::vector<std::string> predicates,
               tbb::flow::graph& g,
               function_t&& f,
-              InputArgs input,
-              std::array<specified_label, N> product_labels) :
+              std::array<specified_label, N> input) :
       declared_predicate{std::move(name), std::move(predicates)},
-      product_labels_{std::move(product_labels)},
-      input_{std::move(input)},
+      input_{form_input_arguments<InputArgs>(full_name(), std::move(input))},
+      product_labels_{detail::port_names(input_)},
       join_{make_join_or_none(g, std::make_index_sequence<N>{})},
       predicate_{g,
                  concurrency,
@@ -124,8 +125,8 @@ namespace phlex::experimental {
 
     std::size_t num_calls() const final { return calls_.load(); }
 
+    input_retriever_types<InputArgs> input_;
     std::array<specified_label, N> product_labels_;
-    InputArgs input_;
     join_or_none_t<N> join_;
     tbb::flow::function_node<messages_t<N>, predicate_result> predicate_;
     results_t results_;

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -68,7 +68,7 @@ namespace phlex::experimental {
     class total_transform;
 
   public:
-    pre_transform(registrar<declared_transforms> reg,
+    pre_transform(registrar<declared_transform_ptr> reg,
                   algorithm_name name,
                   std::size_t concurrency,
                   std::vector<std::string> predicates,
@@ -129,7 +129,7 @@ namespace phlex::experimental {
     function_t ft_;
     InputArgs input_args_;
     std::array<specified_label, N> product_labels_;
-    registrar<declared_transforms> reg_;
+    registrar<declared_transform_ptr> reg_;
   };
 
   // =====================================================================================

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -84,7 +84,7 @@ namespace phlex::experimental {
     class complete_unfold;
 
   public:
-    partial_unfold(registrar<declared_unfolds> reg,
+    partial_unfold(registrar<declared_unfold_ptr> reg,
                    algorithm_name name,
                    std::size_t concurrency,
                    std::vector<std::string> predicates,
@@ -149,7 +149,7 @@ namespace phlex::experimental {
     InputArgs input_args_;
     std::array<specified_label, N> product_labels_;
     std::string new_level_name_;
-    registrar<declared_unfolds> reg_;
+    registrar<declared_unfold_ptr> reg_;
   };
 
   // =====================================================================================

--- a/phlex/core/double_bound_function.hpp
+++ b/phlex/core/double_bound_function.hpp
@@ -7,6 +7,7 @@
 #include "phlex/core/declared_observer.hpp"
 #include "phlex/core/declared_predicate.hpp"
 #include "phlex/core/declared_transform.hpp"
+#include "phlex/core/declared_unfold.hpp"
 #include "phlex/core/input_arguments.hpp"
 #include "phlex/core/node_catalog.hpp"
 #include "phlex/core/node_options.hpp"

--- a/phlex/core/double_bound_function.hpp
+++ b/phlex/core/double_bound_function.hpp
@@ -60,7 +60,7 @@ namespace phlex::experimental {
         form_input_arguments<input_parameter_types>(name_.full(), std::move(input_args));
 
       return partial_unfold<Object, Predicate, Unfold, decltype(processed_input_args)>{
-        nodes_.register_unfold(errors_),
+        nodes_.registrar_for<declared_unfold_ptr>(errors_),
         std::move(name_),
         concurrency_,
         node_options_t::release_predicates(),

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -78,6 +78,11 @@ namespace phlex::experimental {
       return unfold_proxy<T>().declare_unfold(predicate, unfold, c);
     }
 
+    auto observe(std::string name, is_observer_like auto f, concurrency c = concurrency::serial)
+    {
+      return proxy().observe(std::move(name), f, c);
+    }
+
     template <typename T, typename... Args>
     glue<T> make(Args&&... args)
     {

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -83,6 +83,11 @@ namespace phlex::experimental {
       return proxy().observe(std::move(name), f, c);
     }
 
+    auto predicate(std::string name, is_predicate_like auto f, concurrency c = concurrency::serial)
+    {
+      return proxy().predicate(std::move(name), f, c);
+    }
+
     template <typename T, typename... Args>
     glue<T> make(Args&&... args)
     {

--- a/phlex/core/glue.cpp
+++ b/phlex/core/glue.cpp
@@ -1,6 +1,7 @@
 #include "phlex/core/glue.hpp"
 #include "phlex/configuration.hpp"
 
+#include <stdexcept>
 #include <string>
 
 namespace phlex::experimental::detail {

--- a/phlex/core/glue.cpp
+++ b/phlex/core/glue.cpp
@@ -1,0 +1,22 @@
+#include "phlex/core/glue.hpp"
+#include "phlex/configuration.hpp"
+
+#include <string>
+
+namespace phlex::experimental::detail {
+  void verify_name(std::string const& name, configuration const* config)
+  {
+    if (not name.empty()) {
+      return;
+    }
+
+    std::string msg{"Cannot specify algorithm with no name"};
+    std::string const module = config ? config->get<std::string>("module_label") : "";
+    if (!module.empty()) {
+      msg += " (module: '";
+      msg += module;
+      msg += "')";
+    }
+    throw std::runtime_error{msg};
+  }
+}

--- a/phlex/core/glue.hpp
+++ b/phlex/core/glue.hpp
@@ -2,7 +2,6 @@
 #define phlex_core_glue_hpp
 
 #include "phlex/concurrency.hpp"
-#include "phlex/configuration.hpp"
 #include "phlex/core/bound_function.hpp"
 #include "phlex/core/concepts.hpp"
 #include "phlex/core/double_bound_function.hpp"
@@ -14,12 +13,12 @@
 #include "oneapi/tbb/flow_graph.h"
 
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <utility>
 
 namespace phlex::experimental {
+  class configuration;
 
   namespace detail {
     void verify_name(std::string const& name, configuration const* config);

--- a/phlex/core/glue.hpp
+++ b/phlex/core/glue.hpp
@@ -52,6 +52,12 @@ namespace phlex::experimental {
       return observer_api{config_, std::move(name), bound_obj_, f, c, graph_, nodes_, errors_};
     }
 
+    auto predicate(std::string name, auto f, concurrency c = concurrency::serial)
+    {
+      detail::verify_name(name, config_);
+      return predicate_api{config_, std::move(name), bound_obj_, f, c, graph_, nodes_, errors_};
+    }
+
     auto output_with(std::string name, is_output_like auto f, concurrency c = concurrency::serial)
     {
       return output_creator{nodes_.register_output(errors_),

--- a/phlex/core/glue.hpp
+++ b/phlex/core/glue.hpp
@@ -46,16 +46,27 @@ namespace phlex::experimental {
       return bound_function{config_, std::move(name), bound_obj_, f, c, graph_, nodes_, errors_};
     }
 
-    auto observe(std::string name, auto f, concurrency c = concurrency::serial)
+    template <typename FT>
+    auto observe(std::string name, FT f, concurrency c = concurrency::serial)
     {
       detail::verify_name(name, config_);
-      return observer_api{config_, std::move(name), bound_obj_, f, c, graph_, nodes_, errors_};
+      return make_registration<observer>(
+        config_, std::move(name), algorithm_bits{bound_obj_, f}, c, graph_, nodes_, errors_);
     }
 
-    auto predicate(std::string name, auto f, concurrency c = concurrency::serial)
+    template <typename FT>
+    auto predicate(std::string name, FT f, concurrency c = concurrency::serial)
     {
       detail::verify_name(name, config_);
-      return predicate_api{config_, std::move(name), bound_obj_, f, c, graph_, nodes_, errors_};
+      return make_registration<
+        phlex::experimental::predicate>( // Disambiguate from function template name
+        config_,
+        std::move(name),
+        algorithm_bits{bound_obj_, f},
+        c,
+        graph_,
+        nodes_,
+        errors_);
     }
 
     auto output_with(std::string name, is_output_like auto f, concurrency c = concurrency::serial)

--- a/phlex/core/glue.hpp
+++ b/phlex/core/glue.hpp
@@ -21,6 +21,10 @@
 
 namespace phlex::experimental {
 
+  namespace detail {
+    void verify_name(std::string const& name, configuration const* config);
+  }
+
   // ==============================================================================
   // Registering user functions
 
@@ -38,17 +42,14 @@ namespace phlex::experimental {
 
     auto with(std::string name, auto f, concurrency c = concurrency::serial)
     {
-      if (name.empty()) {
-        std::string msg{"Cannot specify algorithm with no name"};
-        std::string const module = config_ ? config_->get<std::string>("module_label") : "";
-        if (!module.empty()) {
-          msg += " (module: '";
-          msg += module;
-          msg += "')";
-        }
-        throw std::runtime_error{msg};
-      }
+      detail::verify_name(name, config_);
       return bound_function{config_, std::move(name), bound_obj_, f, c, graph_, nodes_, errors_};
+    }
+
+    auto observe(std::string name, auto f, concurrency c = concurrency::serial)
+    {
+      detail::verify_name(name, config_);
+      return observer_api{config_, std::move(name), bound_obj_, f, c, graph_, nodes_, errors_};
     }
 
     auto output_with(std::string name, is_output_like auto f, concurrency c = concurrency::serial)

--- a/phlex/core/graph_proxy.hpp
+++ b/phlex/core/graph_proxy.hpp
@@ -47,7 +47,12 @@ namespace phlex::experimental {
 
     auto with(std::string name, auto f, concurrency c = concurrency::serial)
     {
-      return glue{graph_, nodes_, bound_obj_, errors_, config_}.with(name, f, c);
+      return glue{graph_, nodes_, bound_obj_, errors_, config_}.with(std::move(name), f, c);
+    }
+
+    auto observe(std::string name, is_observer_like auto f, concurrency c = concurrency::serial)
+    {
+      return glue{graph_, nodes_, bound_obj_, errors_, config_}.observe(std::move(name), f, c);
     }
 
     template <typename Splitter>

--- a/phlex/core/graph_proxy.hpp
+++ b/phlex/core/graph_proxy.hpp
@@ -47,17 +47,17 @@ namespace phlex::experimental {
 
     auto with(std::string name, auto f, concurrency c = concurrency::serial)
     {
-      return glue{graph_, nodes_, bound_obj_, errors_, config_}.with(std::move(name), f, c);
+      return create_glue().with(std::move(name), f, c);
     }
 
     auto observe(std::string name, is_observer_like auto f, concurrency c = concurrency::serial)
     {
-      return glue{graph_, nodes_, bound_obj_, errors_, config_}.observe(std::move(name), f, c);
+      return create_glue().observe(std::move(name), f, c);
     }
 
     auto predicate(std::string name, is_predicate_like auto f, concurrency c = concurrency::serial)
     {
-      return glue{graph_, nodes_, bound_obj_, errors_, config_}.predicate(std::move(name), f, c);
+      return create_glue().predicate(std::move(name), f, c);
     }
 
     template <typename Splitter>
@@ -82,6 +82,8 @@ namespace phlex::experimental {
       : config_{config}, graph_{g}, nodes_{nodes}, bound_obj_{bound_obj}, errors_{errors}
     {
     }
+
+    glue<T> create_glue() { return glue{graph_, nodes_, bound_obj_, errors_, config_}; }
 
     configuration const* config_;
     tbb::flow::graph& graph_;

--- a/phlex/core/graph_proxy.hpp
+++ b/phlex/core/graph_proxy.hpp
@@ -55,6 +55,11 @@ namespace phlex::experimental {
       return glue{graph_, nodes_, bound_obj_, errors_, config_}.observe(std::move(name), f, c);
     }
 
+    auto predicate(std::string name, is_predicate_like auto f, concurrency c = concurrency::serial)
+    {
+      return glue{graph_, nodes_, bound_obj_, errors_, config_}.predicate(std::move(name), f, c);
+    }
+
     template <typename Splitter>
     auto with(auto predicate, auto unfold, concurrency c = concurrency::serial)
     {

--- a/phlex/core/input_arguments.hpp
+++ b/phlex/core/input_arguments.hpp
@@ -26,6 +26,18 @@ namespace phlex::experimental {
     }
   };
 
+  template <typename InputTypes>
+  struct input_retriever_types_impl {
+    template <std::size_t... Is>
+    static std::tuple<retriever<std::tuple_element_t<Is, InputTypes>, Is>...> form_tuple(
+      std::index_sequence<Is...>);
+
+    using type = decltype(form_tuple(std::make_index_sequence<std::tuple_size_v<InputTypes>>{}));
+  };
+
+  template <typename InputTypes>
+  using input_retriever_types = typename input_retriever_types_impl<InputTypes>::type;
+
   template <typename InputTypes, std::size_t... Is>
   auto form_input_arguments_impl(std::array<specified_label, sizeof...(Is)> args,
                                  std::index_sequence<Is...>)
@@ -33,8 +45,6 @@ namespace phlex::experimental {
     return std::make_tuple(
       retriever<std::tuple_element_t<Is, InputTypes>, Is>{std::move(args[Is])}...);
   }
-
-  // =====================================================================================
 
   template <typename InputTypes, std::size_t N>
   auto form_input_arguments(std::string const& algorithm_name, std::array<specified_label, N> args)

--- a/phlex/core/node_catalog.hpp
+++ b/phlex/core/node_catalog.hpp
@@ -9,6 +9,9 @@
 #include "phlex/core/declared_unfold.hpp"
 #include "phlex/core/registrar.hpp"
 
+#include <string>
+#include <vector>
+
 namespace phlex::experimental {
   struct node_catalog {
     auto register_output(std::vector<std::string>& errors) { return registrar{outputs_, errors}; }

--- a/phlex/core/node_catalog.hpp
+++ b/phlex/core/node_catalog.hpp
@@ -11,21 +11,10 @@
 
 namespace phlex::experimental {
   struct node_catalog {
-    auto register_predicate(std::vector<std::string>& errors)
-    {
-      return registrar{predicates_, errors};
-    }
-    auto register_observer(std::vector<std::string>& errors)
-    {
-      return registrar{observers_, errors};
-    }
     auto register_output(std::vector<std::string>& errors) { return registrar{outputs_, errors}; }
-    auto register_fold(std::vector<std::string>& errors) { return registrar{folds_, errors}; }
-    auto register_unfold(std::vector<std::string>& errors) { return registrar{unfolds_, errors}; }
-    auto register_transform(std::vector<std::string>& errors)
-    {
-      return registrar{transforms_, errors};
-    }
+
+    template <typename T>
+    auto registrar_for(std::vector<std::string>& errors) = delete;
 
     declared_predicates predicates_{};
     declared_observers observers_{};
@@ -34,6 +23,36 @@ namespace phlex::experimental {
     declared_unfolds unfolds_{};
     declared_transforms transforms_{};
   };
+
+  template <>
+  inline auto node_catalog::registrar_for<declared_predicate_ptr>(std::vector<std::string>& errors)
+  {
+    return registrar{predicates_, errors};
+  }
+
+  template <>
+  inline auto node_catalog::registrar_for<declared_observer_ptr>(std::vector<std::string>& errors)
+  {
+    return registrar{observers_, errors};
+  }
+
+  template <>
+  inline auto node_catalog::registrar_for<declared_transform_ptr>(std::vector<std::string>& errors)
+  {
+    return registrar{transforms_, errors};
+  }
+
+  template <>
+  inline auto node_catalog::registrar_for<declared_fold_ptr>(std::vector<std::string>& errors)
+  {
+    return registrar{folds_, errors};
+  }
+
+  template <>
+  inline auto node_catalog::registrar_for<declared_unfold_ptr>(std::vector<std::string>& errors)
+  {
+    return registrar{unfolds_, errors};
+  }
 }
 
 #endif // phlex_core_node_catalog_hpp

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -48,6 +48,7 @@
 // =======================================================================================
 
 #include <functional>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -63,7 +64,7 @@ namespace phlex::experimental {
 
   public:
     explicit registrar(Nodes& nodes, std::vector<std::string>& errors) :
-      nodes_{nodes}, errors_{errors}
+      nodes_{&nodes}, errors_{&errors}
     {
     }
 
@@ -79,16 +80,16 @@ namespace phlex::experimental {
       if (creator_) {
         auto ptr = creator_();
         auto name = ptr->full_name();
-        auto [_, inserted] = nodes_.try_emplace(name, std::move(ptr));
+        auto [_, inserted] = nodes_->try_emplace(name, std::move(ptr));
         if (not inserted) {
-          errors_.push_back(fmt::format("Node with name '{}' already exists", name));
+          errors_->push_back(fmt::format("Node with name '{}' already exists", name));
         }
       }
     }
 
   private:
-    Nodes& nodes_;
-    std::vector<std::string>& errors_;
+    Nodes* nodes_;
+    std::vector<std::string>* errors_;
     Creator creator_{};
   };
 

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -56,9 +56,10 @@ namespace phlex::experimental {
   template <typename T>
   concept map_like = requires { typename T::mapped_type; };
 
-  template <map_like Nodes>
+  template <typename Ptr>
   class registrar {
-    using Creator = std::function<typename Nodes::mapped_type()>;
+    using Nodes = std::map<std::string, Ptr>;
+    using Creator = std::function<Ptr()>;
 
   public:
     explicit registrar(Nodes& nodes, std::vector<std::string>& errors) :
@@ -90,6 +91,9 @@ namespace phlex::experimental {
     std::vector<std::string>& errors_;
     Creator creator_{};
   };
+
+  template <map_like Nodes>
+  registrar(Nodes&, std::vector<std::string>&) -> registrar<typename Nodes::mapped_type>;
 
 }
 

--- a/phlex/metaprogramming/delegate.hpp
+++ b/phlex/metaprogramming/delegate.hpp
@@ -1,6 +1,8 @@
 #ifndef phlex_metaprogramming_delegate_hpp
 #define phlex_metaprogramming_delegate_hpp
 
+#include "phlex/metaprogramming/type_deduction.hpp"
+
 #include <functional>
 #include <memory>
 
@@ -9,28 +11,51 @@ namespace phlex::experimental {
   struct unfold_tag {};
 
   template <typename FT>
-  auto delegate(std::shared_ptr<void_tag>&, FT f) // Used for lambda closures
+  auto delegate(std::shared_ptr<void_tag>, FT f) // Used for lambda closures
   {
     return std::function{f};
   }
 
   template <typename R, typename... Args>
-  auto delegate(std::shared_ptr<void_tag>&, R (*f)(Args...))
+  auto delegate(std::shared_ptr<void_tag>, R (*f)(Args...))
   {
     return std::function{f};
   }
 
   template <typename R, typename T, typename... Args>
-  auto delegate(std::shared_ptr<T>& obj, R (T::*f)(Args...))
+  auto delegate(std::shared_ptr<T> obj, R (T::*f)(Args...))
   {
     return std::function{[t = obj, f](Args... args) mutable -> R { return ((*t).*f)(args...); }};
   }
 
   template <typename R, typename T, typename... Args>
-  auto delegate(std::shared_ptr<T>& obj, R (T::*f)(Args...) const)
+  auto delegate(std::shared_ptr<T> obj, R (T::*f)(Args...) const)
   {
     return std::function{[t = obj, f](Args... args) mutable -> R { return ((*t).*f)(args...); }};
   }
+
+  template <typename Bound, typename Algorithm>
+  class algorithm_bits {
+  public:
+    using bound_type = Bound;
+    using algorithm_type = Algorithm;
+    using input_parameter_types = function_parameter_types<Algorithm>;
+    template <typename T>
+    algorithm_bits(T object, Algorithm algorithm) :
+      bound_{delegate(std::move(object), std::move(algorithm))}
+    {
+    }
+    auto release_algorithm() { return std::move(bound_); }
+
+  private:
+    Bound bound_;
+  };
+
+  template <typename T, typename Algorithm>
+  algorithm_bits(std::shared_ptr<T>, Algorithm)
+    -> algorithm_bits<decltype(delegate(std::shared_ptr<T>{}, std::declval<Algorithm>())),
+                      Algorithm>;
+
 }
 
 #endif // phlex_metaprogramming_delegate_hpp

--- a/phlex/metaprogramming/delegate.hpp
+++ b/phlex/metaprogramming/delegate.hpp
@@ -8,7 +8,6 @@
 
 namespace phlex::experimental {
   struct void_tag {};
-  struct unfold_tag {};
 
   template <typename FT>
   auto delegate(std::shared_ptr<void_tag>, FT f) // Used for lambda closures

--- a/test/allowed_families.cpp
+++ b/test/allowed_families.cpp
@@ -53,9 +53,9 @@ namespace {
 TEST_CASE("Testing families", "[data model]")
 {
   framework_graph g{levels_to_process, 2};
-  g.with("se", check_two_ids).observe("id"_in("subrun"), "id"_in("event"));
-  g.with("rs", check_two_ids).observe("id"_in("run"), "id"_in("subrun"));
-  g.with("rse", check_three_ids).observe("id"_in("run"), "id"_in("subrun"), "id"_in("event"));
+  g.observe("se", check_two_ids).family("id"_in("subrun"), "id"_in("event"));
+  g.observe("rs", check_two_ids).family("id"_in("run"), "id"_in("subrun"));
+  g.observe("rse", check_three_ids).family("id"_in("run"), "id"_in("subrun"), "id"_in("event"));
   g.execute("allowed_families_t");
 
   CHECK(g.execution_counts("se") == 1ull);

--- a/test/benchmarks/accept_even_ids.cpp
+++ b/test/benchmarks/accept_even_ids.cpp
@@ -5,9 +5,9 @@
 
 PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
 {
-  m.with(
+  m.predicate(
      "accept_even_ids",
      [](phlex::experimental::level_id const& id) { return id.number() % 2 == 0; },
      phlex::experimental::concurrency::unlimited)
-    .evaluate(config.get<std::string>("product_name"));
+    .family(config.get<std::string>("product_name"));
 }

--- a/test/benchmarks/accept_even_numbers.cpp
+++ b/test/benchmarks/accept_even_numbers.cpp
@@ -4,9 +4,9 @@
 
 PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
 {
-  m.with(
+  m.predicate(
      "accept_even_numbers",
      [](int i) { return i % 2 == 0; },
      phlex::experimental::concurrency::unlimited)
-    .evaluate(config.get<std::string>("consumes"));
+    .family(config.get<std::string>("consumes"));
 }

--- a/test/benchmarks/accept_fibonacci_numbers.cpp
+++ b/test/benchmarks/accept_fibonacci_numbers.cpp
@@ -6,6 +6,7 @@
 PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
 {
   m.make<test::fibonacci_numbers>(config.get<int>("max_number"))
-    .with("accept", &test::fibonacci_numbers::accept, phlex::experimental::concurrency::unlimited)
-    .evaluate(config.get<std::string>("consumes"));
+    .predicate(
+      "accept", &test::fibonacci_numbers::accept, phlex::experimental::concurrency::unlimited)
+    .family(config.get<std::string>("consumes"));
 }

--- a/test/benchmarks/read_id.cpp
+++ b/test/benchmarks/read_id.cpp
@@ -7,5 +7,5 @@ namespace {
 
 PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m)
 {
-  m.with("read_id", read_id, phlex::experimental::concurrency::unlimited).observe("id");
+  m.observe("read_id", read_id, phlex::experimental::concurrency::unlimited).family("id");
 }

--- a/test/benchmarks/read_index.cpp
+++ b/test/benchmarks/read_index.cpp
@@ -7,6 +7,6 @@ namespace {
 
 PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
 {
-  m.with("read_index", read_index, phlex::experimental::concurrency::unlimited)
-    .observe(config.get<std::string>("consumes"));
+  m.observe("read_index", read_index, phlex::experimental::concurrency::unlimited)
+    .family(config.get<std::string>("consumes"));
 }

--- a/test/benchmarks/verify_difference.cpp
+++ b/test/benchmarks/verify_difference.cpp
@@ -6,9 +6,9 @@ using namespace phlex::experimental;
 
 PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
 {
-  m.with(
+  m.observe(
      "verify_difference",
      [expected = config.get<int>("expected", 100)](int i, int j) { assert(j - i == expected); },
      concurrency::unlimited)
-    .observe(config.get<std::string>("i", "b"), config.get<std::string>("j", "c"));
+    .family(config.get<std::string>("i", "b"), config.get<std::string>("j", "c"));
 }

--- a/test/benchmarks/verify_even_fibonacci_numbers.cpp
+++ b/test/benchmarks/verify_even_fibonacci_numbers.cpp
@@ -18,7 +18,7 @@ PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
 {
   using namespace test;
   m.make<even_fibonacci_numbers>(config.get<int>("max_number"))
-    .with(
+    .observe(
       "only_even", &even_fibonacci_numbers::only_even, phlex::experimental::concurrency::unlimited)
-    .observe(config.get<std::string>("consumes"));
+    .family(config.get<std::string>("consumes"));
 }

--- a/test/class_registration.cpp
+++ b/test/class_registration.cpp
@@ -92,7 +92,7 @@ TEST_CASE("Call non-framework functions", "[programming model]")
   }
 
   // The following is invoked for *each* section above
-  g.with("verify_results", verify_results, concurrency::unlimited).observe(product_names);
+  g.observe("verify_results", verify_results, concurrency::unlimited).family(product_names);
 
   g.execute("class_component_t");
 }

--- a/test/different_hierarchies.cpp
+++ b/test/different_hierarchies.cpp
@@ -86,12 +86,12 @@ TEST_CASE("Different hierarchies used with fold", "[graph]")
     .initialized_with(0u);
   g.with("job_add", add, concurrency::unlimited).fold("number").to("job_sum");
 
-  g.with("verify_run_sum", [](unsigned int actual) { CHECK(actual == 10u); }).observe("run_sum");
-  g.with("verify_job_sum",
-         [](unsigned int actual) {
-           CHECK(actual == 20u + 45u); // 20u from events, 45u from trigger primitives
-         })
-    .observe("job_sum");
+  g.observe("verify_run_sum", [](unsigned int actual) { CHECK(actual == 10u); }).family("run_sum");
+  g.observe("verify_job_sum",
+            [](unsigned int actual) {
+              CHECK(actual == 20u + 45u); // 20u from events, 45u from trigger primitives
+            })
+    .family("job_sum");
 
   g.execute();
 

--- a/test/filter.cpp
+++ b/test/filter.cpp
@@ -85,8 +85,8 @@ namespace {
 TEST_CASE("Two predicates", "[filtering]")
 {
   framework_graph g{source{10u}};
-  g.with("evens_only", evens_only, concurrency::unlimited).evaluate("num"_in("event"));
-  g.with("odds_only", odds_only, concurrency::unlimited).evaluate("num"_in("event"));
+  g.predicate("evens_only", evens_only, concurrency::unlimited).family("num"_in("event"));
+  g.predicate("odds_only", odds_only, concurrency::unlimited).family("num"_in("event"));
   g.make<sum_numbers>(20u)
     .observe("add_evens", &sum_numbers::add, concurrency::unlimited)
     .when("evens_only")
@@ -102,8 +102,8 @@ TEST_CASE("Two predicates", "[filtering]")
 TEST_CASE("Two predicates in series", "[filtering]")
 {
   framework_graph g{source{10u}};
-  g.with("evens_only", evens_only, concurrency::unlimited).evaluate("num");
-  g.with("odds_only", odds_only, concurrency::unlimited).when("evens_only").evaluate("num");
+  g.predicate("evens_only", evens_only, concurrency::unlimited).family("num");
+  g.predicate("odds_only", odds_only, concurrency::unlimited).when("evens_only").family("num");
   g.make<sum_numbers>(0u)
     .observe("add", &sum_numbers::add, concurrency::unlimited)
     .when("odds_only")
@@ -115,8 +115,8 @@ TEST_CASE("Two predicates in series", "[filtering]")
 TEST_CASE("Two predicates in parallel", "[filtering]")
 {
   framework_graph g{source{10u}};
-  g.with("evens_only", evens_only, concurrency::unlimited).evaluate("num");
-  g.with("odds_only", odds_only, concurrency::unlimited).evaluate("num");
+  g.predicate("evens_only", evens_only, concurrency::unlimited).family("num");
+  g.predicate("odds_only", odds_only, concurrency::unlimited).family("num");
   g.make<sum_numbers>(0u)
     .observe("add", &sum_numbers::add, concurrency::unlimited)
     .when("odds_only", "evens_only")
@@ -139,8 +139,8 @@ TEST_CASE("Three predicates in parallel", "[filtering]")
   framework_graph g{source{10u}};
   for (auto const& [name, b, e] : configs) {
     g.make<not_in_range>(b, e)
-      .with(name, &not_in_range::eval, concurrency::unlimited)
-      .evaluate("num");
+      .predicate(name, &not_in_range::eval, concurrency::unlimited)
+      .family("num");
   }
 
   std::vector<std::string> const predicate_names{
@@ -157,8 +157,8 @@ TEST_CASE("Three predicates in parallel", "[filtering]")
 TEST_CASE("Two predicates in parallel (each with multiple arguments)", "[filtering]")
 {
   framework_graph g{source{10u}};
-  g.with("evens_only", evens_only, concurrency::unlimited).evaluate("num");
-  g.with("odds_only", odds_only, concurrency::unlimited).evaluate("num");
+  g.predicate("evens_only", evens_only, concurrency::unlimited).family("num");
+  g.predicate("odds_only", odds_only, concurrency::unlimited).family("num");
   g.make<check_multiple_numbers>(5 * 100)
     .observe("check_evens", &check_multiple_numbers::add_difference, concurrency::unlimited)
     .when("evens_only")

--- a/test/filter.cpp
+++ b/test/filter.cpp
@@ -88,13 +88,13 @@ TEST_CASE("Two predicates", "[filtering]")
   g.with("evens_only", evens_only, concurrency::unlimited).evaluate("num"_in("event"));
   g.with("odds_only", odds_only, concurrency::unlimited).evaluate("num"_in("event"));
   g.make<sum_numbers>(20u)
-    .with("add_evens", &sum_numbers::add, concurrency::unlimited)
+    .observe("add_evens", &sum_numbers::add, concurrency::unlimited)
     .when("evens_only")
-    .observe("num"_in("event"));
+    .family("num"_in("event"));
   g.make<sum_numbers>(25u)
-    .with("add_odds", &sum_numbers::add, concurrency::unlimited)
+    .observe("add_odds", &sum_numbers::add, concurrency::unlimited)
     .when("odds_only")
-    .observe("num"_in("event"));
+    .family("num"_in("event"));
 
   g.execute("two_independent_predicates_t");
 }
@@ -105,9 +105,9 @@ TEST_CASE("Two predicates in series", "[filtering]")
   g.with("evens_only", evens_only, concurrency::unlimited).evaluate("num");
   g.with("odds_only", odds_only, concurrency::unlimited).when("evens_only").evaluate("num");
   g.make<sum_numbers>(0u)
-    .with("add", &sum_numbers::add, concurrency::unlimited)
+    .observe("add", &sum_numbers::add, concurrency::unlimited)
     .when("odds_only")
-    .observe("num");
+    .family("num");
 
   g.execute("two_predicates_in_series_t");
 }
@@ -118,9 +118,9 @@ TEST_CASE("Two predicates in parallel", "[filtering]")
   g.with("evens_only", evens_only, concurrency::unlimited).evaluate("num");
   g.with("odds_only", odds_only, concurrency::unlimited).evaluate("num");
   g.make<sum_numbers>(0u)
-    .with("add", &sum_numbers::add, concurrency::unlimited)
+    .observe("add", &sum_numbers::add, concurrency::unlimited)
     .when("odds_only", "evens_only")
-    .observe("num");
+    .family("num");
 
   g.execute("two_predicates_in_parallel_t");
 }
@@ -147,9 +147,9 @@ TEST_CASE("Three predicates in parallel", "[filtering]")
     "exclude_0_to_4", "exclude_6_to_7", "exclude_gt_8"};
   auto const expected_numbers = {4u, 5u, 7u};
   g.make<collect_numbers>(expected_numbers)
-    .with("collect", &collect_numbers::collect, concurrency::unlimited)
+    .observe("collect", &collect_numbers::collect, concurrency::unlimited)
     .when(predicate_names)
-    .observe("num");
+    .family("num");
 
   g.execute("three_predicates_in_parallel_t");
 }
@@ -160,14 +160,14 @@ TEST_CASE("Two predicates in parallel (each with multiple arguments)", "[filteri
   g.with("evens_only", evens_only, concurrency::unlimited).evaluate("num");
   g.with("odds_only", odds_only, concurrency::unlimited).evaluate("num");
   g.make<check_multiple_numbers>(5 * 100)
-    .with("check_evens", &check_multiple_numbers::add_difference, concurrency::unlimited)
+    .observe("check_evens", &check_multiple_numbers::add_difference, concurrency::unlimited)
     .when("evens_only")
-    .observe("num", "other_num"); // <= Note input order
+    .family("num", "other_num"); // <= Note input order
 
   g.make<check_multiple_numbers>(-5 * 100)
-    .with("check_odds", &check_multiple_numbers::add_difference, concurrency::unlimited)
+    .observe("check_odds", &check_multiple_numbers::add_difference, concurrency::unlimited)
     .when("odds_only")
-    .observe("other_num", "num"); // <= Note input order
+    .family("other_num", "num"); // <= Note input order
 
   g.execute("two_predicates_in_parallel_multiarg_t");
 }

--- a/test/fold.cpp
+++ b/test/fold.cpp
@@ -69,17 +69,17 @@ TEST_CASE("Different levels of fold", "[graph]")
 
   g.with("two_layer_job_add", add, concurrency::unlimited).fold("run_sum").to("two_layer_job_sum");
 
-  g.with(
+  g.observe(
      "verify_run_sum", [](unsigned int actual) { CHECK(actual == 10u); }, concurrency::unlimited)
-    .observe("run_sum");
-  g.with(
+    .family("run_sum");
+  g.observe(
      "verify_two_layer_job_sum",
      [](unsigned int actual) { CHECK(actual == 20u); },
      concurrency::unlimited)
-    .observe("two_layer_job_sum");
-  g.with(
+    .family("two_layer_job_sum");
+  g.observe(
      "verify_job_sum", [](unsigned int actual) { CHECK(actual == 20u); }, concurrency::unlimited)
-    .observe("job_sum");
+    .family("job_sum");
 
   g.execute();
 

--- a/test/function_registration.cpp
+++ b/test/function_registration.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Call non-framework functions", "[programming model]")
   }
 
   // The following is invoked for *each* section above
-  g.with("verify_results", verify_results).observe(product_names);
+  g.observe("verify_results", verify_results).family(product_names);
 
   g.execute();
 }

--- a/test/hierarchical_nodes.cpp
+++ b/test/hierarchical_nodes.cpp
@@ -113,7 +113,7 @@ TEST_CASE("Hierarchical nodes", "[graph]")
     .initialized_with(15u);
 
   g.with("scale", scale, concurrency::unlimited).transform("added_data").to("result");
-  g.with("print_result", print_result, concurrency::unlimited).observe("result", "strtime");
+  g.observe("print_result", print_result, concurrency::unlimited).family("result", "strtime");
 
   g.make<test::products_for_output>().output_with("save", &test::products_for_output::save).when();
 

--- a/test/max-parallelism/check_parallelism.cpp
+++ b/test/max-parallelism/check_parallelism.cpp
@@ -33,9 +33,9 @@ namespace {
 PHLEX_EXPERIMENTAL_REGISTER_SOURCE(send_parallelism)
 PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
 {
-  m.with("verify_expected",
-         [expected = config.get<std::size_t>("expected_parallelism")](std::size_t actual) {
-           assert(actual == expected);
-         })
-    .observe("max_parallelism");
+  m.observe("verify_expected",
+            [expected = config.get<std::size_t>("expected_parallelism")](std::size_t actual) {
+              assert(actual == expected);
+            })
+    .family("max_parallelism");
 }

--- a/test/multiple_function_registration.cpp
+++ b/test/multiple_function_registration.cpp
@@ -74,6 +74,6 @@ TEST_CASE("Call multiple functions", "[programming model]")
   }
 
   // The following is invoked for *each* section above
-  g.with("verify_result", [](double actual) { assert(actual == 6.); }).observe("result");
+  g.observe("verify_result", [](double actual) { assert(actual == 6.); }).family("result");
   g.execute();
 }

--- a/test/plugins/module.cpp
+++ b/test/plugins/module.cpp
@@ -10,5 +10,7 @@ using namespace phlex::experimental;
 PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m)
 {
   m.with("add", test::add, concurrency::unlimited).transform("i", "j").to("sum");
-  m.with("verify", [](int actual) { assert(actual == 0); }, concurrency::unlimited).observe("sum");
+  m.observe(
+     "verify", [](int actual) { assert(actual == 0); }, concurrency::unlimited)
+    .family("sum");
 }

--- a/test/unfold.cpp
+++ b/test/unfold.cpp
@@ -102,7 +102,7 @@ TEST_CASE("Splitting the processing", "[graph]")
     .into("new_number")
     .within_family("lower1");
   g.with("add", add, concurrency::unlimited).fold("new_number").partitioned_by("event").to("sum1");
-  g.with("check_sum", check_sum, concurrency::unlimited).observe("sum1");
+  g.observe("check_sum", check_sum, concurrency::unlimited).family("sum1");
 
   g.with<iterate_through>(
      &iterate_through::predicate, &iterate_through::unfold, concurrency::unlimited)
@@ -113,7 +113,7 @@ TEST_CASE("Splitting the processing", "[graph]")
     .fold("each_number")
     .partitioned_by("event")
     .to("sum2");
-  g.with("check_sum_same", check_sum_same, concurrency::unlimited).observe("sum2");
+  g.observe("check_sum_same", check_sum_same, concurrency::unlimited).family("sum2");
 
   g.make<test::products_for_output>().output_with(
     "save", &test::products_for_output::save, concurrency::serial);


### PR DESCRIPTION
Addresses issues #16 and #17.  This PR primarily effects the change:

```diff
- m.with(...).observe(...)
+ m.observe(...).family(...)
```

and 

```diff
- m.with(...).predicate(...)
+ m.predicate(...).family(...)
```

This PR also introduces some adjustments to the internal registration mechanisms, in preparation for adjusting the other HOFs.