### PR TITLE
Change observer/predicate API to use input_family(...)

### DIFF
--- a/phlex/core/bound_function.hpp
+++ b/phlex/core/bound_function.hpp
@@ -45,7 +45,7 @@ namespace phlex::experimental {
     {
     }
 
-    auto family(std::array<specified_label, N> input_args)
+    auto input_family(std::array<specified_label, N> input_args)
     {
       registrar_.set([this, inputs = std::move(input_args)] {
         return std::make_unique<hof_type>(std::move(name_),
@@ -58,17 +58,18 @@ namespace phlex::experimental {
     }
 
     template <label_compatible L>
-    auto family(std::array<L, N> input_args)
+    auto input_family(std::array<L, N> input_args)
     {
-      return family(to_labels(input_args));
+      return input_family(to_labels(input_args));
     }
 
-    auto family(label_compatible auto... input_args)
+    auto input_family(label_compatible auto... input_args)
     {
       static_assert(N == sizeof...(input_args),
                     "The number of function parameters is not the same as the number of specified "
                     "input arguments.");
-      return family({specified_label::create(std::forward<decltype(input_args)>(input_args))...});
+      return input_family(
+        {specified_label::create(std::forward<decltype(input_args)>(input_args))...});
     }
 
   private:

--- a/test/allowed_families.cpp
+++ b/test/allowed_families.cpp
@@ -53,9 +53,10 @@ namespace {
 TEST_CASE("Testing families", "[data model]")
 {
   framework_graph g{levels_to_process, 2};
-  g.observe("se", check_two_ids).family("id"_in("subrun"), "id"_in("event"));
-  g.observe("rs", check_two_ids).family("id"_in("run"), "id"_in("subrun"));
-  g.observe("rse", check_three_ids).family("id"_in("run"), "id"_in("subrun"), "id"_in("event"));
+  g.observe("se", check_two_ids).input_family("id"_in("subrun"), "id"_in("event"));
+  g.observe("rs", check_two_ids).input_family("id"_in("run"), "id"_in("subrun"));
+  g.observe("rse", check_three_ids)
+    .input_family("id"_in("run"), "id"_in("subrun"), "id"_in("event"));
   g.execute("allowed_families_t");
 
   CHECK(g.execution_counts("se") == 1ull);

--- a/test/benchmarks/accept_even_ids.cpp
+++ b/test/benchmarks/accept_even_ids.cpp
@@ -9,5 +9,5 @@ PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
      "accept_even_ids",
      [](phlex::experimental::level_id const& id) { return id.number() % 2 == 0; },
      phlex::experimental::concurrency::unlimited)
-    .family(config.get<std::string>("product_name"));
+    .input_family(config.get<std::string>("product_name"));
 }

--- a/test/benchmarks/accept_even_numbers.cpp
+++ b/test/benchmarks/accept_even_numbers.cpp
@@ -8,5 +8,5 @@ PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
      "accept_even_numbers",
      [](int i) { return i % 2 == 0; },
      phlex::experimental::concurrency::unlimited)
-    .family(config.get<std::string>("consumes"));
+    .input_family(config.get<std::string>("consumes"));
 }

--- a/test/benchmarks/accept_fibonacci_numbers.cpp
+++ b/test/benchmarks/accept_fibonacci_numbers.cpp
@@ -8,5 +8,5 @@ PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
   m.make<test::fibonacci_numbers>(config.get<int>("max_number"))
     .predicate(
       "accept", &test::fibonacci_numbers::accept, phlex::experimental::concurrency::unlimited)
-    .family(config.get<std::string>("consumes"));
+    .input_family(config.get<std::string>("consumes"));
 }

--- a/test/benchmarks/read_id.cpp
+++ b/test/benchmarks/read_id.cpp
@@ -7,5 +7,5 @@ namespace {
 
 PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m)
 {
-  m.observe("read_id", read_id, phlex::experimental::concurrency::unlimited).family("id");
+  m.observe("read_id", read_id, phlex::experimental::concurrency::unlimited).input_family("id");
 }

--- a/test/benchmarks/read_index.cpp
+++ b/test/benchmarks/read_index.cpp
@@ -8,5 +8,5 @@ namespace {
 PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
 {
   m.observe("read_index", read_index, phlex::experimental::concurrency::unlimited)
-    .family(config.get<std::string>("consumes"));
+    .input_family(config.get<std::string>("consumes"));
 }

--- a/test/benchmarks/verify_difference.cpp
+++ b/test/benchmarks/verify_difference.cpp
@@ -10,5 +10,5 @@ PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
      "verify_difference",
      [expected = config.get<int>("expected", 100)](int i, int j) { assert(j - i == expected); },
      concurrency::unlimited)
-    .family(config.get<std::string>("i", "b"), config.get<std::string>("j", "c"));
+    .input_family(config.get<std::string>("i", "b"), config.get<std::string>("j", "c"));
 }

--- a/test/benchmarks/verify_even_fibonacci_numbers.cpp
+++ b/test/benchmarks/verify_even_fibonacci_numbers.cpp
@@ -20,5 +20,5 @@ PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
   m.make<even_fibonacci_numbers>(config.get<int>("max_number"))
     .observe(
       "only_even", &even_fibonacci_numbers::only_even, phlex::experimental::concurrency::unlimited)
-    .family(config.get<std::string>("consumes"));
+    .input_family(config.get<std::string>("consumes"));
 }

