### PR TITLE
Fix filtering race condition

### DIFF
--- a/phlex/core/detail/filter_impl.cpp
+++ b/phlex/core/detail/filter_impl.cpp
@@ -43,7 +43,12 @@ namespace phlex::experimental {
     return 0u;
   }
 
-  void decision_map::erase(std::size_t const msg_id) { results_.erase(msg_id); }
+  bool decision_map::claim(accessor& a, std::size_t const msg_id)
+  {
+    return results_.find(a, msg_id);
+  }
+
+  void decision_map::erase(accessor& a) { results_.erase(a); }
 
   data_map::data_map(specified_labels const& product_names) :
     product_names_{&product_names}, nargs_{product_names.size()}
@@ -85,10 +90,10 @@ namespace phlex::experimental {
     return false;
   }
 
-  std::vector<product_store_const_ptr> data_map::release_data(accessor& a, std::size_t const msg_id)
+  std::vector<product_store_const_ptr> data_map::release_data(std::size_t const msg_id)
   {
     std::vector<product_store_const_ptr> result;
-    if (stores_.find(a, msg_id)) {
+    if (decltype(stores_)::accessor a; stores_.find(a, msg_id)) {
       result = std::move(a->second);
       stores_.erase(a);
     }

--- a/phlex/core/detail/filter_impl.hpp
+++ b/phlex/core/detail/filter_impl.hpp
@@ -31,16 +31,21 @@ namespace phlex::experimental {
   }
 
   class decision_map {
+    using decisions_t = oneapi::tbb::concurrent_hash_map<std::size_t, unsigned int>;
+
   public:
+    using accessor = decisions_t::accessor;
+
     explicit decision_map(unsigned int total_decisions);
 
     void update(predicate_result result);
     unsigned int value(std::size_t msg_id) const;
-    void erase(std::size_t msg_id);
+    void erase(accessor& a);
+    bool claim(accessor& a, std::size_t msg_id);
 
   private:
     unsigned int const total_decisions_;
-    oneapi::tbb::concurrent_hash_map<std::size_t, unsigned int> results_;
+    decisions_t results_;
   };
 
   class data_map {
@@ -48,8 +53,6 @@ namespace phlex::experimental {
       oneapi::tbb::concurrent_hash_map<std::size_t, std::vector<product_store_const_ptr>>;
 
   public:
-    using accessor = stores_t::accessor;
-
     struct for_output_t {};
     static constexpr for_output_t for_output{};
     explicit data_map(for_output_t);
@@ -58,7 +61,7 @@ namespace phlex::experimental {
     bool is_complete(std::size_t const msg_id) const;
 
     void update(std::size_t const msg_id, product_store_const_ptr const& store);
-    std::vector<product_store_const_ptr> release_data(accessor& a, std::size_t const msg_id);
+    std::vector<product_store_const_ptr> release_data(std::size_t const msg_id);
 
   private:
     stores_t stores_;

--- a/test/filter.cpp
+++ b/test/filter.cpp
@@ -97,6 +97,9 @@ TEST_CASE("Two predicates", "[filtering]")
     .when("odds_only");
 
   g.execute("two_independent_predicates_t");
+
+  CHECK(g.execution_counts("add_evens") == 5);
+  CHECK(g.execution_counts("add_odds") == 5);
 }
 
 TEST_CASE("Two predicates in series", "[filtering]")
@@ -112,6 +115,8 @@ TEST_CASE("Two predicates in series", "[filtering]")
     .when("odds_only");
 
   g.execute("two_predicates_in_series_t");
+
+  CHECK(g.execution_counts("add") == 0);
 }
 
 TEST_CASE("Two predicates in parallel", "[filtering]")
@@ -125,6 +130,8 @@ TEST_CASE("Two predicates in parallel", "[filtering]")
     .when("odds_only", "evens_only");
 
   g.execute("two_predicates_in_parallel_t");
+
+  CHECK(g.execution_counts("add") == 0);
 }
 
 TEST_CASE("Three predicates in parallel", "[filtering]")
@@ -154,6 +161,8 @@ TEST_CASE("Three predicates in parallel", "[filtering]")
     .when(predicate_names);
 
   g.execute("three_predicates_in_parallel_t");
+
+  CHECK(g.execution_counts("collect") == 3);
 }
 
 TEST_CASE("Two predicates in parallel (each with multiple arguments)", "[filtering]")
@@ -172,4 +181,7 @@ TEST_CASE("Two predicates in parallel (each with multiple arguments)", "[filteri
     .when("odds_only");
 
   g.execute("two_predicates_in_parallel_multiarg_t");
+
+  CHECK(g.execution_counts("check_odds") == 5);
+  CHECK(g.execution_counts("check_evens") == 5);
 }

--- a/test/filter_impl.cpp
+++ b/test/filter_impl.cpp
@@ -13,24 +13,31 @@ TEST_CASE("Filter values", "[filtering]")
 
 TEST_CASE("Filter decision", "[filtering]")
 {
+  // This test does not exercise erasure of cached filter decisions
   decision_map decisions{2};
-  decisions.update({nullptr, 1, false});
+
+  SECTION("Test short-circuiting if false predicate result")
   {
-    auto const value = decisions.value(1);
-    CHECK(is_complete(value));
-    CHECK(to_boolean(value) == false);
-    decisions.erase(1);
+    decisions.update({nullptr, 1, false});
+    {
+      auto const value = decisions.value(1);
+      CHECK(is_complete(value));
+      CHECK(to_boolean(value) == false);
+    }
   }
-  decisions.update({nullptr, 3, true});
+
+  SECTION("Verify once a complete decision is made")
   {
-    auto const value = decisions.value(3);
-    CHECK(not is_complete(value));
-  }
-  decisions.update({nullptr, 3, true});
-  {
-    auto const value = decisions.value(3);
-    CHECK(is_complete(value));
-    CHECK(to_boolean(value) == true);
-    decisions.erase(3);
+    decisions.update({nullptr, 3, true});
+    {
+      auto const value = decisions.value(3);
+      CHECK(not is_complete(value));
+    }
+    decisions.update({nullptr, 3, true});
+    {
+      auto const value = decisions.value(3);
+      CHECK(is_complete(value));
+      CHECK(to_boolean(value) == true);
+    }
   }
 }


### PR DESCRIPTION
This PR fixes a data race in filtering, where a filter result was being sent multiple times for the same data cell.  This PR also introduces unit tests that verify the expected filtering behavior.