### PR TITLE
Reduce execution times for mock workflow

### DIFF
--- a/test/mock-workflow/G4Stage1.libsonnet
+++ b/test/mock-workflow/G4Stage1.libsonnet
@@ -3,7 +3,7 @@ local generators = import 'SinglesGen.libsonnet';
 {
   largeant: {
     plugin: 'largeant',
-    duration_usec: 15662051,
+    duration_usec: 156, # Typical: 15662051
     inputs: [f + "/MCTruths" for f in std.objectFields(generators)],
     outputs: ["ParticleAncestryMap", "Assns", "SimEnergyDeposits", "AuxDetHits", "MCParticles"],
   }

--- a/test/mock-workflow/G4Stage2.libsonnet
+++ b/test/mock-workflow/G4Stage2.libsonnet
@@ -3,13 +3,13 @@ local g4stage1 = import 'G4Stage1.libsonnet';
 {
   IonAndScint: {
     plugin: 'ion_and_scint',
-    duration_usec: 5457973,
+    duration_usec: 546, # Typical: 5457973
     inputs: [f + "/SimEnergyDeposits" for f in std.objectFields(g4stage1)],
     outputs: ["SimEnergyDeposits", "SimEnergyDeposits_priorSCE"],
   },
   PDFastSim: {
     plugin: 'pd_fast_sim',
-    duration_usec: 69, #69681950,
+    duration_usec: 69, # Typical: 69681950
     inputs: ['SimEnergyDeposits_priorSCE'],
     outputs: ['SimPhotonLites', 'OpDetBacktrackerRecords'],
   }

--- a/test/mock-workflow/SinglesGen.libsonnet
+++ b/test/mock-workflow/SinglesGen.libsonnet
@@ -13,7 +13,7 @@
   },
   cosmicgenerator: {
     plugin: "MC_truth_algorithm",
-    duration_usec: 4926215,
+    duration_usec: 492, # Typical: 4926215
     inputs: ["id"],
     outputs: ["MCTruths"]
   },


### PR DESCRIPTION
The mock workflow was implemented to simulate realistic execution times for a simulation+reconstruction workflow.  This results in a lengthy unit test (~26 seconds) whose algorithms "spin" for the configured duration.  For the purposes of framework development, it is not necessary to use such long durations.  We can restore the original configured durations when it is deemed necessary.