### PR TITLE
Fix(actions): Make detect-relevant-changes robust to missing SHAs

### DIFF
--- a/.github/actions/detect-relevant-changes/action.yaml
+++ b/.github/actions/detect-relevant-changes/action.yaml
@@ -93,6 +93,16 @@ runs:
           fi
         fi
 
+        # Fail fast if refs are not present
+        for ref in "$HEAD_REF" "$BASE_REF"; do
+          if ! git cat-file -e "$ref" >/dev/null 2>&1; then
+            echo "::warning::Could not find ref '$ref' in repository. Assuming changes are present."
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+            echo "matched_files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        done
+
         git diff --name-only "$BASE_REF" "$HEAD_REF" > "$RUNNER_TEMP/changed-files.txt"
 
         if [ ! -s "$RUNNER_TEMP/changed-files.txt" ]; then


### PR DESCRIPTION
The detect-relevant-changes reusable action would previously fail if the base or head SHA was missing from the repository, for example, due to a force-push.

This change adds a check to verify that both SHAs exist before running 'git diff'. If either SHA is not found, the action now logs a warning and outputs matched=true instead of erroring out.
