### PR TITLE
FORM RNTuple Support

### DIFF
--- a/.github/workflows/cmake-build.yaml
+++ b/.github/workflows/cmake-build.yaml
@@ -29,7 +29,7 @@ jobs:
         . $GITHUB_WORKSPACE/phlex-src/ci/entrypoint.sh
         mkdir -p $GITHUB_WORKSPACE/phlex-build
         cd $GITHUB_WORKSPACE/phlex-build
-        cmake $GITHUB_WORKSPACE/phlex-src -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DPHLEX_USE_FORM=ON -DFORM_USE_ROOT_STORAGE=ON
+        cmake $GITHUB_WORKSPACE/phlex-src -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DPHLEX_USE_FORM=ON -DFORM_USE_ROOT_STORAGE=ON -DFORM_USE_RNTUPLE_STORAGE=ON
         cmake --build . -j $(nproc)
 
     - name: Test

--- a/form/CMakeLists.txt
+++ b/form/CMakeLists.txt
@@ -16,6 +16,11 @@ if (FORM_USE_ROOT_STORAGE)
 	add_definitions( -DUSE_ROOT_STORAGE )
 endif()
 
+option(FORM_USE_RNTUPLE_STORAGE "Enable RNTuple Container from ROOT 7" OFF)
+if (FORM_USE_RNTUPLE_STORAGE)
+	add_definitions( -DUSE_RNTUPLE_STORAGE )
+endif()
+
 # Add sub directories
 add_subdirectory(form)
 add_subdirectory(mock_phlex)

--- a/form/root_storage/CMakeLists.txt
+++ b/form/root_storage/CMakeLists.txt
@@ -1,14 +1,34 @@
 # Copyright (C) 2025 ...
 
 # Specify the ROOT dependencies
-find_package(ROOT REQUIRED COMPONENTS Core RIO Tree)
+set(root_storage_ROOT_components)
+set(root_storage_ROOT_libs)
+list(APPEND root_storage_ROOT_components Core RIO Tree)
+list(APPEND root_storage_ROOT_libs ROOT::Core ROOT::RIO ROOT::Tree storage)
+
+if(FORM_USE_RNTUPLE_STORAGE)
+  list(APPEND root_storage_ROOT_components ROOTNTuple)
+  list(APPEND root_storage_ROOT_libs ROOT::ROOTNTuple)
+endif(FORM_USE_RNTUPLE_STORAGE)
+
+find_package(ROOT REQUIRED COMPONENTS ${root_storage_ROOT_components})
 
 # Component(s) in the package:
-add_library(root_storage
-	root_tfile.cpp
-	root_ttree_container.cpp
-	root_tbranch_container.cpp
+set(root_storage_SOURCES)
+list(APPEND root_storage_SOURCES
+     root_tfile.cpp
+     root_ttree_container.cpp
+     root_tbranch_container.cpp
 )
 
+if(FORM_USE_RNTUPLE_STORAGE)
+list(APPEND root_storage_SOURCES
+     root_rntuple_container.cpp
+     root_rfield_container.cpp
+)
+endif(FORM_USE_RNTUPLE_STORAGE)
+
+add_library(root_storage ${root_storage_SOURCES})
+
 # Link the ROOT libraries
-target_link_libraries(root_storage PUBLIC ROOT::Core ROOT::RIO ROOT::Tree storage)
+target_link_libraries(root_storage PUBLIC ${root_storage_ROOT_libs})

--- a/form/root_storage/root_rfield_container.cpp
+++ b/form/root_storage/root_rfield_container.cpp
@@ -70,11 +70,13 @@ namespace form::detail::experimental {
           std::make_unique<ROOT::RNTupleView<void>>(m_reader->GetView(col_name(), nullptr, ""));
         //TClass takes the "std::" off of "std::vector<>" when RNTuple's on-disk format doesn't.  Convert RNTuple's type name to match TClass for manual type check because our dictionary of choice will likely be the same as TClass.
         if (strcmp(TClass::GetClass(m_view->GetField().GetTypeName().c_str())->GetName(),
-                   type.c_str())) {
+                   TClass::GetClass(type.c_str())->GetName())) {
           throw std::runtime_error(
-            "ROOT_RField_containerImp::read type " + type + " requested for a field named " +
-            col_name() +
-            " does not match the type in the file: " + m_view->GetField().GetTypeName());
+            "ROOT_RField_containerImp::read type " +
+            std::string(TClass::GetClass(type.c_str())->GetName()) +
+            " requested for a field named " + col_name() +
+            " does not match the type in the file: " +
+            TClass::GetClass(m_view->GetField().GetTypeName().c_str())->GetName());
         }
       }
     }