--- a/test/class_registration.cpp
+++ b/test/class_registration.cpp
@@ -92,7 +92,7 @@ TEST_CASE("Call non-framework functions", "[programming model]")
   }
 
   // The following is invoked for *each* section above
-  g.observe("verify_results", verify_results, concurrency::unlimited).family(product_names);
+  g.observe("verify_results", verify_results, concurrency::unlimited).input_family(product_names);
 
   g.execute("class_component_t");
 }

--- a/test/different_hierarchies.cpp
+++ b/test/different_hierarchies.cpp
@@ -86,12 +86,13 @@ TEST_CASE("Different hierarchies used with fold", "[graph]")
     .initialized_with(0u);
   g.with("job_add", add, concurrency::unlimited).fold("number").to("job_sum");
 
-  g.observe("verify_run_sum", [](unsigned int actual) { CHECK(actual == 10u); }).family("run_sum");
+  g.observe("verify_run_sum", [](unsigned int actual) { CHECK(actual == 10u); })
+    .input_family("run_sum");
   g.observe("verify_job_sum",
             [](unsigned int actual) {
               CHECK(actual == 20u + 45u); // 20u from events, 45u from trigger primitives
             })
-    .family("job_sum");
+    .input_family("job_sum");
 
   g.execute();
 

--- a/test/fold.cpp
+++ b/test/fold.cpp
@@ -71,15 +71,15 @@ TEST_CASE("Different levels of fold", "[graph]")
 
   g.observe(
      "verify_run_sum", [](unsigned int actual) { CHECK(actual == 10u); }, concurrency::unlimited)
-    .family("run_sum");
+    .input_family("run_sum");
   g.observe(
      "verify_two_layer_job_sum",
      [](unsigned int actual) { CHECK(actual == 20u); },
      concurrency::unlimited)
-    .family("two_layer_job_sum");
+    .input_family("two_layer_job_sum");
   g.observe(
      "verify_job_sum", [](unsigned int actual) { CHECK(actual == 20u); }, concurrency::unlimited)
-    .family("job_sum");
+    .input_family("job_sum");
 
   g.execute();
 

--- a/test/function_registration.cpp
+++ b/test/function_registration.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Call non-framework functions", "[programming model]")
   }
 
   // The following is invoked for *each* section above
-  g.observe("verify_results", verify_results).family(product_names);
+  g.observe("verify_results", verify_results).input_family(product_names);
 
   g.execute();
 }

--- a/test/hierarchical_nodes.cpp
+++ b/test/hierarchical_nodes.cpp
@@ -113,7 +113,7 @@ TEST_CASE("Hierarchical nodes", "[graph]")
     .initialized_with(15u);
 
   g.with("scale", scale, concurrency::unlimited).transform("added_data").to("result");
-  g.observe("print_result", print_result, concurrency::unlimited).family("result", "strtime");
+  g.observe("print_result", print_result, concurrency::unlimited).input_family("result", "strtime");
 
   g.make<test::products_for_output>().output_with("save", &test::products_for_output::save).when();
 

--- a/test/max-parallelism/check_parallelism.cpp
+++ b/test/max-parallelism/check_parallelism.cpp
@@ -37,5 +37,5 @@ PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m, config)
             [expected = config.get<std::size_t>("expected_parallelism")](std::size_t actual) {
               assert(actual == expected);
             })
-    .family("max_parallelism");
+    .input_family("max_parallelism");
 }

--- a/test/multiple_function_registration.cpp
+++ b/test/multiple_function_registration.cpp
@@ -74,6 +74,6 @@ TEST_CASE("Call multiple functions", "[programming model]")
   }
 
   // The following is invoked for *each* section above
-  g.observe("verify_result", [](double actual) { assert(actual == 6.); }).family("result");
+  g.observe("verify_result", [](double actual) { assert(actual == 6.); }).input_family("result");
   g.execute();
 }

--- a/test/plugins/module.cpp
+++ b/test/plugins/module.cpp
@@ -12,5 +12,5 @@ PHLEX_EXPERIMENTAL_REGISTER_ALGORITHMS(m)
   m.with("add", test::add, concurrency::unlimited).transform("i", "j").to("sum");
   m.observe(
      "verify", [](int actual) { assert(actual == 0); }, concurrency::unlimited)
-    .family("sum");
+    .input_family("sum");
 }

--- a/test/unfold.cpp
+++ b/test/unfold.cpp
@@ -102,7 +102,7 @@ TEST_CASE("Splitting the processing", "[graph]")
     .into("new_number")
     .within_family("lower1");
   g.with("add", add, concurrency::unlimited).fold("new_number").partitioned_by("event").to("sum1");
-  g.observe("check_sum", check_sum, concurrency::unlimited).family("sum1");
+  g.observe("check_sum", check_sum, concurrency::unlimited).input_family("sum1");
 
   g.with<iterate_through>(
      &iterate_through::predicate, &iterate_through::unfold, concurrency::unlimited)
@@ -113,7 +113,7 @@ TEST_CASE("Splitting the processing", "[graph]")
     .fold("each_number")
     .partitioned_by("event")
     .to("sum2");
-  g.observe("check_sum_same", check_sum_same, concurrency::unlimited).family("sum2");
+  g.observe("check_sum_same", check_sum_same, concurrency::unlimited).input_family("sum2");
 
   g.make<test::products_for_output>().output_with(
     "save", &test::products_for_output::save, concurrency::serial);


### PR DESCRIPTION
Replacing observer/predicate API `.family(...)` with `.input_family(...)` per developer agreement.