### PR TITLE
Adjust header guards to use LLVM style

### DIFF
--- a/phlex/app/load_module.hpp
+++ b/phlex/app/load_module.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_app_load_module_hpp
-#define phlex_app_load_module_hpp
+#ifndef PHLEX_APP_LOAD_MODULE_HPP
+#define PHLEX_APP_LOAD_MODULE_HPP
 
 #include "phlex/core/fwd.hpp"
 #include "phlex/source.hpp"
@@ -13,4 +13,4 @@ namespace phlex::experimental {
   detail::next_store_t load_source(boost::json::object const& config);
 }
 
-#endif // phlex_app_load_module_hpp
+#endif // PHLEX_APP_LOAD_MODULE_HPP

--- a/phlex/app/run.hpp
+++ b/phlex/app/run.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_app_run_hpp
-#define phlex_app_run_hpp
+#ifndef PHLEX_APP_RUN_HPP
+#define PHLEX_APP_RUN_HPP
 
 #include "boost/json.hpp"
 
@@ -11,4 +11,4 @@ namespace phlex::experimental {
            int max_parallelism);
 }
 
-#endif // phlex_app_run_hpp
+#endif // PHLEX_APP_RUN_HPP

--- a/phlex/app/version.hpp
+++ b/phlex/app/version.hpp
@@ -1,7 +1,7 @@
-#ifndef phlex_app_version_hpp
-#define phlex_app_version_hpp
+#ifndef PHLEX_APP_VERSION_HPP
+#define PHLEX_APP_VERSION_HPP
 
 namespace phlex::experimental {
   char const* version();
 }
-#endif // phlex_app_version_hpp
+#endif // PHLEX_APP_VERSION_HPP

--- a/phlex/concurrency.hpp
+++ b/phlex/concurrency.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_concurrency_hpp
-#define phlex_concurrency_hpp
+#ifndef PHLEX_CONCURRENCY_HPP
+#define PHLEX_CONCURRENCY_HPP
 
 #include <cstddef>
 
@@ -12,4 +12,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_concurrency_hpp
+#endif // PHLEX_CONCURRENCY_HPP

--- a/phlex/configuration.hpp
+++ b/phlex/configuration.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_configuration_hpp
-#define phlex_configuration_hpp
+#ifndef PHLEX_CONFIGURATION_HPP
+#define PHLEX_CONFIGURATION_HPP
 
 #include "boost/json.hpp"
 
@@ -38,4 +38,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_configuration_hpp
+#endif // PHLEX_CONFIGURATION_HPP

--- a/phlex/core/cached_product_stores.hpp
+++ b/phlex/core/cached_product_stores.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_cached_product_stores_hpp
-#define phlex_core_cached_product_stores_hpp
+#ifndef PHLEX_CORE_CACHED_PRODUCT_STORES_HPP
+#define PHLEX_CORE_CACHED_PRODUCT_STORES_HPP
 
 // FIXME: only intended to be used in a single-threaded context as std::map is not
 //        thread-safe.
@@ -38,4 +38,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_core_cached_product_stores_hpp
+#endif // PHLEX_CORE_CACHED_PRODUCT_STORES_HPP

--- a/phlex/core/concepts.hpp
+++ b/phlex/core/concepts.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_concepts_hpp
-#define phlex_core_concepts_hpp
+#ifndef PHLEX_CORE_CONCEPTS_HPP
+#define PHLEX_CORE_CONCEPTS_HPP
 
 #include "phlex/core/fwd.hpp"
 #include "phlex/metaprogramming/type_deduction.hpp"
@@ -69,4 +69,4 @@ namespace phlex::experimental {
   concept is_transform_like = at_least_one_input_parameter<T> && at_least_one_output_object<T>;
 }
 
-#endif // phlex_core_concepts_hpp
+#endif // PHLEX_CORE_CONCEPTS_HPP

--- a/phlex/core/consumer.hpp
+++ b/phlex/core/consumer.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_consumer_hpp
-#define phlex_core_consumer_hpp
+#ifndef PHLEX_CORE_CONSUMER_HPP
+#define PHLEX_CORE_CONSUMER_HPP
 
 #include "phlex/model/algorithm_name.hpp"
 
@@ -22,4 +22,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_consumer_hpp
+#endif // PHLEX_CORE_CONSUMER_HPP

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_declared_fold_hpp
-#define phlex_core_declared_fold_hpp
+#ifndef PHLEX_CORE_DECLARED_FOLD_HPP
+#define PHLEX_CORE_DECLARED_FOLD_HPP
 
 #include "phlex/concurrency.hpp"
 #include "phlex/core/concepts.hpp"
@@ -185,4 +185,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_declared_fold_hpp
+#endif // PHLEX_CORE_DECLARED_FOLD_HPP

--- a/phlex/core/declared_observer.hpp
+++ b/phlex/core/declared_observer.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_declared_observer_hpp
-#define phlex_core_declared_observer_hpp
+#ifndef PHLEX_CORE_DECLARED_OBSERVER_HPP
+#define PHLEX_CORE_DECLARED_OBSERVER_HPP
 
 #include "phlex/core/concepts.hpp"
 #include "phlex/core/fwd.hpp"
@@ -125,4 +125,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_declared_observer_hpp
+#endif // PHLEX_CORE_DECLARED_OBSERVER_HPP

--- a/phlex/core/declared_output.hpp
+++ b/phlex/core/declared_output.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_declared_output_hpp
-#define phlex_core_declared_output_hpp
+#ifndef PHLEX_CORE_DECLARED_OUTPUT_HPP
+#define PHLEX_CORE_DECLARED_OUTPUT_HPP
 
 #include "phlex/core/consumer.hpp"
 #include "phlex/core/fwd.hpp"
@@ -38,4 +38,4 @@ namespace phlex::experimental {
   using declared_outputs = simple_ptr_map<declared_output_ptr>;
 }
 
-#endif // phlex_core_declared_output_hpp
+#endif // PHLEX_CORE_DECLARED_OUTPUT_HPP

--- a/phlex/core/declared_predicate.hpp
+++ b/phlex/core/declared_predicate.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_declared_predicate_hpp
-#define phlex_core_declared_predicate_hpp
+#ifndef PHLEX_CORE_DECLARED_PREDICATE_HPP
+#define PHLEX_CORE_DECLARED_PREDICATE_HPP
 
 #include "phlex/core/concepts.hpp"
 #include "phlex/core/detail/filter_impl.hpp"
@@ -129,4 +129,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_core_declared_predicate_hpp
+#endif // PHLEX_CORE_DECLARED_PREDICATE_HPP

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_declared_transform_hpp
-#define phlex_core_declared_transform_hpp
+#ifndef PHLEX_CORE_DECLARED_TRANSFORM_HPP
+#define PHLEX_CORE_DECLARED_TRANSFORM_HPP
 
 // FIXME: Add comments explaining the process.  For each implementation, explain what part
 //        of the process a given section of code is addressing.
