### PR TITLE
Adjust unfold so that it doesn't need a multiplexer

### DIFF
--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -142,7 +142,7 @@ namespace phlex::experimental {
     filters_.merge(internal_edges_for_predicates(graph_, nodes_.predicates, nodes_.unfolds));
     filters_.merge(internal_edges_for_predicates(graph_, nodes_.predicates, nodes_.transforms));
 
-    edge_maker make_edges{dot_file_prefix, nodes_.transforms, nodes_.folds};
+    edge_maker make_edges{dot_file_prefix, nodes_.transforms, nodes_.folds, nodes_.unfolds};
     make_edges(src_,
                multiplexer_,
                filters_,


### PR DESCRIPTION
The unfold node was originally implemented to use a message router (called a `multiplexer`) for forwarding data to downstream nodes.  This design is overly complicated and unnecessary.  This PR removes the use of the `multiplexer` and expresses the unfold in a manner similar to other higher-order functions.

This also considerably simplifies the logic of forming the execution graph.