### PR TITLE
Resolve `[clang-diagnostic-error]` issues when running `clang-tidy`

### DIFF
--- a/phlex/utilities/simple_ptr_map.hpp
+++ b/phlex/utilities/simple_ptr_map.hpp
@@ -32,6 +32,17 @@ namespace phlex::experimental {
     std::map<std::string, Ptr> data_;
 
   public:
+    // std::map<std::string, Ptr> has a default constructor that does
+    // not invoke the deleted default constructor of its
+    // std::pair<std::string const, Ptr> data member, but the compiler
+    // doesn't look at that when deciding whether to delete the default
+    // constructor of simple_ptr_map
+    simple_ptr_map() = default;
+
+    // Explicitly disable copying
+    simple_ptr_map(simple_ptr_map const&) = delete;
+    simple_ptr_map& operator=(simple_ptr_map const&) = delete;
+
     auto try_emplace(std::string node_name, Ptr ptr)
     {
       return data_.try_emplace(std::move(node_name), std::move(ptr));


### PR DESCRIPTION
`clang-tidy-21` reported errors due to implicit deletion of `simple_ptr_map<unique_ptr<T>>::simple_map()` According to the C++ standard, it is deleted because of the lack of a default constructor of the `pair<string const, unique_ptr<T>>` member data of `map<string, unique_ptr<T>>`, even though the map explicitly defines a default
constructor that does not attempt to construct such a pair.

Hypothesis: this error goes unreported by GCC 15.2 due to the use of copy elision, and no diagnostic is required.

Resolved by explicitly defining the default constructor as:

```
    simple_ptr_map() = default;
```

and by explicitly deleting copy construction and copy assignment.
