### PR TITLE
Verify that a data product can be a vector of abstract types

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,6 +62,7 @@ add_unit_test(yielding_driver LIBRARIES phlex::core TBB::tbb)
 add_catch_test(
   allowed_families LIBRARIES phlex::core Boost::json TEST_DOT_GRAPH
   )
+add_catch_test(vector_of_abstract_types LIBRARIES phlex::core)
 add_catch_test(
   cached_execution LIBRARIES phlex::core Boost::json TEST_DOT_GRAPH
   )

--- a/test/vector_of_abstract_types.cpp
+++ b/test/vector_of_abstract_types.cpp
@@ -1,0 +1,70 @@
+#include "phlex/core/framework_graph.hpp"
+
+#include "catch2/catch_test_macros.hpp"
+
+#include <numeric>
+
+using namespace phlex::experimental;
+
+namespace types {
+  struct Abstract {
+    virtual int value() const = 0;
+    virtual ~Abstract() = default;
+  };
+  struct DerivedA : Abstract {
+    int value() const override { return 1; }
+  };
+  struct DerivedB : Abstract {
+    int value() const override { return 2; }
+  };
+}
+
+namespace {
+  auto make_derived_as_abstract()
+  {
+    std::vector<std::unique_ptr<types::Abstract>> vec;
+    vec.reserve(2);
+    vec.push_back(std::make_unique<types::DerivedA>());
+    vec.push_back(std::make_unique<types::DerivedB>());
+    return vec;
+  }
+
+  int read_abstract(std::vector<std::unique_ptr<types::Abstract>> const& vec)
+  {
+    return std::transform_reduce(
+      vec.begin(), vec.end(), 0, std::plus{}, [](auto const& ptr) -> int { return ptr->value(); });
+  }
+
+  class source {
+  public:
+    explicit source(unsigned const max_n) : max_{max_n} {}
+
+    void operator()(framework_driver& driver)
+    {
+      auto job_store = phlex::experimental::product_store::base();
+      driver.yield(job_store);
+
+      for (unsigned int i : std::views::iota(1u, max_ + 1)) {
+        auto store = job_store->make_child(i, "event");
+        store->add_product("thing", make_derived_as_abstract());
+        driver.yield(store);
+      }
+    }
+
+  private:
+    unsigned const max_;
+  };
+
+}
+
+TEST_CASE("Test vector of abstract types")
+{
+  framework_graph g{source{1u}};
+  g.with("read_thing", read_abstract).transform("thing").to("sum");
+  g.observe(
+     "verify_sum", [](int sum) { CHECK(sum == 3); }, concurrency::serial)
+    .input_family("sum");
+  g.execute();
+
+  CHECK(g.execution_counts("read_thing") == 1);
+}


### PR DESCRIPTION
In yesterday's Phlex development meeting, the question arose whether we should support data products with abstract types.  This PR demonstrates that the current implementation of Phlex already supports this.

All Phlex cares about is that the type of a produced product can be matched with the type of a consumed product.