### PR TITLE
Use `simple_ptr_map` and other cleanups

### DIFF
--- a/phlex/core/CMakeLists.txt
+++ b/phlex/core/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   glue.cpp
   message.cpp
   message_sender.cpp
+  node_catalog.cpp
   multiplexer.cpp
   products_consumer.cpp
   specified_label.cpp

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -16,6 +16,7 @@
 #include "phlex/model/level_id.hpp"
 #include "phlex/model/product_store.hpp"
 #include "phlex/model/qualified_name.hpp"
+#include "phlex/utilities/simple_ptr_map.hpp"
 
 #include "oneapi/tbb/concurrent_unordered_map.h"
 #include "oneapi/tbb/flow_graph.h"
@@ -26,7 +27,6 @@
 #include <cstddef>
 #include <functional>
 #include <iterator>
-#include <map>
 #include <memory>
 #include <span>
 #include <stdexcept>
@@ -48,7 +48,7 @@ namespace phlex::experimental {
   };
 
   using declared_fold_ptr = std::unique_ptr<declared_fold>;
-  using declared_folds = std::map<std::string, declared_fold_ptr>;
+  using declared_folds = simple_ptr_map<declared_fold_ptr>;
 
   // Registering concrete folds
 

--- a/phlex/core/declared_observer.hpp
+++ b/phlex/core/declared_observer.hpp
@@ -14,6 +14,7 @@
 #include "phlex/model/level_id.hpp"
 #include "phlex/model/product_store.hpp"
 #include "phlex/model/qualified_name.hpp"
+#include "phlex/utilities/simple_ptr_map.hpp"
 #include "phlex/utilities/sized_tuple.hpp"
 
 #include "fmt/std.h"
@@ -26,7 +27,6 @@
 #include <cstddef>
 #include <functional>
 #include <iterator>
-#include <map>
 #include <memory>
 #include <span>
 #include <string>
@@ -42,7 +42,7 @@ namespace phlex::experimental {
   };
 
   using declared_observer_ptr = std::unique_ptr<declared_observer>;
-  using declared_observers = std::map<std::string, declared_observer_ptr>;
+  using declared_observers = simple_ptr_map<declared_observer_ptr>;
 
   // =====================================================================================
 

--- a/phlex/core/declared_output.hpp
+++ b/phlex/core/declared_output.hpp
@@ -16,7 +16,6 @@
 
 #include <cstddef>
 #include <functional>
-#include <map>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/phlex/core/declared_output.hpp
+++ b/phlex/core/declared_output.hpp
@@ -10,6 +10,7 @@
 #include "phlex/model/algorithm_name.hpp"
 #include "phlex/model/level_id.hpp"
 #include "phlex/model/product_store.hpp"
+#include "phlex/utilities/simple_ptr_map.hpp"
 
 #include "oneapi/tbb/flow_graph.h"
 
@@ -40,7 +41,7 @@ namespace phlex::experimental {
   };
 
   using declared_output_ptr = std::unique_ptr<declared_output>;