@@ -164,4 +164,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_core_declared_transform_hpp
+#endif // PHLEX_CORE_DECLARED_TRANSFORM_HPP

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_declared_unfold_hpp
-#define phlex_core_declared_unfold_hpp
+#ifndef PHLEX_CORE_DECLARED_UNFOLD_HPP
+#define PHLEX_CORE_DECLARED_UNFOLD_HPP
 
 #include "phlex/core/concepts.hpp"
 #include "phlex/core/end_of_message.hpp"
@@ -199,4 +199,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_declared_unfold_hpp
+#endif // PHLEX_CORE_DECLARED_UNFOLD_HPP

--- a/phlex/core/detail/filter_impl.hpp
+++ b/phlex/core/detail/filter_impl.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_detail_filter_impl_hpp
-#define phlex_core_detail_filter_impl_hpp
+#ifndef PHLEX_CORE_DETAIL_FILTER_IMPL_HPP
+#define PHLEX_CORE_DETAIL_FILTER_IMPL_HPP
 
 #include "phlex/core/fwd.hpp"
 #include "phlex/core/specified_label.hpp"
@@ -70,4 +70,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_detail_filter_impl_hpp
+#endif // PHLEX_CORE_DETAIL_FILTER_IMPL_HPP

--- a/phlex/core/detail/make_algorithm_name.hpp
+++ b/phlex/core/detail/make_algorithm_name.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_detail_make_algorithm_name_hpp
-#define phlex_core_detail_make_algorithm_name_hpp
+#ifndef PHLEX_CORE_DETAIL_MAKE_ALGORITHM_NAME_HPP
+#define PHLEX_CORE_DETAIL_MAKE_ALGORITHM_NAME_HPP
 
 // This simple utility is placed in an implementation file to avoid including the
 // phlex/configuration.hpp in framework code.
@@ -15,4 +15,4 @@ namespace phlex::experimental {
   }
 }
 
-#endif
+#endif // PHLEX_CORE_DETAIL_MAKE_ALGORITHM_NAME_HPP

--- a/phlex/core/detail/maybe_predicates.hpp
+++ b/phlex/core/detail/maybe_predicates.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_detail_maybe_predicates_hpp
-#define phlex_core_detail_maybe_predicates_hpp
+#ifndef PHLEX_CORE_DETAIL_MAYBE_PREDICATES_HPP
+#define PHLEX_CORE_DETAIL_MAYBE_PREDICATES_HPP
 
 // This simple utility is placed in an implementation file to avoid including the
 // phlex/configuration.hpp in framework code.
@@ -16,4 +16,4 @@ namespace phlex::experimental {
   }
 }
 
-#endif
+#endif // PHLEX_CORE_DETAIL_MAYBE_PREDICATES_HPP

--- a/phlex/core/dot/attributes.hpp
+++ b/phlex/core/dot/attributes.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_dot_attributes_hpp
-#define phlex_core_dot_attributes_hpp
+#ifndef PHLEX_CORE_DOT_ATTRIBUTES_HPP
+#define PHLEX_CORE_DOT_ATTRIBUTES_HPP
 
 #include <string>
 
@@ -19,4 +19,4 @@ namespace phlex::experimental::dot {
   std::string parenthesized(std::string const& n);
 }
 
-#endif // phlex_core_dot_attributes_hpp
+#endif // PHLEX_CORE_DOT_ATTRIBUTES_HPP

--- a/phlex/core/dot/data_graph.hpp
+++ b/phlex/core/dot/data_graph.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_dot_data_graph_hpp
-#define phlex_core_dot_data_graph_hpp
+#ifndef PHLEX_CORE_DOT_DATA_GRAPH_HPP
+#define PHLEX_CORE_DOT_DATA_GRAPH_HPP
 
 #include "phlex/core/dot/attributes.hpp"
 #include "phlex/core/specified_label.hpp"
@@ -33,4 +33,4 @@ namespace phlex::experimental::dot {
     std::vector<product_node> nodes_;
   };
 }
-#endif // phlex_core_dot_data_graph_hpp
+#endif // PHLEX_CORE_DOT_DATA_GRAPH_HPP

--- a/phlex/core/dot/function_graph.hpp
+++ b/phlex/core/dot/function_graph.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_dot_function_graph_hpp
-#define phlex_core_dot_function_graph_hpp
+#ifndef PHLEX_CORE_DOT_FUNCTION_GRAPH_HPP
+#define PHLEX_CORE_DOT_FUNCTION_GRAPH_HPP
 
 #include "phlex/core/dot/attributes.hpp"
 #include "phlex/core/multiplexer.hpp"
@@ -36,4 +36,4 @@ namespace phlex::experimental::dot {
     std::vector<function_edge> edges_;
   };
 }
-#endif // phlex_core_dot_function_graph_hpp
+#endif // PHLEX_CORE_DOT_FUNCTION_GRAPH_HPP

--- a/phlex/core/edge_creation_policy.hpp
+++ b/phlex/core/edge_creation_policy.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_edge_creation_policy_hpp
-#define phlex_core_edge_creation_policy_hpp
+#ifndef PHLEX_CORE_EDGE_CREATION_POLICY_HPP
+#define PHLEX_CORE_EDGE_CREATION_POLICY_HPP
 
 #include "phlex/core/message.hpp"
 #include "phlex/model/qualified_name.hpp"
@@ -59,4 +59,4 @@ namespace phlex::experimental {
   }
 }
 
-#endif // phlex_core_edge_creation_policy_hpp
+#endif // PHLEX_CORE_EDGE_CREATION_POLICY_HPP

--- a/phlex/core/edge_maker.hpp
+++ b/phlex/core/edge_maker.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_edge_maker_hpp
-#define phlex_core_edge_maker_hpp
+#ifndef PHLEX_CORE_EDGE_MAKER_HPP
+#define PHLEX_CORE_EDGE_MAKER_HPP
 
 #include "phlex/core/declared_output.hpp"
 #include "phlex/core/declared_unfold.hpp"
@@ -246,4 +246,4 @@ namespace phlex::experimental {
   }
 }
 
-#endif // phlex_core_edge_maker_hpp
+#endif // PHLEX_CORE_EDGE_MAKER_HPP

--- a/phlex/core/end_of_message.hpp
+++ b/phlex/core/end_of_message.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_end_of_message_hpp
-#define phlex_core_end_of_message_hpp
+#ifndef PHLEX_CORE_END_OF_MESSAGE_HPP
+#define PHLEX_CORE_END_OF_MESSAGE_HPP
 
 #include "phlex/core/fwd.hpp"
 #include "phlex/model/fwd.hpp"