--- a/form/root_storage/root_rfield_container.cpp
+++ b/form/root_storage/root_rfield_container.cpp
@@ -1,0 +1,153 @@
+//A ROOT_RField_Container reads data products of a single type from vectors stored in an RNTuple field on disk.
+
+#include "root_rfield_container.hpp"
+#include "root_rntuple_container.hpp"
+#include "root_tfile.hpp"
+
+#include "ROOT/RNTupleReader.hxx"
+#include "ROOT/RNTupleView.hxx"
+#include "ROOT/RNTupleWriter.hxx"
+#include "TFile.h"
+
+#include <exception>
+#include <iostream>
+
+namespace form::detail::experimental {
+  ROOT_RField_ContainerImp::ROOT_RField_ContainerImp(std::string const& name) :
+    Storage_Associative_Container(name), m_force_streamer_field(false)
+  {
+  }
+
+  ROOT_RField_ContainerImp::~ROOT_RField_ContainerImp() {}
+
+  void ROOT_RField_ContainerImp::setAttribute(std::string const& key, std::string const& /*value*/)
+  {
+    if (key == "force_streamer_field") {
+      m_force_streamer_field = true;
+    } else {
+      throw std::runtime_error("ROOT_RField_ContainerImp supports some attributes, but not " + key);
+    }
+  }
+
+  void ROOT_RField_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
+  {
+    Storage_Container::setFile(file);
+    m_tfile = dynamic_cast<ROOT_TFileImp*>(file.get())->getTFile();
+    return;
+  }
+
+  void ROOT_RField_ContainerImp::setParent(std::shared_ptr<IStorage_Container> parent)
+  {
+    this->Storage_Associative_Container::setParent(parent);
+    auto parentDerived = dynamic_pointer_cast<ROOT_RNTuple_ContainerImp>(parent);
+    if (!parentDerived) {
+      throw std::runtime_error(
+        "ROOT_RField_ContainerImp::setParent parent is not a ROOT_RNTuple_ContainerImp!  Something "
+        "may be wrong with how Storage works.");
+    }
+    m_rntuple_parent = parentDerived;
+  }
+
+  bool ROOT_RField_ContainerImp::read(int id, void const** data, std::string& type)
+  {
+    //Connect to file at the last possible moment at the cost of a little run-time branching
+    if (!m_view) {
+      if (!m_reader) { //First time this RNTuple is read this job
+        if (!m_tfile) {
+          throw std::runtime_error(
+            "ROOT_RField_ContainerImp::read No file loaded to read from on first read() call!");
+        }
+
+        m_reader = ROOT::RNTupleReader::Open(top_name(), m_tfile->GetName());
+      }
+
+      try {
+        m_view =
+          std::make_unique<ROOT::RNTupleView<void>>(m_reader->GetView(col_name(), nullptr, type));
+      } catch (const ROOT::RException& e) {
+        //RNTupleView<void> will fail to create a field for fields written in streamer mode or for which type does not match the field's type on disk.  Passing an empty string for type forces it to create the same type of field as the object on disk.  Do this to handle streamer fields, then perform our own type check.
+        m_view =
+          std::make_unique<ROOT::RNTupleView<void>>(m_reader->GetView(col_name(), nullptr, ""));
+        //TClass takes the "std::" off of "std::vector<>" when RNTuple's on-disk format doesn't.  Convert RNTuple's type name to match TClass for manual type check because our dictionary of choice will likely be the same as TClass.
+        if (strcmp(TClass::GetClass(m_view->GetField().GetTypeName().c_str())->GetName(),
+                   type.c_str())) {
+          throw std::runtime_error(
+            "ROOT_RField_containerImp::read type " + type + " requested for a field named " +
+            col_name() +
+            " does not match the type in the file: " + m_view->GetField().GetTypeName());
+        }
+      }
+    }
+
+    if (id >= (int)m_reader->GetNEntries())
+      return false;
+
+    //Using RNTupleView<> to read instead of reusing REntry gives us full schema evolution support: the ROOT feature that lets us read files with an old class version into a new class version's memory.
+    auto buffer = m_view->GetField().CreateObject<void>(); //PHLEX gets ownership of this memory
+    if (!buffer) {
+      throw std::runtime_error("ROOT_RField_Container::read failed to create an object of type " +
+                               m_view->GetField().GetTypeName() +
+                               ".  Maybe the type name for this read() (" + type +
+                               ") doesn't match the type from the first read() (" +
+                               m_view->GetField().GetTypeName() + ")?");
+    }
+
+    m_view->BindRawPtr(buffer.get());
+    try {
+      (*m_view)(id);
+    } catch (const ROOT::RException& e) {
+      throw std::runtime_error("ROOT_RField_ContainerImp::read got a ROOT exception: " +
+                               std::string(e.what()));
+    }
+    *data = buffer.release();
+
+    return true;
+  }
+
+  void ROOT_RField_ContainerImp::fill(void const* data)
+  {
+    if (!m_rntuple_parent->m_writer) {
+      m_rntuple_parent->m_writer =
+        ROOT::RNTupleWriter::Append(std::move(m_rntuple_parent->m_model), top_name(), *m_tfile);
+      m_rntuple_parent->m_entry = m_rntuple_parent->m_writer->CreateRawPtrWriteEntry();
+    }
+    m_rntuple_parent->m_entry->BindRawPtr(col_name(), data);
+  }
+
+  void ROOT_RField_ContainerImp::commit()
+  {
+    if (!m_rntuple_parent->m_entry) {
+      throw std::runtime_error("ROOT_RField_ContainerImp::commit No RRawPtrWriteEntry set up.  "
+                               "You may have called commit() without calling setupWrite() first.");
+    }
+    if (!m_rntuple_parent->m_writer) {
+      throw std::runtime_error("ROOT_RField_ContainerImp::commit No RNTupleWriter set up.  "
+                               "You may have called commit() without calling setupWrite() first.");
+    }
+    m_rntuple_parent->m_writer->Fill(*m_rntuple_parent->m_entry);
+  }
+
+  void ROOT_RField_ContainerImp::setupWrite(std::string const& type)
+  {
+    std::unique_ptr<ROOT::RFieldBase> field;
+
+    if (m_force_streamer_field) {
+      field = std::make_unique<ROOT::RStreamerField>(col_name(), type);
+    } else {
+      auto result = ROOT::RFieldBase::Create(col_name(), type);
+      if (result) {
+        field = result.Unwrap();
+      } else {
+        std::cerr
+          << "ROOT_RField_ContainerImp::setupWrite could not create column-wise storage for "
+          << type
+          << ".  This class is probably using something obsolete like TLorentzVector.  Storing it "
+             "in streamer mode to keep the application going."
+          << std::endl;
+        field = std::make_unique<ROOT::RStreamerField>(col_name(), type);
+      }
+    }
+
+    m_rntuple_parent->m_model->AddField(std::move(field));
+  }
+}

