### PR TITLE
Improvements to CI image, including installation of Ruff

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -88,7 +88,7 @@ jobs:
   my-job:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/framework-r-d/phlex-ci:2025-10-21
+      image: ghcr.io/framework-r-d/phlex-ci:latest
     
     steps:
     - name: Checkout code

--- a/.github/workflows/clang-tidy-check.yaml
+++ b/.github/workflows/clang-tidy-check.yaml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     container:
-      image: ghcr.io/framework-r-d/phlex-ci:2025-10-21
+      image: ghcr.io/framework-r-d/phlex-ci:latest
 
     steps:
     - name: Checkout code (PR)

--- a/.github/workflows/clang-tidy-fix.yaml
+++ b/.github/workflows/clang-tidy-fix.yaml
@@ -55,7 +55,7 @@ jobs:
     if: ${{ needs.check.outputs.match_result == 'match' }}
 
     container:
-      image: ghcr.io/framework-r-d/phlex-ci:2025-10-21
+      image: ghcr.io/framework-r-d/phlex-ci:latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cmake-build.yaml
+++ b/.github/workflows/cmake-build.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     container:
-      image: ghcr.io/framework-r-d/phlex-ci:2025-10-21
+      image: ghcr.io/framework-r-d/phlex-ci:latest
 
     steps:
     - name: Get PR details for comment trigger

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
     name: Analyze with CodeQL (C++, Python)
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/framework-r-d/phlex-ci:2025-10-21
+      image: ghcr.io/framework-r-d/phlex-ci:latest
     strategy:
       fail-fast: false
     timeout-minutes: 120

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,21 +3,54 @@
 # Podman instructions for building an image with this file:
 #
 #   $ cd <directory with this file>
-#   $ podman build --tag phlex-ci:<tag> [-v <local-buildcache>:/build-cache] .
+#   $ podman build --tag phlex-ci:<tag> [-v <local-buildcache>:/build-cache:U] .
 #   $ podman login ghcr.io --username <username> -p <token>
 #   $ podman push phlex-ci:<tag> ghcr.io/framework-r-d/phlex-ci:<tag>
+# ... and optionally:
+#   $ podman push phlex-ci:<tag> ghcr.io/framework-r-d/phlex-ci:latest
 #
 # where <tag> is the date (e.g. "2025-08-12").
 
 FROM gcc:15.2.0
 ARG parallelism=18
 