@@ -24,4 +24,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_core_end_of_message_hpp
+#endif // PHLEX_CORE_END_OF_MESSAGE_HPP

--- a/phlex/core/filter.hpp
+++ b/phlex/core/filter.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_filter_hpp
-#define phlex_core_filter_hpp
+#ifndef PHLEX_CORE_FILTER_HPP
+#define PHLEX_CORE_FILTER_HPP
 
 #include "phlex/core/detail/filter_impl.hpp"
 #include "phlex/core/fwd.hpp"
@@ -38,4 +38,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_filter_hpp
+#endif // PHLEX_CORE_FILTER_HPP

--- a/phlex/core/fold/send.hpp
+++ b/phlex/core/fold/send.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_fold_send_hpp
-#define phlex_core_fold_send_hpp
+#ifndef PHLEX_CORE_FOLD_SEND_HPP
+#define PHLEX_CORE_FOLD_SEND_HPP
 
 // =======================================================================================
 // Phlex requires fold results to be "sendable", where the result can be represented
@@ -22,4 +22,4 @@ namespace phlex::experimental {
   }
 }
 
-#endif // phlex_core_fold_send_hpp
+#endif // PHLEX_CORE_FOLD_SEND_HPP

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_framework_graph_hpp
-#define phlex_core_framework_graph_hpp
+#ifndef PHLEX_CORE_FRAMEWORK_GRAPH_HPP
+#define PHLEX_CORE_FRAMEWORK_GRAPH_HPP
 
 #include "phlex/core/declared_fold.hpp"
 #include "phlex/core/declared_unfold.hpp"
@@ -152,4 +152,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_framework_graph_hpp
+#endif // PHLEX_CORE_FRAMEWORK_GRAPH_HPP

--- a/phlex/core/fwd.hpp
+++ b/phlex/core/fwd.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_fwd_hpp
-#define phlex_core_fwd_hpp
+#ifndef PHLEX_CORE_FWD_HPP
+#define PHLEX_CORE_FWD_HPP
 
 #include "phlex/model/fwd.hpp"
 #include "phlex/utilities/async_driver.hpp"
@@ -21,7 +21,7 @@ namespace phlex::experimental {
   using framework_driver = async_driver<product_store_ptr>;
 }
 
-#endif // phlex_core_fwd_hpp
+#endif // PHLEX_CORE_FWD_HPP
 
 // Local Variables:
 // mode: c++

--- a/phlex/core/glue.hpp
+++ b/phlex/core/glue.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_glue_hpp
-#define phlex_core_glue_hpp
+#ifndef PHLEX_CORE_GLUE_HPP
+#define PHLEX_CORE_GLUE_HPP
 
 #include "phlex/concurrency.hpp"
 #include "phlex/core/concepts.hpp"
@@ -142,4 +142,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_glue_hpp
+#endif // PHLEX_CORE_GLUE_HPP

--- a/phlex/core/graph_proxy.hpp
+++ b/phlex/core/graph_proxy.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_graph_proxy_hpp
-#define phlex_core_graph_proxy_hpp
+#ifndef PHLEX_CORE_GRAPH_PROXY_HPP
+#define PHLEX_CORE_GRAPH_PROXY_HPP
 
 #include "phlex/concurrency.hpp"
 #include "phlex/core/concepts.hpp"
@@ -116,4 +116,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_graph_proxy_hpp
+#endif // PHLEX_CORE_GRAPH_PROXY_HPP

--- a/phlex/core/input_arguments.hpp
+++ b/phlex/core/input_arguments.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_input_arguments_hpp
-#define phlex_core_input_arguments_hpp
+#ifndef PHLEX_CORE_INPUT_ARGUMENTS_HPP
+#define PHLEX_CORE_INPUT_ARGUMENTS_HPP
 
 #include "phlex/core/message.hpp"
 #include "phlex/core/specified_label.hpp"
@@ -55,4 +55,4 @@ namespace phlex::experimental {
   }
 }
 
-#endif // phlex_core_input_arguments_hpp
+#endif // PHLEX_CORE_INPUT_ARGUMENTS_HPP

--- a/phlex/core/message.hpp
+++ b/phlex/core/message.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_message_hpp
-#define phlex_core_message_hpp
+#ifndef PHLEX_CORE_MESSAGE_HPP
+#define PHLEX_CORE_MESSAGE_HPP
 
 #include "phlex/core/fwd.hpp"
 #include "phlex/core/specified_label.hpp"
@@ -105,4 +105,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_core_message_hpp
+#endif // PHLEX_CORE_MESSAGE_HPP

--- a/phlex/core/message_sender.hpp
+++ b/phlex/core/message_sender.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_message_sender_hpp
-#define phlex_core_message_sender_hpp
+#ifndef PHLEX_CORE_MESSAGE_SENDER_HPP
+#define PHLEX_CORE_MESSAGE_SENDER_HPP
 
 #include "phlex/core/fwd.hpp"
 #include "phlex/core/message.hpp"
@@ -32,4 +32,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_core_message_sender_hpp
+#endif // PHLEX_CORE_MESSAGE_SENDER_HPP

--- a/phlex/core/multiplexer.hpp
+++ b/phlex/core/multiplexer.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_multiplexer_hpp
-#define phlex_core_multiplexer_hpp
+#ifndef PHLEX_CORE_MULTIPLEXER_HPP
+#define PHLEX_CORE_MULTIPLEXER_HPP
 
 #include "phlex/core/message.hpp"
 #include "phlex/model/level_id.hpp"
@@ -45,4 +45,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_core_multiplexer_hpp
+#endif // PHLEX_CORE_MULTIPLEXER_HPP

--- a/phlex/core/node_catalog.hpp
+++ b/phlex/core/node_catalog.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_node_catalog_hpp
-#define phlex_core_node_catalog_hpp
+#ifndef PHLEX_CORE_NODE_CATALOG_HPP
+#define PHLEX_CORE_NODE_CATALOG_HPP
 
 #include "phlex/core/declared_fold.hpp"
 #include "phlex/core/declared_observer.hpp"
@@ -35,4 +35,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_node_catalog_hpp
+#endif // PHLEX_CORE_NODE_CATALOG_HPP

--- a/phlex/core/products_consumer.hpp
+++ b/phlex/core/products_consumer.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_products_consumer_hpp
-#define phlex_core_products_consumer_hpp
+#ifndef PHLEX_CORE_PRODUCTS_CONSUMER_HPP
+#define PHLEX_CORE_PRODUCTS_CONSUMER_HPP
 
 #include "phlex/core/consumer.hpp"
 #include "phlex/core/fwd.hpp"
@@ -44,4 +44,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_products_consumer_hpp
+#endif // PHLEX_CORE_PRODUCTS_CONSUMER_HPP

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_registrar_hpp
-#define phlex_core_registrar_hpp
+#ifndef PHLEX_CORE_REGISTRAR_HPP
+#define PHLEX_CORE_REGISTRAR_HPP
 
 // =======================================================================================
 //
