### PR TITLE
Remove unused code when forming graph

### DIFF
--- a/phlex/core/edge_maker.hpp
+++ b/phlex/core/edge_maker.hpp
@@ -193,17 +193,6 @@ namespace phlex::experimental {
     (head_ports.merge(edges(filters, cons)), ...);
 
     // Create head nodes for unfolds
-    auto get_consumed_products = [](auto const& cons, auto& products) {
-      for (auto const& [key, consumer] : cons.data) {
-        for (auto const& product_name : consumer->input() | std::views::transform(to_name)) {
-          products[product_name].push_back(key);
-        }
-      }
-    };
-
-    std::map<std::string, std::vector<std::string>> consumed_products;
-    (get_consumed_products(cons, consumed_products), ...);
-
     std::set<std::string> remove_ports_for_products;
     for (auto const& [name, unfold] : unfolds.data) {
       multiplexer::head_ports_t heads;


### PR DESCRIPTION
This code was filling a `std::map<...>` of consumed products, but the map is never used.  This PR removes that map, and it removes the lambda expression/closure object used to create the map.