### PR TITLE
Clang-tidy configuration adjustment

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -91,8 +91,6 @@ CheckOptions:
     value: '50'
   - key: readability-function-size.BranchThreshold
     value: '10'
-  - key: readability-function-size.ParameterThreshold
-    value: '6'
 
   # Performance settings
   - key: performance-move-const-arg.CheckTriviallyCopyableMove


### PR DESCRIPTION
This PR makes some adjustments to the `clang-tidy` configuration:

- Ensure `const` data members have a trailing underscore as a suffix
- Remove limit of 6 parameters on functions (not a formal C++ code guideline)