-RUN git clone --depth=2 https://github.com/spack/spack.git
+
+########################################################################
+# Improve compatibility with VSCode dev container
+
+RUN <<EOF
+  # Create vscode user with passwordless sudo
+
+  set -euo pipefail
+  apt-get update
+  apt-get install -y sudo locales-all
+  apt-get clean
+  rm -rf /var/lib/apt/lists/*
+  useradd -m vscode
+  echo "vscode ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/vscode
+  chmod 0440 /etc/sudoers.d/vscode
+EOF
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+########################################################################
+
+RUN git clone --depth=2 https://github.com/spack/spack.git && chown -R vscode:vscode /spack
+
+USER vscode
+WORKDIR /home/vscode
+
+# Disable Spack's user scope to prevent user-level config interference
+ENV SPACK_USER_CONFIG_PATH=/dev/null
+ENV SPACK_DISABLE_LOCAL_CONFIG=true
+
 RUN <<EOF
   # Set up and configure basic Spack installation
 
   # Setup environment
-  . spack/share/spack/setup-env.sh
+  . /spack/share/spack/setup-env.sh
+
+  set -euo pipefail
 
   # Add package repositories
   spack --timestamp repo add https://github.com/FNALssi/fnal_art.git
@@ -34,20 +67,31 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
-  # Configure a buildcache if mounted at build-time
+  # Configure build caches
+
+  . /spack/share/spack/setup-env.sh
+
+  set -euo pipefail
+
+  # Add public mirror
+  spack mirror add --type binary phlex-ci-scisoft https://scisoft.fnal.gov/scisoft/phlex-dev-build-cache
+
+  # Add private mirror with higher priority if available
   if [ -d "/build-cache" ]; then
-    . spack/share/spack/setup-env.sh
-    spack --timestamp mirror add --scope=site --type binary \
-      scisoft_phlex_ci /build-cache
+    spack --timestamp mirror add --type binary \
+      phlex-ci-local /build-cache
   fi
 EOF
 
-COPY ./spack.yaml /
+COPY ./spack.yaml /home/vscode/spack.yaml
 
 RUN <<EOF
   # Create and prepare phlex-development environment
 
-  . spack/share/spack/setup-env.sh
+  . /spack/share/spack/setup-env.sh
+
+  set -euo pipefail
+
   spack versions -s llvm | grep -qEe '^[[:space:]]+21\.1\.4$' || spack checksum -ab llvm 21.1.4
   spack --timestamp env create phlex-ci spack.yaml
   spack --timestamp env activate phlex-ci
@@ -56,23 +100,31 @@ RUN <<EOF
   spack --timestamp concretize
 EOF
 
+USER root
 COPY ./entrypoint.sh /
 
-RUN chmod +x /entrypoint.sh
-
+USER vscode
 RUN <<EOF
   # Install most of the tools as their own layer
+
   . /entrypoint.sh
+
+  set -euo pipefail
+
   spack --timestamp install --fail-fast -j $parallelism -p 1 \
     --no-add --only-concrete --no-check-signature \
-    cmake lcov ninja py-cmake-format py-gcovr
+    cmake lcov ninja py-cmake-format py-gcovr py-pip
   # Clean up to reduce layer size
   spack clean -dfs
 EOF
 
 RUN <<EOF
   # Install llvm as its own layer
+
   . /entrypoint.sh
+
+  set -euo pipefail
+
   spack --timestamp install --fail-fast -j $parallelism -p 1 \
     --no-add --only-concrete --no-check-signature llvm
   # Clean up to reduce layer size
@@ -81,7 +133,11 @@ EOF
 
 RUN <<EOF
   # Install almost everything else
+
   . /entrypoint.sh
+
+  set -euo pipefail
+
   spack --timestamp install --fail-fast -j $parallelism -p 1 \
     --no-add --only-concrete --no-check-signature \
     $(spack find -r --no-groups | sed -Ene 's&^ - &&p' | grep -v phlex)
@@ -91,7 +147,11 @@ EOF
 
 RUN <<EOF
   # Install Phlex' dependencies
+
   . /entrypoint.sh
+
+  set -euo pipefail
+
   spack --timestamp install --fail-fast -j $parallelism -p 1 \
     --no-add --only-concrete --only dependencies --no-check-signature \
     phlex
@@ -101,10 +161,29 @@ EOF
 
 RUN <<EOF
   # Write a buildcache if mounted
+
   . /entrypoint.sh # Outside the if to reduce container startup time
+
+  set -euo pipefail
+
   if [ -d "/build-cache" ]; then
     spack --timestamp buildcache create -u --rebuild-index \
     /build-cache $(spack find --no-groups -LI | \
       sed -Ene 's&^\[\+\] +([^[:space:]]+).*$&/\1&p')
+    spack mirror rm phlex-ci-local >/dev/null 2>&1 || true
   fi
 EOF
+
+USER root
+RUN <<EOF
+  # Install ruff
+
+   . /entrypoint.sh
+
+  set -euo pipefail
+
+  PYTHONDONTWRITEBYTECODE=1 pip --isolated --no-input --disable-pip-version-check --no-cache-dir install --prefix /usr/local ruff
+  rm -rf ~/.spack
+EOF
+
+USER vscode

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+# Disable Spack's user scope to prevent user-level config interference
+export SPACK_USER_CONFIG_PATH=/dev/null
+export SPACK_DISABLE_LOCAL_CONFIG=true
+
 . /spack/share/spack/setup-env.sh
 spack env activate phlex-ci

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -7,6 +7,7 @@ spack:
   - ninja
   - py-cmake-format
   - py-gcovr
+  - py-pip # Needed temporarily for ruff installation
   - |
       llvm@21.1.4: +zstd +llvm_dylib +link_llvm_dylib targets=x86
 
@@ -18,6 +19,11 @@ spack:
     all:
       target:
       - x86_64_v3
+
+    cmake:
+      require:
+      - "~qtgui"
+      - "@4:"
 
     phlex:
       require:


### PR DESCRIPTION
`Dockerfile`:

- Set up user `vscode` for compatibility with VSCode dev container.

- Select locale for compatibility with VSCode dev container.

- All Spack files and operations are owned by VSCode.

- Disable Spack user scope in container building.

- Improve error handling.

- Add mirror:
  [phlex-ci-scisoft](https://scisoft.fnal.gov/scisoft/phlex-dev-build-cache).

- Remove unnecessary `chmod +x /entrypoint.sh`: not needed for sourced scripts.

- Install Ruff to `/usr/local` as `root` with `pip` (current problems
  with `ruff` and `rust` in Spack).

- Ensure local build cache is deconfigured after use.

`spack.yaml`:

- Add `py-pip` to `spack.yaml` to enable installation of Ruff.

- Add CMake `packages:` clause in `spack.yaml` to prevent dependency
  explosion.

`/entrypoint.sh`:

- Disable Spack user scope in `/entrypoint.sh`.

Workflows:

- Workflows now refer to `ghcr.io/framework-r-d/phlex-ci:latest`.