@@ -124,4 +124,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_registrar_hpp
+#endif // PHLEX_CORE_REGISTRAR_HPP

--- a/phlex/core/registration_api.hpp
+++ b/phlex/core/registration_api.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_registration_api_hpp
-#define phlex_core_registration_api_hpp
+#ifndef PHLEX_CORE_REGISTRATION_API_HPP
+#define PHLEX_CORE_REGISTRATION_API_HPP
 
 #include "phlex/concurrency.hpp"
 #include "phlex/core/concepts.hpp"
@@ -287,4 +287,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_registration_api_hpp
+#endif // PHLEX_CORE_REGISTRATION_API_HPP

--- a/phlex/core/specified_label.hpp
+++ b/phlex/core/specified_label.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_specified_label_hpp
-#define phlex_core_specified_label_hpp
+#ifndef PHLEX_CORE_SPECIFIED_LABEL_HPP
+#define PHLEX_CORE_SPECIFIED_LABEL_HPP
 
 #include "phlex/model/qualified_name.hpp"
 
@@ -48,4 +48,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_core_specified_label_hpp
+#endif // PHLEX_CORE_SPECIFIED_LABEL_HPP

--- a/phlex/core/store_counters.hpp
+++ b/phlex/core/store_counters.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_store_counters_hpp
-#define phlex_core_store_counters_hpp
+#ifndef PHLEX_CORE_STORE_COUNTERS_HPP
+#define PHLEX_CORE_STORE_COUNTERS_HPP
 
 #include "phlex/core/fwd.hpp"
 #include "phlex/model/level_counter.hpp"
@@ -76,4 +76,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_store_counters_hpp
+#endif // PHLEX_CORE_STORE_COUNTERS_HPP

--- a/phlex/core/upstream_predicates.hpp
+++ b/phlex/core/upstream_predicates.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_core_upstream_predicates_hpp
-#define phlex_core_upstream_predicates_hpp
+#ifndef PHLEX_CORE_UPSTREAM_PREDICATES_HPP
+#define PHLEX_CORE_UPSTREAM_PREDICATES_HPP
 
 #include "phlex/core/detail/maybe_predicates.hpp"
 #include "phlex/core/registrar.hpp"
@@ -58,4 +58,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_core_upstream_predicates_hpp
+#endif // PHLEX_CORE_UPSTREAM_PREDICATES_HPP

--- a/phlex/graph/serial_node.hpp
+++ b/phlex/graph/serial_node.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_graph_serial_node_hpp
-#define phlex_graph_serial_node_hpp
+#ifndef PHLEX_GRAPH_SERIAL_NODE_HPP
+#define PHLEX_GRAPH_SERIAL_NODE_HPP
 
 #include "phlex/graph/serializer_node.hpp"
 #include "phlex/utilities/sized_tuple.hpp"
@@ -79,4 +79,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_graph_serial_node_hpp
+#endif // PHLEX_GRAPH_SERIAL_NODE_HPP

--- a/phlex/graph/serializer_node.hpp
+++ b/phlex/graph/serializer_node.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_graph_serializer_node_hpp
-#define phlex_graph_serializer_node_hpp
+#ifndef PHLEX_GRAPH_SERIALIZER_NODE_HPP
+#define PHLEX_GRAPH_SERIALIZER_NODE_HPP
 
 #include "phlex/utilities/sized_tuple.hpp"
 
@@ -53,4 +53,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_graph_serializer_node_hpp
+#endif // PHLEX_GRAPH_SERIALIZER_NODE_HPP

--- a/phlex/metaprogramming/delegate.hpp
+++ b/phlex/metaprogramming/delegate.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_metaprogramming_delegate_hpp
-#define phlex_metaprogramming_delegate_hpp
+#ifndef PHLEX_METAPROGRAMMING_DELEGATE_HPP
+#define PHLEX_METAPROGRAMMING_DELEGATE_HPP
 
 #include "phlex/metaprogramming/type_deduction.hpp"
 
@@ -59,4 +59,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_metaprogramming_delegate_hpp
+#endif // PHLEX_METAPROGRAMMING_DELEGATE_HPP

--- a/phlex/metaprogramming/detail/basic_concepts.hpp
+++ b/phlex/metaprogramming/detail/basic_concepts.hpp
@@ -1,9 +1,9 @@
-#ifndef phlex_metaprogramming_detail_basic_concepts_hpp
-#define phlex_metaprogramming_detail_basic_concepts_hpp
+#ifndef PHLEX_METAPROGRAMMING_DETAIL_BASIC_CONCEPTS_HPP
+#define PHLEX_METAPROGRAMMING_DETAIL_BASIC_CONCEPTS_HPP
 
 namespace phlex::experimental::detail {
   template <typename T>
   concept has_call_operator = requires { &T::operator(); };
 }
 
-#endif // phlex_metaprogramming_detail_basic_concepts_hpp
+#endif // PHLEX_METAPROGRAMMING_DETAIL_BASIC_CONCEPTS_HPP

--- a/phlex/metaprogramming/detail/ctor_reflect_types.hpp
+++ b/phlex/metaprogramming/detail/ctor_reflect_types.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_metaprogramming_detail_ctor_reflect_types_hpp
-#define phlex_metaprogramming_detail_ctor_reflect_types_hpp
+#ifndef PHLEX_METAPROGRAMMING_DETAIL_CTOR_REFLECT_TYPES_HPP
+#define PHLEX_METAPROGRAMMING_DETAIL_CTOR_REFLECT_TYPES_HPP
 
 #include "boost/predef.h"
 
