### PR TITLE
Tweaks to clang-tidy configuration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,7 @@ Checks: >
   -readability-identifier-length,
   -readability-magic-numbers,
   -readability-named-parameter,
+  -readability-uppercase-literal-suffix,
 
 WarningsAsErrors: ''
 
@@ -39,35 +40,37 @@ CheckOptions:
   - key: readability-identifier-naming.NamespaceCase
     value: lower_case
   - key: readability-identifier-naming.ClassCase
-    value: CamelCase
+    value: lower_case
   - key: readability-identifier-naming.StructCase
-    value: CamelCase
+    value: lower_case
   - key: readability-identifier-naming.EnumCase
-    value: CamelCase
+    value: lower_case
   - key: readability-identifier-naming.FunctionCase
     value: lower_case
   - key: readability-identifier-naming.VariableCase
     value: lower_case
   - key: readability-identifier-naming.ParameterCase
     value: lower_case
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
   - key: readability-identifier-naming.MemberCase
     value: lower_case
-  - key: readability-identifier-naming.PrivateMemberPrefix
-    value: 'm_'
-  - key: readability-identifier-naming.ProtectedMemberPrefix
-    value: 'm_'
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: '_'
+  - key: readability-identifier-naming.ProtectedMemberSuffix
+    value: '_'
   - key: readability-identifier-naming.ConstantCase
-    value: UPPER_CASE
+    value: lower_case
   - key: readability-identifier-naming.EnumConstantCase
-    value: UPPER_CASE
+    value: lower_case
   - key: readability-identifier-naming.GlobalConstantCase
-    value: UPPER_CASE
+    value: lower_case
   - key: readability-identifier-naming.StaticConstantCase
-    value: UPPER_CASE
+    value: lower_case
   - key: readability-identifier-naming.TypeAliasCase
-    value: CamelCase
+    value: lower_case
   - key: readability-identifier-naming.TypedefCase
-    value: CamelCase
+    value: lower_case
   - key: readability-identifier-naming.TemplateParameterCase
     value: CamelCase
 


### PR DESCRIPTION
This PR introduces the following `clang-tidy` configuration tweaks regarding readability, ensuring that

- Macros names are `UPPER_CASE`
- Template parameters are `CamelCase`
- Everything else is `lower_case`  (consistent with [Phlex's coding guidelines](https://github.com/Framework-R-D/phlex-coding-guidelines/blob/main/CppGuidelines.md#naming-conventions))
- Private and protected data members use an underscore (`'_'`) as the last character

I've also disabled the [`readability-uppercase-literal-suffix` check](https://clang.llvm.org/extra/clang-tidy/checks/readability/uppercase-literal-suffix.html)—e.g. I find `0U`, `0L`, `2Z` less readable than `0u`, `0l`, `2z`, with the possible exception of `0L` vs. `0l`...which I don't imagine ever needing to use.

Discussion welcome.