### PR TITLE
Do not override clang-tidy header filter on command line

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,7 +33,7 @@ Checks: >
 
 WarningsAsErrors: ''
 
-HeaderFilterRegex: '.*\.(h|hpp)$'
+HeaderFilterRegex: '.*/(phlex|form)/.*\.(h|hpp)$'
 
 CheckOptions:
   # Naming conventions

--- a/Modules/private/RunClangTidyFix.sh.in
+++ b/Modules/private/RunClangTidyFix.sh.in
@@ -61,7 +61,7 @@ fi
 CMD=("$RUN_CLANG_TIDY" -p "$COMPILE_DB" -clang-tidy-binary "$CLANG_TIDY_BIN" -config-file "$CLANG_TIDY_CONFIG")
 [ -n "$CHECKS_ARG" ] && CMD+=("$CHECKS_ARG")
 [ -n "$EXPORT_FIXES_FILE" ] && CMD+=("-export-fixes=$EXPORT_FIXES_FILE")
-CMD+=("-source-filter" "$FILES_REGEX" "-header-filter" "$FILES_REGEX")
+CMD+=("-source-filter" "$FILES_REGEX")
 [ "$DO_FIX" -eq 1 ] && CMD+=("-fix")
 
 if [ ${#FILES_ARG_LIST[@]} -gt 0 ]; then


### PR DESCRIPTION
The `-header-filter` program option to `clang-tidy` was being populated with the list of source files, thus overriding the `HeaderFilterRegex` parameter in the `.clang-tidy` configuration file.

Also adjusted the `.clang-tidy` file to check only for `phlex` or `form` headers.