@@ -122,4 +122,4 @@ namespace refl {
 #pragma GCC diagnostic pop
 #endif
 
-#endif // phlex_metaprogramming_detail_ctor_reflect_types_hpp
+#endif // PHLEX_METAPROGRAMMING_DETAIL_CTOR_REFLECT_TYPES_HPP

--- a/phlex/metaprogramming/detail/number_output_objects.hpp
+++ b/phlex/metaprogramming/detail/number_output_objects.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_metaprogramming_detail_number_output_objects_hpp
-#define phlex_metaprogramming_detail_number_output_objects_hpp
+#ifndef PHLEX_METAPROGRAMMING_DETAIL_NUMBER_OUTPUT_OBJECTS_HPP
+#define PHLEX_METAPROGRAMMING_DETAIL_NUMBER_OUTPUT_OBJECTS_HPP
 
 #include "phlex/metaprogramming/detail/basic_concepts.hpp"
 
@@ -60,4 +60,4 @@ namespace phlex::experimental::detail {
     number_types_not_void<R>();
 }
 
-#endif // phlex_metaprogramming_detail_number_output_objects_hpp
+#endif // PHLEX_METAPROGRAMMING_DETAIL_NUMBER_OUTPUT_OBJECTS_HPP

--- a/phlex/metaprogramming/detail/number_parameters.hpp
+++ b/phlex/metaprogramming/detail/number_parameters.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_metaprogramming_detail_number_parameters_hpp
-#define phlex_metaprogramming_detail_number_parameters_hpp
+#ifndef PHLEX_METAPROGRAMMING_DETAIL_NUMBER_PARAMETERS_HPP
+#define PHLEX_METAPROGRAMMING_DETAIL_NUMBER_PARAMETERS_HPP
 
 #include "phlex/metaprogramming/detail/basic_concepts.hpp"
 
@@ -37,4 +37,4 @@ namespace phlex::experimental::detail {
   constexpr std::size_t number_parameters_impl<R(Args...) noexcept> = sizeof...(Args);
 }
 
-#endif // phlex_metaprogramming_detail_number_parameters_hpp
+#endif // PHLEX_METAPROGRAMMING_DETAIL_NUMBER_PARAMETERS_HPP

--- a/phlex/metaprogramming/detail/parameter_types.hpp
+++ b/phlex/metaprogramming/detail/parameter_types.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_metaprogramming_detail_parameter_types_hpp
-#define phlex_metaprogramming_detail_parameter_types_hpp
+#ifndef PHLEX_METAPROGRAMMING_DETAIL_PARAMETER_TYPES_HPP
+#define PHLEX_METAPROGRAMMING_DETAIL_PARAMETER_TYPES_HPP
 
 #include "phlex/metaprogramming/detail/basic_concepts.hpp"
 
@@ -29,4 +29,4 @@ namespace phlex::experimental::detail {
   auto parameter_types_impl(T&&) -> decltype(parameter_types_impl(&T::operator()));
 }
 
-#endif // phlex_metaprogramming_detail_parameter_types_hpp
+#endif // PHLEX_METAPROGRAMMING_DETAIL_PARAMETER_TYPES_HPP

--- a/phlex/metaprogramming/detail/return_type.hpp
+++ b/phlex/metaprogramming/detail/return_type.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_metaprogramming_detail_return_type_hpp
-#define phlex_metaprogramming_detail_return_type_hpp
+#ifndef PHLEX_METAPROGRAMMING_DETAIL_RETURN_TYPE_HPP
+#define PHLEX_METAPROGRAMMING_DETAIL_RETURN_TYPE_HPP
 
 #include "phlex/metaprogramming/detail/basic_concepts.hpp"
 
@@ -28,4 +28,4 @@ namespace phlex::experimental::detail {
   auto return_type_impl(T&&) -> decltype(return_type_impl(&T::operator()));
 }
 
-#endif // phlex_metaprogramming_detail_return_type_hpp
+#endif // PHLEX_METAPROGRAMMING_DETAIL_RETURN_TYPE_HPP

--- a/phlex/metaprogramming/type_deduction.hpp
+++ b/phlex/metaprogramming/type_deduction.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_metaprogramming_type_deduction_hpp
-#define phlex_metaprogramming_type_deduction_hpp
+#ifndef PHLEX_METAPROGRAMMING_TYPE_DEDUCTION_HPP
+#define PHLEX_METAPROGRAMMING_TYPE_DEDUCTION_HPP
 
 #include "phlex/metaprogramming/detail/ctor_reflect_types.hpp"
 #include "phlex/metaprogramming/detail/number_output_objects.hpp"
@@ -61,4 +61,4 @@ namespace phlex::experimental {
   struct is_non_const_lvalue_reference<T const&> : std::false_type {};
 }
 
-#endif // phlex_metaprogramming_type_deduction_hpp
+#endif // PHLEX_METAPROGRAMMING_TYPE_DEDUCTION_HPP

--- a/phlex/model/algorithm_name.hpp
+++ b/phlex/model/algorithm_name.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_model_algorithm_name_hpp
-#define phlex_model_algorithm_name_hpp
+#ifndef PHLEX_MODEL_ALGORITHM_NAME_HPP
+#define PHLEX_MODEL_ALGORITHM_NAME_HPP
 
 #include <string>
 
@@ -37,4 +37,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_model_algorithm_name_hpp
+#endif // PHLEX_MODEL_ALGORITHM_NAME_HPP

--- a/phlex/model/fwd.hpp
+++ b/phlex/model/fwd.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_model_fwd_hpp
-#define phlex_model_fwd_hpp
+#ifndef PHLEX_MODEL_FWD_HPP
+#define PHLEX_MODEL_FWD_HPP
 
 #include <memory>
 
@@ -16,4 +16,4 @@ namespace phlex::experimental {
   enum class stage { process, flush };
 }
 
-#endif // phlex_model_fwd_hpp
+#endif // PHLEX_MODEL_FWD_HPP

--- a/phlex/model/handle.hpp
+++ b/phlex/model/handle.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_model_handle_hpp
-#define phlex_model_handle_hpp
+#ifndef PHLEX_MODEL_HANDLE_HPP
+#define PHLEX_MODEL_HANDLE_HPP
 
 #include "phlex/model/level_id.hpp"
 #include "phlex/model/products.hpp"
@@ -107,4 +107,4 @@ namespace phlex::experimental {
   using handle_for = typename handle_<T>::type;
 }
 
-#endif // phlex_model_handle_hpp
+#endif // PHLEX_MODEL_HANDLE_HPP

--- a/phlex/model/level_counter.hpp
+++ b/phlex/model/level_counter.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_model_level_counter_hpp
-#define phlex_model_level_counter_hpp
+#ifndef PHLEX_MODEL_LEVEL_COUNTER_HPP
+#define PHLEX_MODEL_LEVEL_COUNTER_HPP
 
 #include "phlex/model/fwd.hpp"
 #include "phlex/model/level_id.hpp"
@@ -68,4 +68,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_model_level_counter_hpp
+#endif // PHLEX_MODEL_LEVEL_COUNTER_HPP

--- a/phlex/model/level_hierarchy.hpp
+++ b/phlex/model/level_hierarchy.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_model_level_hierarchy_hpp
-#define phlex_model_level_hierarchy_hpp
+#ifndef PHLEX_MODEL_LEVEL_HIERARCHY_HPP
+#define PHLEX_MODEL_LEVEL_HIERARCHY_HPP
 
 #include "phlex/model/fwd.hpp"
 #include "phlex/model/level_id.hpp"
@@ -45,4 +45,4 @@ namespace phlex::experimental {
 
 }
 
-#endif // phlex_model_level_hierarchy_hpp
+#endif // PHLEX_MODEL_LEVEL_HIERARCHY_HPP

--- a/phlex/model/level_id.hpp
+++ b/phlex/model/level_id.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_model_level_id_hpp
-#define phlex_model_level_id_hpp
+#ifndef PHLEX_MODEL_LEVEL_ID_HPP
+#define PHLEX_MODEL_LEVEL_ID_HPP
 
 #include "phlex/model/fwd.hpp"
 
@@ -62,4 +62,4 @@ namespace std {
   };
 }
 