--- a/form/root_storage/root_rfield_container.hpp
+++ b/form/root_storage/root_rfield_container.hpp
@@ -1,0 +1,48 @@
+//A ROOT_RField_Container is a Storage_Container that uses a shared RNTuple to read and write data products to and from disk.  A single Storage_Container encapsulates the location where a collection of data products of a single type is stored.
+
+#ifndef __ROOT_RFIELD_CONTAINER_H__
+#define __ROOT_RFIELD_CONTAINER_H__
+
+#include "storage/storage_associative_container.hpp"
+
+#include <memory>
+#include <string>
+
+class TFile;
+
+namespace ROOT {
+  class RNTupleReader;
+  template <class FIELD_TYPE>
+  class RNTupleView;
+  class RNTupleView<void>;
+}
+
+namespace form::detail::experimental {
+  class ROOT_RNTuple_ContainerImp;
+
+  class ROOT_RField_ContainerImp : public Storage_Associative_Container {
+  public:
+    ROOT_RField_ContainerImp(std::string const& name);
+    ~ROOT_RField_ContainerImp();
+
+    void setAttribute(std::string const& key, std::string const& value) override;
+
+    void setFile(std::shared_ptr<IStorage_File> file) override;
+    void setupWrite(std::string const& type) override;
+    void setParent(std::shared_ptr<IStorage_Container> const parent) override;
+    void fill(void const* data) override;
+    void commit() override;
+    bool read(int id, void const** data, std::string& type) override;
+
+  private:
+    std::shared_ptr<TFile> m_tfile;
+    std::unique_ptr<ROOT::RNTupleReader> m_reader;
+    std::unique_ptr<ROOT::RNTupleView<void>> m_view;
+
+    std::shared_ptr<ROOT_RNTuple_ContainerImp> m_rntuple_parent;
+
+    bool m_force_streamer_field;
+  };
+}
+
+#endif

