### PR TITLE
Tighten library linking for FORM's test data products

### DIFF
--- a/test/form/data_products/CMakeLists.txt
+++ b/test/form/data_products/CMakeLists.txt
@@ -1,16 +1,11 @@
 set(FORM_DATA_PROD_LIB_NAME "form_test_data_products")
-add_library(
-  ${FORM_DATA_PROD_LIB_NAME} SHARED track_start.cpp
-  ) # REFLEX_GENERATE_DICTIONARY doesn't work trivially without making a shared
-    # library
-target_link_libraries(${FORM_DATA_PROD_LIB_NAME} ROOT::RIO)
+add_library(${FORM_DATA_PROD_LIB_NAME} SHARED track_start.cpp)
 
 if(FORM_USE_ROOT_STORAGE)
-  find_package(ROOT REQUIRED COMPONENTS Core RIO)
+  find_package(ROOT REQUIRED COMPONENTS RIO)
   include_directories(${ROOT_INCLUDE_DIRS})
-
   reflex_generate_dictionary(
     ${FORM_DATA_PROD_LIB_NAME} dict.h SELECTION classes_def.xml
     )
-  target_compile_options(${FORM_DATA_PROD_LIB_NAME} PRIVATE "-w")
+  target_link_libraries(${FORM_DATA_PROD_LIB_NAME} PRIVATE ROOT::RIO)
 endif()


### PR DESCRIPTION
See [comment from @gemmeren](https://github.com/Framework-R-D/phlex/pull/141/files/0814aa71f34e4d3d53eb41c638fd84d83fcb90c6#r2582185444).