-#endif // phlex_model_level_id_hpp
+#endif // PHLEX_MODEL_LEVEL_ID_HPP

--- a/phlex/model/product_matcher.hpp
+++ b/phlex/model/product_matcher.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_model_product_matcher_hpp
-#define phlex_model_product_matcher_hpp
+#ifndef PHLEX_MODEL_PRODUCT_MATCHER_HPP
+#define PHLEX_MODEL_PRODUCT_MATCHER_HPP
 
 // =======================================================================================
 // The full specification of a matcher looks like:
@@ -35,7 +35,7 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_model_product_matcher_hpp
+#endif // PHLEX_MODEL_PRODUCT_MATCHER_HPP
 
 // Local Variables:
 // mode: c++

--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_model_product_store_hpp
-#define phlex_model_product_store_hpp
+#ifndef PHLEX_MODEL_PRODUCT_STORE_HPP
+#define PHLEX_MODEL_PRODUCT_STORE_HPP
 
 #include "phlex/model/fwd.hpp"
 #include "phlex/model/handle.hpp"
@@ -132,4 +132,4 @@ namespace phlex::experimental {
   }
 }
 
-#endif // phlex_model_product_store_hpp
+#endif // PHLEX_MODEL_PRODUCT_STORE_HPP

--- a/phlex/model/products.hpp
+++ b/phlex/model/products.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_model_products_hpp
-#define phlex_model_products_hpp
+#ifndef PHLEX_MODEL_PRODUCTS_HPP
+#define PHLEX_MODEL_PRODUCTS_HPP
 
 #include "phlex/model/qualified_name.hpp"
 
@@ -105,4 +105,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_model_products_hpp
+#endif // PHLEX_MODEL_PRODUCTS_HPP

--- a/phlex/model/qualified_name.hpp
+++ b/phlex/model/qualified_name.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_model_qualified_name_hpp
-#define phlex_model_qualified_name_hpp
+#ifndef PHLEX_MODEL_QUALIFIED_NAME_HPP
+#define PHLEX_MODEL_QUALIFIED_NAME_HPP
 
 #include "phlex/model/algorithm_name.hpp"
 
@@ -50,4 +50,4 @@ namespace phlex::experimental {
                                      std::vector<std::string> output_labels);
 }
 
-#endif // phlex_model_qualified_name_hpp
+#endif // PHLEX_MODEL_QUALIFIED_NAME_HPP

--- a/phlex/module.hpp
+++ b/phlex/module.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_module_hpp
-#define phlex_module_hpp
+#ifndef PHLEX_MODULE_HPP
+#define PHLEX_MODULE_HPP
 
 #include "boost/dll/alias.hpp"
 #include "phlex/concurrency.hpp"
@@ -29,4 +29,4 @@ namespace phlex::experimental::detail {
   BOOST_DLL_ALIAS(create, create_module)                                                           \
   SELECT_SIGNATURE(__VA_ARGS__)
 
-#endif // phlex_module_hpp
+#endif // PHLEX_MODULE_HPP

--- a/phlex/source.hpp
+++ b/phlex/source.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_source_hpp
-#define phlex_source_hpp
+#ifndef PHLEX_SOURCE_HPP
+#define PHLEX_SOURCE_HPP
 
 #include "boost/dll/alias.hpp"
 
@@ -66,4 +66,4 @@ namespace phlex::experimental::detail {
 #define PHLEX_EXPERIMENTAL_REGISTER_SOURCE(source)                                                 \
   BOOST_DLL_ALIAS(phlex::experimental::detail::create_next<source>, create_source)
 
-#endif // phlex_source_hpp
+#endif // PHLEX_SOURCE_HPP

--- a/phlex/utilities/async_driver.hpp
+++ b/phlex/utilities/async_driver.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_async_driver_hpp
-#define phlex_utilities_async_driver_hpp
+#ifndef PHLEX_UTILITIES_ASYNC_DRIVER_HPP
+#define PHLEX_UTILITIES_ASYNC_DRIVER_HPP
 
 #include <atomic>
 #include <condition_variable>
@@ -60,4 +60,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_utilities_async_driver_hpp
+#endif // PHLEX_UTILITIES_ASYNC_DRIVER_HPP

--- a/phlex/utilities/hashing.hpp
+++ b/phlex/utilities/hashing.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_hashing_hpp
-#define phlex_utilities_hashing_hpp
+#ifndef PHLEX_UTILITIES_HASHING_HPP
+#define PHLEX_UTILITIES_HASHING_HPP
 
 #include <cstdint>
 #include <string>
@@ -16,4 +16,4 @@ namespace phlex::experimental {
   }
 }
 
-#endif // phlex_utilities_hashing_hpp
+#endif // PHLEX_UTILITIES_HASHING_HPP

--- a/phlex/utilities/max_allowed_parallelism.hpp
+++ b/phlex/utilities/max_allowed_parallelism.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_max_allowed_parallelism_hpp
-#define phlex_utilities_max_allowed_parallelism_hpp
+#ifndef PHLEX_UTILITIES_MAX_ALLOWED_PARALLELISM_HPP
+#define PHLEX_UTILITIES_MAX_ALLOWED_PARALLELISM_HPP
 
 #include "oneapi/tbb/global_control.h"
 
@@ -24,4 +24,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_utilities_max_allowed_parallelism_hpp
+#endif // PHLEX_UTILITIES_MAX_ALLOWED_PARALLELISM_HPP

--- a/phlex/utilities/resource_usage.hpp
+++ b/phlex/utilities/resource_usage.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_resource_usage_hpp
-#define phlex_utilities_resource_usage_hpp
+#ifndef PHLEX_UTILITIES_RESOURCE_USAGE_HPP
+#define PHLEX_UTILITIES_RESOURCE_USAGE_HPP
 
 // =======================================================================================
 // The resource_usage class tracks the CPU time and real time during the lifetime of a
@@ -20,4 +20,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_utilities_resource_usage_hpp
+#endif // PHLEX_UTILITIES_RESOURCE_USAGE_HPP

--- a/phlex/utilities/simple_ptr_map.hpp
+++ b/phlex/utilities/simple_ptr_map.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_simple_ptr_map_hpp
-#define phlex_utilities_simple_ptr_map_hpp
+#ifndef PHLEX_UTILITIES_SIMPLE_PTR_MAP_HPP
+#define PHLEX_UTILITIES_SIMPLE_PTR_MAP_HPP
 
 // ==================================================================================
 // The type simple_ptr_map<Ptr> is nearly equivalent to the type:
@@ -61,4 +61,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_utilities_simple_ptr_map_hpp
+#endif // PHLEX_UTILITIES_SIMPLE_PTR_MAP_HPP

--- a/phlex/utilities/sized_tuple.hpp
+++ b/phlex/utilities/sized_tuple.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_sized_tuple_hpp
-#define phlex_utilities_sized_tuple_hpp
+#ifndef PHLEX_UTILITIES_SIZED_TUPLE_HPP
+#define PHLEX_UTILITIES_SIZED_TUPLE_HPP
 
 #include <cstddef>
 #include <tuple>
@@ -24,4 +24,4 @@ namespace phlex::experimental {
   using concatenated_tuples = decltype(std::tuple_cat(std::declval<T>()...));
 }
 
-#endif // phlex_utilities_sized_tuple_hpp
+#endif // PHLEX_UTILITIES_SIZED_TUPLE_HPP

--- a/phlex/utilities/sleep_for.hpp
+++ b/phlex/utilities/sleep_for.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_sleep_for_hpp
-#define phlex_utilities_sleep_for_hpp
+#ifndef PHLEX_UTILITIES_SLEEP_FOR_HPP
+#define PHLEX_UTILITIES_SLEEP_FOR_HPP
 
 #include <chrono>
 #include <thread>
@@ -23,4 +23,4 @@ namespace phlex::experimental {
   using namespace std::chrono_literals;
 }
 
-#endif // phlex_utilities_sleep_for_hpp
+#endif // PHLEX_UTILITIES_SLEEP_FOR_HPP

--- a/phlex/utilities/string_literal.hpp
+++ b/phlex/utilities/string_literal.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_string_literal_hpp
-#define phlex_utilities_string_literal_hpp
+#ifndef PHLEX_UTILITIES_STRING_LITERAL_HPP
+#define PHLEX_UTILITIES_STRING_LITERAL_HPP
 
 #include <algorithm>
 #include <array>
@@ -28,4 +28,4 @@ namespace phlex::experimental {
   concept are_unique = detail::unique<Resources...>();
 }
 
-#endif // phlex_utilities_string_literal_hpp
+#endif // PHLEX_UTILITIES_STRING_LITERAL_HPP

--- a/phlex/utilities/stripped_name.hpp
+++ b/phlex/utilities/stripped_name.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_stripped_name_hpp
-#define phlex_utilities_stripped_name_hpp
+#ifndef PHLEX_UTILITIES_STRIPPED_NAME_HPP
+#define PHLEX_UTILITIES_STRIPPED_NAME_HPP
 
 #include <string>
 
@@ -10,4 +10,4 @@ namespace phlex::experimental {
   }
 }
 