--- a/form/root_storage/root_rntuple_container.cpp
+++ b/form/root_storage/root_rntuple_container.cpp
@@ -1,0 +1,48 @@
+//A ROOT_RNTuple_Container reads data products of a single type from vectors stored in an RNTuple field on disk.
+
+#include "root_rntuple_container.hpp"
+#include "root_tfile.hpp"
+
+#include "ROOT/RNTupleReader.hxx"
+#include "ROOT/RNTupleView.hxx"
+#include "ROOT/RNTupleWriter.hxx"
+#include "TFile.h"
+
+#include <exception>
+
+namespace form::detail::experimental {
+  ROOT_RNTuple_ContainerImp::ROOT_RNTuple_ContainerImp(std::string const& name) :
+    Storage_Association(name), m_model(ROOT::RNTupleModel::Create())
+  {
+  }
+
+  ROOT_RNTuple_ContainerImp::~ROOT_RNTuple_ContainerImp()
+  {
+    if (m_writer) {
+      m_writer->CommitDataset();
+    }
+  }
+
+  void ROOT_RNTuple_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
+  {
+    Storage_Container::setFile(file);
+    return;
+  }
+
+  bool ROOT_RNTuple_ContainerImp::read(int /*id*/, void const** /*data*/, std::string& /*type*/)
+  {
+    throw std::runtime_error("ROOT_RNTuple_CotnainerImp::read not implemented");
+  }
+
+  void ROOT_RNTuple_ContainerImp::fill(void const* /*data*/)
+  {
+    throw std::runtime_error("ROOT_RNTuple_ContainerImp::fill not implemented");
+  }
+
+  void ROOT_RNTuple_ContainerImp::commit()
+  {
+    throw std::runtime_error("ROOT_RNTuple_ContainerImp::commit not implemented");
+  }
+
+  void ROOT_RNTuple_ContainerImp::setupWrite(std::string const& /*type*/) { return; }
+}