-  using declared_outputs = std::map<std::string, declared_output_ptr>;
+  using declared_outputs = simple_ptr_map<declared_output_ptr>;
 
   class output_creator : public node_options<output_creator> {
     using node_options_t = node_options<output_creator>;

--- a/phlex/core/declared_predicate.hpp
+++ b/phlex/core/declared_predicate.hpp
@@ -48,7 +48,7 @@ namespace phlex::experimental {
   };
 
   using declared_predicate_ptr = std::unique_ptr<declared_predicate>;
-  using declared_predicates = std::map<std::string, declared_predicate_ptr>;
+  using declared_predicates = simple_ptr_map<declared_predicate_ptr>;
 
   // =====================================================================================
 

--- a/phlex/core/declared_predicate.hpp
+++ b/phlex/core/declared_predicate.hpp
@@ -15,6 +15,7 @@
 #include "phlex/model/handle.hpp"
 #include "phlex/model/level_id.hpp"
 #include "phlex/model/product_store.hpp"
+#include "phlex/utilities/simple_ptr_map.hpp"
 #include "phlex/utilities/sized_tuple.hpp"
 
 #include "fmt/std.h"
@@ -27,7 +28,6 @@
 #include <cstddef>
 #include <functional>
 #include <iterator>
-#include <map>
 #include <memory>
 #include <ranges>
 #include <span>

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -18,6 +18,7 @@
 #include "phlex/model/level_id.hpp"
 #include "phlex/model/product_store.hpp"
 #include "phlex/model/qualified_name.hpp"
+#include "phlex/utilities/simple_ptr_map.hpp"
 
 #include "fmt/std.h"
 #include "oneapi/tbb/concurrent_hash_map.h"
@@ -31,7 +32,6 @@
 #include <cstddef>
 #include <functional>
 #include <iterator>
-#include <map>
 #include <memory>
 #include <ranges>
 #include <span>
@@ -54,7 +54,7 @@ namespace phlex::experimental {
   };
 
   using declared_transform_ptr = std::unique_ptr<declared_transform>;
-  using declared_transforms = std::map<std::string, declared_transform_ptr>;
+  using declared_transforms = simple_ptr_map<declared_transform_ptr>;
 
   // =====================================================================================
 

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -15,6 +15,7 @@
 #include "phlex/model/level_id.hpp"
 #include "phlex/model/product_store.hpp"
 #include "phlex/model/qualified_name.hpp"
+#include "phlex/utilities/simple_ptr_map.hpp"
 #include "phlex/utilities/sized_tuple.hpp"
 
 #include "fmt/std.h"

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -72,7 +72,7 @@ namespace phlex::experimental {
   };
 
   using declared_unfold_ptr = std::unique_ptr<declared_unfold>;
-  using declared_unfolds = std::map<std::string, declared_unfold_ptr>;
+  using declared_unfolds = simple_ptr_map<declared_unfold_ptr>;
 
   // =====================================================================================
 

--- a/phlex/core/fwd.hpp
+++ b/phlex/core/fwd.hpp
@@ -5,6 +5,7 @@
 
 namespace phlex::experimental {
   class component;
+  class consumer;
   class declared_output;
   class end_of_message;
   class generator;

--- a/phlex/core/node_catalog.cpp
+++ b/phlex/core/node_catalog.cpp
@@ -1,0 +1,40 @@
+#include "phlex/core/node_catalog.hpp"
+
+namespace phlex::experimental {
+  std::size_t node_catalog::execution_counts(std::string const& node_name) const
+  {
+    // FIXME: Yuck!
+    if (auto node = predicates.get(node_name)) {
+      return node->num_calls();
+    }
+    if (auto node = observers.get(node_name)) {
+      return node->num_calls();
+    }
+    if (auto node = folds.get(node_name)) {
+      return node->num_calls();
+    }
+    if (auto node = unfolds.get(node_name)) {
+      return node->num_calls();
+    }
+    if (auto node = transforms.get(node_name)) {
+      return node->num_calls();
+    }
+    return -1u;
+  }
+
+  std::size_t node_catalog::product_counts(std::string const& node_name) const
+  {
+    // FIXME: Yuck!
+    if (auto node = folds.get(node_name)) {
+      return node->product_count();
+    }
+    if (auto node = unfolds.get(node_name)) {
+      return node->product_count();
+    }
+    if (auto node = transforms.get(node_name)) {
+      return node->product_count();
+    }
+    return -1u;
+  }
+
+}

--- a/phlex/core/node_catalog.hpp
+++ b/phlex/core/node_catalog.hpp
@@ -12,7 +12,6 @@
 
 #include "boost/pfr.hpp"
 
-#include <map>
 #include <string>
 #include <vector>
 

--- a/phlex/core/node_catalog.hpp
+++ b/phlex/core/node_catalog.hpp
@@ -8,6 +8,7 @@
 #include "phlex/core/declared_transform.hpp"
 #include "phlex/core/declared_unfold.hpp"
 #include "phlex/core/registrar.hpp"
+#include "phlex/utilities/simple_ptr_map.hpp"
 
 #include "boost/pfr.hpp"
 
@@ -16,22 +17,22 @@
 #include <vector>
 
 namespace phlex::experimental {
-  template <typename Ptr>
-  using declared_nodes = std::map<std::string, Ptr>;
-
   struct node_catalog {
     template <typename Ptr>
     auto registrar_for(std::vector<std::string>& errors)
     {
-      return registrar{boost::pfr::get<declared_nodes<Ptr>>(*this), errors};
+      return registrar{boost::pfr::get<simple_ptr_map<Ptr>>(*this), errors};
     }
 
-    declared_nodes<declared_predicate_ptr> predicates_{};
-    declared_nodes<declared_observer_ptr> observers_{};
-    declared_nodes<declared_output_ptr> outputs_{};
-    declared_nodes<declared_fold_ptr> folds_{};
-    declared_nodes<declared_unfold_ptr> unfolds_{};
-    declared_nodes<declared_transform_ptr> transforms_{};
+    std::size_t execution_counts(std::string const& node_name) const;
+    std::size_t product_counts(std::string const& node_name) const;
+
+    simple_ptr_map<declared_predicate_ptr> predicates{};
+    simple_ptr_map<declared_observer_ptr> observers{};
+    simple_ptr_map<declared_output_ptr> outputs{};
+    simple_ptr_map<declared_fold_ptr> folds{};
+    simple_ptr_map<declared_unfold_ptr> unfolds{};
+    simple_ptr_map<declared_transform_ptr> transforms{};
   };
 }
 

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -47,19 +47,16 @@
 //
 // =======================================================================================
 
+#include "phlex/utilities/simple_ptr_map.hpp"
+
 #include <functional>
-#include <map>
 #include <string>
 #include <vector>
 
 namespace phlex::experimental {
-
-  template <typename T>
-  concept map_like = requires { typename T::mapped_type; };
-
   template <typename Ptr>
   class registrar {
-    using Nodes = std::map<std::string, Ptr>;
+    using Nodes = simple_ptr_map<Ptr>;
     using Creator = std::function<Ptr()>;
 
   public:
@@ -92,10 +89,6 @@ namespace phlex::experimental {
     std::vector<std::string>* errors_;
     Creator creator_{};
   };
-
-  template <map_like Nodes>
-  registrar(Nodes&, std::vector<std::string>&) -> registrar<typename Nodes::mapped_type>;
-
 }
 
 #endif // phlex_core_registrar_hpp

--- a/phlex/core/specified_label.cpp
+++ b/phlex/core/specified_label.cpp
@@ -12,19 +12,6 @@ namespace phlex::experimental {
     return {std::move(name), std::move(family)};
   }
 
-  // specified_label specified_label::related_to(std::string relation) &&
-  // {
-  //   return {std::move(name),
-  //           std::move(family),
-  //           std::make_shared<specified_label>(specified_label{relation})};
-  // }
-
-  // specified_label specified_label::related_to(specified_label relation) &&
-  // {
-  //   return {
-  //     std::move(name), std::move(family), std::make_shared<specified_label>(std::move(relation))};
-  // }
-
   std::string specified_label::to_string() const
   {
     if (family.empty()) {

--- a/phlex/utilities/simple_ptr_map.hpp
+++ b/phlex/utilities/simple_ptr_map.hpp
@@ -1,0 +1,53 @@
+#ifndef phlex_utilities_simple_map_hpp
+#define phlex_utilities_simple_map_hpp
+
+// ==================================================================================
+// The type simple_ptr_map<Ptr> is nearly equivalent to the type:
+//
+//   std::map<std::string, Ptr>
+//
+// except that only four public member functions are available:
+//
+//   - try_emplace(string, Ptr)
+//   - begin()
+//   - end()
+//   - get(std::string const& key)
+//
+// The 'get(...') function returns a bare pointer to the stored element if it exists;
+// otherwise the null pointer is returned.
+// ==================================================================================
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace phlex::experimental {
+  template <typename T>
+  class simple_ptr_map;
+
+  // Support std::unique_ptr<T> only for now
+  template <typename T>
+  class simple_ptr_map<std::unique_ptr<T>> {
+    using Ptr = std::unique_ptr<T>;
+    std::map<std::string, Ptr> data_;
+
+  public:
+    auto try_emplace(std::string node_name, Ptr ptr)
+    {
+      return data_.try_emplace(std::move(node_name), std::move(ptr));
+    }
+
+    auto begin() const { return data_.begin(); }
+    auto end() const { return data_.end(); }
+
+    typename Ptr::element_type* get(std::string const& node_name) const
+    {
+      if (auto it = data_.find(node_name); it != data_.end()) {
+        return it->second.get();
+      }
+      return nullptr;
+    }
+  };
+}
+
+#endif // phlex_utilities_simple_map_hpp

--- a/phlex/utilities/simple_ptr_map.hpp
+++ b/phlex/utilities/simple_ptr_map.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_simple_map_hpp
-#define phlex_utilities_simple_map_hpp
+#ifndef phlex_utilities_simple_ptr_map_hpp
+#define phlex_utilities_simple_ptr_map_hpp
 
 // ==================================================================================
 // The type simple_ptr_map<Ptr> is nearly equivalent to the type:
@@ -11,7 +11,7 @@
 //   - try_emplace(string, Ptr)
 //   - begin()
 //   - end()
-//   - get(std::string const& key)
+//   - get(std::string const& key) [[not provided by std::map]]
 //
 // The 'get(...') function returns a bare pointer to the stored element if it exists;
 // otherwise the null pointer is returned.
@@ -50,4 +50,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_utilities_simple_map_hpp
+#endif // phlex_utilities_simple_ptr_map_hpp


### PR DESCRIPTION
This PR introduces a `simple_ptr_map<T>` template, which simplifies some boilerplate code elsewhere.

This PR also moves some logic from the `framework_graph` class to the `node_catalog` class.