-#endif // phlex_utilities_stripped_name_hpp
+#endif // PHLEX_UTILITIES_STRIPPED_NAME_HPP

--- a/phlex/utilities/thread_counter.hpp
+++ b/phlex/utilities/thread_counter.hpp
@@ -1,5 +1,5 @@
-#ifndef phlex_utilities_thread_counter_hpp
-#define phlex_utilities_thread_counter_hpp
+#ifndef PHLEX_UTILITIES_THREAD_COUNTER_HPP
+#define PHLEX_UTILITIES_THREAD_COUNTER_HPP
 
 #include <atomic>
 #include <stdexcept>
@@ -27,4 +27,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // phlex_utilities_thread_counter_hpp
+#endif // PHLEX_UTILITIES_THREAD_COUNTER_HPP

--- a/test/benchmarks/fibonacci_numbers.hpp
+++ b/test/benchmarks/fibonacci_numbers.hpp
@@ -1,5 +1,5 @@
-#ifndef test_benchmarks_fibonacci_numbers_hpp
-#define test_benchmarks_fibonacci_numbers_hpp
+#ifndef TEST_BENCHMARKS_FIBONACCI_NUMBERS_HPP
+#define TEST_BENCHMARKS_FIBONACCI_NUMBERS_HPP
 
 #include <vector>
 
@@ -14,4 +14,4 @@ namespace test {
   };
 }
 
-#endif // test_benchmarks_fibonacci_numbers_hpp
+#endif // TEST_BENCHMARKS_FIBONACCI_NUMBERS_HPP

--- a/test/cached_execution_source.hpp
+++ b/test/cached_execution_source.hpp
@@ -1,5 +1,5 @@
-#ifndef test_cached_execution_source_hpp
-#define test_cached_execution_source_hpp
+#ifndef TEST_CACHED_EXECUTION_SOURCE_HPP
+#define TEST_CACHED_EXECUTION_SOURCE_HPP
 
 // ===================================================================
 // This source creates:
@@ -48,4 +48,4 @@ namespace test {
   };
 }
 
-#endif // test_cached_execution_source_hpp
+#endif // TEST_CACHED_EXECUTION_SOURCE_HPP

--- a/test/demo-giantdata/log_record.hpp
+++ b/test/demo-giantdata/log_record.hpp
@@ -1,5 +1,5 @@
-#ifndef test_demo_giantdata_log_record_hpp
-#define test_demo_giantdata_log_record_hpp
+#ifndef TEST_DEMO_GIANTDATA_LOG_RECORD_HPP
+#define TEST_DEMO_GIANTDATA_LOG_RECORD_HPP
 
 #include "oneapi/tbb/concurrent_queue.h"
 #include "oneapi/tbb/task_arena.h"
@@ -87,4 +87,4 @@ namespace demo {
   }
 } // namespace demo
 
-#endif // test_demo_giantdata_log_record_hpp
+#endif // TEST_DEMO_GIANTDATA_LOG_RECORD_HPP

--- a/test/demo-giantdata/summed_clamped_waveforms.hpp
+++ b/test/demo-giantdata/summed_clamped_waveforms.hpp
@@ -1,6 +1,6 @@
 // This is the data product created by our fold node.
-#ifndef test_demo_giantdata_summed_clamped_waveforms_hpp
-#define test_demo_giantdata_summed_clamped_waveforms_hpp
+#ifndef TEST_DEMO_GIANTDATA_SUMMED_CLAMPED_WAVEFORMS_HPP
+#define TEST_DEMO_GIANTDATA_SUMMED_CLAMPED_WAVEFORMS_HPP
 
 #include <cstddef>
 
@@ -13,4 +13,4 @@ namespace demo {
 
 } // namespace demo
 
-#endif // test_demo_giantdata_summed_clamped_waveforms_hpp
+#endif // TEST_DEMO_GIANTDATA_SUMMED_CLAMPED_WAVEFORMS_HPP

