### PR TITLE
Some FORM fixes

### DIFF
--- a/test/form/data_products/CMakeLists.txt
+++ b/test/form/data_products/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(
   ${FORM_DATA_PROD_LIB_NAME} SHARED track_start.cpp
   ) # REFLEX_GENERATE_DICTIONARY doesn't work trivially without making a shared
     # library
-target_link_libraries(${FORM_DATA_PROD_LIB_NAME})
+target_link_libraries(${FORM_DATA_PROD_LIB_NAME} ROOT::RIO)
 
 if(FORM_USE_ROOT_STORAGE)
   find_package(ROOT REQUIRED COMPONENTS Core RIO)

--- a/test/form/reader.cpp
+++ b/test/form/reader.cpp
@@ -43,7 +43,7 @@ int main(int /* argc*/, char** /* argv[]*/)
       // Processing per sub-event
       std::vector<float> const* track_start_x = nullptr;
       char seg_id_text[64];
-      sprintf(seg_id_text, seg_id, nevent, nseg);
+      snprintf(seg_id_text, 64, seg_id, nevent, nseg);
       std::string const creator = "Toy_Tracker";
       mock_phlex::product_base pb = {
         "trackStart", seg_id_text, track_start_x, std::type_index{typeid(std::vector<float>)}};
@@ -87,7 +87,7 @@ int main(int /* argc*/, char** /* argv[]*/)
     std::cout << "PHLEX: Read Event segments done " << nevent << std::endl;
 
     char evt_id_text[64];
-    sprintf(evt_id_text, evt_id, nevent);
+    snprintf(evt_id_text, 64, evt_id, nevent);
     std::string const creator = "Toy_Tracker_Event";
     mock_phlex::product_base pb = {
       "trackStartX", evt_id_text, track_x, std::type_index{typeid(std::vector<float>)}};

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -72,7 +72,7 @@ int main(int /*argc*/, char** /* argv[]*/)
       // done, phlex call write(mock_phlex::product_base)
       // sub-event writing called by phlex
       char seg_id_text[64];
-      sprintf(seg_id_text, seg_id, nevent, nseg);
+      snprintf(seg_id_text, 64, seg_id, nevent, nseg);
       std::vector<mock_phlex::product_base> batch;
       std::string const creator = "Toy_Tracker";
       mock_phlex::product_base pb = {
@@ -122,7 +122,7 @@ int main(int /*argc*/, char** /* argv[]*/)
 
     // event writing, current framework, will also write references
     char evt_id_text[64];
-    sprintf(evt_id_text, evt_id, nevent);
+    snprintf(evt_id_text, 64, evt_id, nevent);
     std::string const creator = "Toy_Tracker_Event";
     mock_phlex::product_base pb = {
       "trackStartX", evt_id_text, &track_x, std::type_index{typeid(std::vector<float>)}};


### PR DESCRIPTION
This PR:

- Links the `ROOT::RIO` library during the dictionary-generation step
- Uses `snprintf` instead of `sprintf` when filling a string buffer (per apple-clang warning)