--- a/form/root_storage/root_rntuple_container.hpp
+++ b/form/root_storage/root_rntuple_container.hpp
@@ -1,0 +1,44 @@
+//A ROOT_RNTuple_ContainerImp is a Storage_Association (and therefore a Storage_Container) that coordinates the file accesses shared by several ROOT_RField_ContainerImps.  It only coordinates RNTuple-specific file-based resources and doesn't actually implement write() or read() for example.  This matches the early design of the TTree associative container.
+
+#ifndef __ROOT_RNTUPLE_CONTAINER_H__
+#define __ROOT_RNTUPLE_CONTAINER_H__
+
+#include "storage/storage_association.hpp"
+
+#include <memory>
+#include <string>
+
+class TFile;
+
+namespace ROOT {
+  class RNTupleWriter;
+  class RNTupleModel;
+
+  namespace Experimental {
+    namespace Detail {
+      class RRawPtrWriteEntry;
+    }
+  }
+}
+
+namespace form::detail::experimental {
+
+  class ROOT_RNTuple_ContainerImp : public Storage_Association {
+  public:
+    ROOT_RNTuple_ContainerImp(std::string const& name);
+    ~ROOT_RNTuple_ContainerImp();
+
+    void setFile(std::shared_ptr<IStorage_File> file) override;
+    void setupWrite(std::string const& type) override;
+    void fill(void const* data) override;
+    void commit() override;
+    bool read(int id, void const** data, std::string& type) override;
+
+    //State shared by ROOT_RField_ContainerImps
+    std::unique_ptr<ROOT::RNTupleWriter> m_writer;
+    std::unique_ptr<ROOT::RNTupleModel> m_model;
+    std::unique_ptr<ROOT::Experimental::Detail::RRawPtrWriteEntry> m_entry;
+  };
+}
+
+#endif

--- a/form/util/factories.hpp
+++ b/form/util/factories.hpp
@@ -16,6 +16,11 @@
 #include "root_storage/root_ttree_container.hpp"
 #endif
 
+#ifdef USE_RNTUPLE_STORAGE
+#include "root_storage/root_rfield_container.hpp"
+#include "root_storage/root_rntuple_container.hpp"
+#endif //USE_RNTUPLE_STORAGE
+
 #include <memory>
 #include <string>
 
@@ -40,6 +45,10 @@ namespace form::detail::experimental {
 #ifdef USE_ROOT_STORAGE
         return std::make_shared<ROOT_TTree_ContainerImp>(name);
 #endif // USE_ROOT_STORAGE
+      } else if (form::technology::GetMinor(tech) == form::technology::ROOT_RNTUPLE_MINOR) {
+#ifdef USE_RNTUPLE_STORAGE
+        return std::make_shared<ROOT_RNTuple_ContainerImp>(name);
+#endif // USE_RNTUPLE_STORAGE
       }
     } else if (form::technology::GetMajor(tech) == form::technology::HDF5_MAJOR) {
 #ifdef USE_HDF5_STORAGE
@@ -60,6 +69,10 @@ namespace form::detail::experimental {
 #ifdef USE_ROOT_STORAGE
         return std::make_shared<ROOT_TBranch_ContainerImp>(name);
 #endif // USE_ROOT_STORAGE
+      } else if (form::technology::GetMinor(tech) == form::technology::ROOT_RNTUPLE_MINOR) {
+#ifdef USE_RNTUPLE_STORAGE
+        return std::make_shared<ROOT_RField_ContainerImp>(name);
+#endif // USE_RNTUPLE_STORAGE
       }
     } else if (form::technology::GetMajor(tech) == form::technology::HDF5_MAJOR) {
 #ifdef USE_HDF5_STORAGE


### PR DESCRIPTION
Introduces RNTuple as a file technology FORM can use to read and write to .root files.  RNTuple support is introduced through the `Storage_Container` interface, just like how TTree technology works.  Automatically adapts to classes that have custom streamers like `TLorentzVector`.