--- a/test/demo-giantdata/user_algorithms.hpp
+++ b/test/demo-giantdata/user_algorithms.hpp
@@ -1,5 +1,5 @@
-#ifndef test_demo_giantdata_user_algorithms_hpp
-#define test_demo_giantdata_user_algorithms_hpp
+#ifndef TEST_DEMO_GIANTDATA_USER_ALGORITHMS_HPP
+#define TEST_DEMO_GIANTDATA_USER_ALGORITHMS_HPP
 
 #include "summed_clamped_waveforms.hpp"
 #include "waveforms.hpp"
@@ -24,4 +24,4 @@ namespace demo {
 
 } // namespace demo
 
-#endif // test_demo_giantdata_user_algorithms_hpp
+#endif // TEST_DEMO_GIANTDATA_USER_ALGORITHMS_HPP

--- a/test/demo-giantdata/waveform_generator.hpp
+++ b/test/demo-giantdata/waveform_generator.hpp
@@ -1,5 +1,5 @@
-#ifndef test_demo_giantdata_waveform_generator_hpp
-#define test_demo_giantdata_waveform_generator_hpp
+#ifndef TEST_DEMO_GIANTDATA_WAVEFORM_GENERATOR_HPP
+#define TEST_DEMO_GIANTDATA_WAVEFORM_GENERATOR_HPP
 
 #include "log_record.hpp"
 #include "waveform_generator_input.hpp"
@@ -40,4 +40,4 @@ namespace demo {
     int spill_id_;        // the id of the spill this object will process
   }; // class WaveformGenerator
 } // namespace demo
-#endif // test_demo_giantdata_waveform_generator_hpp
+#endif // TEST_DEMO_GIANTDATA_WAVEFORM_GENERATOR_HPP

--- a/test/demo-giantdata/waveform_generator_input.hpp
+++ b/test/demo-giantdata/waveform_generator_input.hpp
@@ -1,5 +1,5 @@
-#ifndef test_demo_giantdata_waveform_generator_input_hpp
-#define test_demo_giantdata_waveform_generator_input_hpp
+#ifndef TEST_DEMO_GIANTDATA_WAVEFORM_GENERATOR_INPUT_HPP
+#define TEST_DEMO_GIANTDATA_WAVEFORM_GENERATOR_INPUT_HPP
 
 #include <cstddef>
 
@@ -29,4 +29,4 @@ namespace demo {
   inline std::size_t mysize(WaveformGeneratorInput const& w) { return sizeof(w); }
 } // namespace demo
 
-#endif // test_demo_giantdata_waveform_generator_input_hpp
+#endif // TEST_DEMO_GIANTDATA_WAVEFORM_GENERATOR_INPUT_HPP

--- a/test/demo-giantdata/waveforms.hpp
+++ b/test/demo-giantdata/waveforms.hpp
@@ -1,6 +1,6 @@
 // waveforms.hpp
-#ifndef test_demo_giantdata_waveforms_hpp
-#define test_demo_giantdata_waveforms_hpp
+#ifndef TEST_DEMO_GIANTDATA_WAVEFORMS_HPP
+#define TEST_DEMO_GIANTDATA_WAVEFORMS_HPP
 
 #include <array>
 #include <vector>
@@ -33,4 +33,4 @@ namespace demo {
   };
 
 } // namespace demo
-#endif // test_demo_giantdata_waveforms_hpp
+#endif // TEST_DEMO_GIANTDATA_WAVEFORMS_HPP

--- a/test/mock-workflow/algorithm.hpp
+++ b/test/mock-workflow/algorithm.hpp
@@ -1,5 +1,5 @@
-#ifndef test_mock_workflow_algorithm_hpp
-#define test_mock_workflow_algorithm_hpp
+#ifndef TEST_MOCK_WORKFLOW_ALGORITHM_HPP
+#define TEST_MOCK_WORKFLOW_ALGORITHM_HPP
 
 #include "phlex/concurrency.hpp"
 #include "phlex/configuration.hpp"
@@ -76,4 +76,4 @@ namespace phlex::experimental::test {
   }
 }
 
-#endif // test_mock_workflow_algorithm_hpp
+#endif // TEST_MOCK_WORKFLOW_ALGORITHM_HPP

--- a/test/mock-workflow/timed_busy.hpp
+++ b/test/mock-workflow/timed_busy.hpp
@@ -1,5 +1,5 @@
-#ifndef test_mock_workflow_timed_busy_hpp
-#define test_mock_workflow_timed_busy_hpp
+#ifndef TEST_MOCK_WORKFLOW_TIMED_BUSY_HPP
+#define TEST_MOCK_WORKFLOW_TIMED_BUSY_HPP
 
 #include <chrono>
 
@@ -7,4 +7,4 @@ namespace phlex::experimental::test {
   void timed_busy(std::chrono::microseconds const& duration);
 }
 
-#endif // test_mock_workflow_timed_busy_hpp
+#endif // TEST_MOCK_WORKFLOW_TIMED_BUSY_HPP

--- a/test/mock-workflow/types.hpp
+++ b/test/mock-workflow/types.hpp
@@ -1,5 +1,5 @@
-#ifndef test_mock_workflow_types_hpp
-#define test_mock_workflow_types_hpp
+#ifndef TEST_MOCK_WORKFLOW_TYPES_HPP
+#define TEST_MOCK_WORKFLOW_TYPES_HPP
 
 namespace phlex::experimental {
   template <typename A, typename B, typename D = void>
@@ -30,4 +30,4 @@ namespace simb {
 
 #undef DATA_PRODUCT
 
-#endif // test_mock_workflow_types_hpp
+#endif // TEST_MOCK_WORKFLOW_TYPES_HPP

--- a/test/plugins/add.hpp
+++ b/test/plugins/add.hpp
@@ -1,8 +1,8 @@
-#ifndef test_plugins_add_hpp
-#define test_plugins_add_hpp
+#ifndef TEST_PLUGINS_ADD_HPP
+#define TEST_PLUGINS_ADD_HPP
 
 namespace test {
   constexpr int add(int i, int j) { return i + j; }
 }
 
-#endif // test_plugins_add_hpp
+#endif // TEST_PLUGINS_ADD_HPP

--- a/test/products_for_output.hpp
+++ b/test/products_for_output.hpp
@@ -1,5 +1,5 @@
-#ifndef test_products_for_output_hpp
-#define test_products_for_output_hpp
+#ifndef TEST_PRODUCTS_FOR_OUTPUT_HPP
+#define TEST_PRODUCTS_FOR_OUTPUT_HPP
 
 #include "phlex/model/product_store.hpp"
 
@@ -23,4 +23,4 @@ namespace phlex::experimental::test {
 
 }
 
-#endif // test_products_for_output_hpp
+#endif // TEST_PRODUCTS_FOR_OUTPUT_HPP


### PR DESCRIPTION
The current `clang-tidy` configuration for Phlex requires macros to use `UPPER_CASE`, and the header guards are all `lower_case` right now.  If we switch to the LLVM header-guard style, that error goes away.

This PR does not make the corresponding changes to the `form` files.