### PR TITLE
Adjust more terminology in the code

### DIFF
--- a/phlex/core/declared_unfold.cpp
+++ b/phlex/core/declared_unfold.cpp
@@ -9,16 +9,16 @@ namespace phlex::experimental {
 
   generator::generator(product_store_const_ptr const& parent,
                        std::string node_name,
-                       std::string const& new_layer_name) :
+                       std::string const& child_layer_name) :
     parent_{std::const_pointer_cast<product_store>(parent)},
     node_name_{std::move(node_name)},
-    new_layer_name_{new_layer_name}
+    child_layer_name_{child_layer_name}
   {
   }
 
   product_store_const_ptr generator::make_child(std::size_t const i, products new_products)
   {
-    auto child = parent_->make_child(i, new_layer_name_, node_name_, std::move(new_products));
+    auto child = parent_->make_child(i, child_layer_name_, node_name_, std::move(new_products));
     ++child_counts_[child->id()->layer_hash()];
     return child;
   }

--- a/phlex/core/multiplexer.cpp
+++ b/phlex/core/multiplexer.cpp
@@ -97,7 +97,7 @@ namespace phlex::experimental {
     }
 
     for (auto const& ports : head_ports_ | std::views::values) {
-      // FIXME: Should make sure that the received store has a level equal to the most
+      // FIXME: Should make sure that the received store has the same layer name as the most
       //        derived store required by the algorithm.
       auto const senders = senders_for(store, ports);
       if (size(senders) != size(ports)) {

--- a/phlex/model/data_cell_index.cpp
+++ b/phlex/model/data_cell_index.cpp
@@ -58,11 +58,11 @@ namespace phlex::experimental {
   std::string const& data_cell_index::layer_name() const noexcept { return layer_name_; }
   std::size_t data_cell_index::depth() const noexcept { return depth_; }
 
-  data_cell_index_ptr data_cell_index::make_child(std::size_t const new_level_number,
-                                                  std::string new_layer_name) const
+  data_cell_index_ptr data_cell_index::make_child(std::size_t const data_cell_number,
+                                                  std::string child_layer_name) const
   {
     return data_cell_index_ptr{
-      new data_cell_index{shared_from_this(), new_level_number, std::move(new_layer_name)}};
+      new data_cell_index{shared_from_this(), data_cell_number, std::move(child_layer_name)}};
   }
 
   bool data_cell_index::has_parent() const noexcept { return static_cast<bool>(parent_); }
@@ -137,17 +137,17 @@ namespace phlex::experimental {
     std::string suffix{"]"};
 
     if (number_ != -1ull) {
-      result = to_string_this_level();
+      result = to_string_this_layer();
       auto parent = parent_;
       while (parent != nullptr and parent->number_ != -1ull) {
-        result.insert(0, parent->to_string_this_level() + ", ");
+        result.insert(0, parent->to_string_this_layer() + ", ");
         parent = parent->parent_;
       }
     }
     return prefix + result + suffix;
   }
 
-  std::string data_cell_index::to_string_this_level() const
+  std::string data_cell_index::to_string_this_layer() const
   {
     if (empty(layer_name_)) {
       return std::to_string(number_);

--- a/phlex/model/data_cell_index.hpp
+++ b/phlex/model/data_cell_index.hpp
@@ -18,7 +18,7 @@ namespace phlex::experimental {
     static data_cell_index_ptr base_ptr();
 
     using hash_type = std::size_t;
-    data_cell_index_ptr make_child(std::size_t new_level_number, std::string layer_name) const;
+    data_cell_index_ptr make_child(std::size_t data_cell_number, std::string layer_name) const;
     std::string const& layer_name() const noexcept;
     std::size_t depth() const noexcept;
     data_cell_index_ptr parent(std::string const& layer_name) const;
@@ -31,7 +31,7 @@ namespace phlex::experimental {
     bool operator<(data_cell_index const& other) const;
 
     std::string to_string() const;
-    std::string to_string_this_level() const;
+    std::string to_string_this_layer() const;
 
     friend std::ostream& operator<<(std::ostream& os, data_cell_index const& id);
 

--- a/phlex/model/data_layer_hierarchy.cpp
+++ b/phlex/model/data_layer_hierarchy.cpp
@@ -33,8 +33,8 @@ namespace phlex::experimental {
 
   std::size_t data_layer_hierarchy::count_for(std::string const& layer_name) const
   {
-    auto it = find_if(begin(layers_), end(layers_), [&layer_name](auto const& level) {
-      return level.second->name == layer_name;
+    auto it = find_if(begin(layers_), end(layers_), [&layer_name](auto const& layer) {
+      return layer.second->name == layer_name;
     });
     return it != cend(layers_) ? it->second->count.load() : 0;
   }
@@ -84,7 +84,7 @@ namespace phlex::experimental {
     }
 
     auto const initial_indent = "  ";
-    return fmt::format("\nProcessed levels:\n\n{}job{}\n",
+    return fmt::format("\nProcessed layers:\n\n{}job{}\n",
                        initial_indent,
                        pretty_recurse(tree, "job", initial_indent));
   }

--- a/phlex/model/product_store.cpp
+++ b/phlex/model/product_store.cpp
@@ -20,25 +20,25 @@ namespace phlex::experimental {
   }
 
   product_store::product_store(product_store_const_ptr parent,
-                               std::size_t new_level_number,
-                               std::string const& new_layer_name,
+                               std::size_t data_cell_number,
+                               std::string const& child_layer_name,
                                std::string source,
                                products new_products) :
     parent_{parent},
     products_{std::move(new_products)},
-    id_{parent->id()->make_child(new_level_number, new_layer_name)},
+    id_{parent->id()->make_child(data_cell_number, child_layer_name)},
     source_{std::move(source)},
     stage_{stage::process}
   {
   }
 
   product_store::product_store(product_store_const_ptr parent,
-                               std::size_t new_level_number,
-                               std::string const& new_layer_name,
+                               std::size_t data_cell_number,
+                               std::string const& child_layer_name,
                                std::string source,
                                stage processing_stage) :
     parent_{parent},
-    id_{parent->id()->make_child(new_level_number, new_layer_name)},
+    id_{parent->id()->make_child(data_cell_number, child_layer_name)},
     source_{std::move(source)},
     stage_{processing_stage}
   {
@@ -88,25 +88,25 @@ namespace phlex::experimental {
       new product_store{parent_, id_, std::move(source), stage::process, std::move(new_products)}};
   }
 
-  product_store_ptr product_store::make_child(std::size_t new_level_number,
-                                              std::string const& new_layer_name,
+  product_store_ptr product_store::make_child(std::size_t data_cell_number,
+                                              std::string const& child_layer_name,
                                               std::string source,
                                               products new_products)
   {
     return product_store_ptr{new product_store{shared_from_this(),
-                                               new_level_number,
-                                               new_layer_name,
+                                               data_cell_number,
+                                               child_layer_name,
                                                std::move(source),
                                                std::move(new_products)}};
   }
 
-  product_store_ptr product_store::make_child(std::size_t new_level_number,
-                                              std::string const& new_layer_name,
+  product_store_ptr product_store::make_child(std::size_t data_cell_number,
+                                              std::string const& child_layer_name,
                                               std::string source,
                                               stage processing_stage)
   {
     return product_store_ptr{new product_store{
-      shared_from_this(), new_level_number, new_layer_name, std::move(source), processing_stage}};
+      shared_from_this(), data_cell_number, child_layer_name, std::move(source), processing_stage}};
   }
 
   std::string const& product_store::layer_name() const noexcept { return id_->layer_name(); }

--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -30,12 +30,12 @@ namespace phlex::experimental {
     product_store_const_ptr parent() const noexcept;
     product_store_ptr make_flush() const;
     product_store_ptr make_continuation(std::string source, products new_products = {}) const;
-    product_store_ptr make_child(std::size_t new_level_number,
-                                 std::string const& new_layer_name,
+    product_store_ptr make_child(std::size_t data_cell_number,
+                                 std::string const& child_layer_name,
                                  std::string source,
                                  products new_products);
-    product_store_ptr make_child(std::size_t new_level_number,
-                                 std::string const& new_layer_name,
+    product_store_ptr make_child(std::size_t data_cell_number,
+                                 std::string const& child_layer_name,
                                  std::string source = {},
                                  stage st = stage::process);
     data_cell_index_ptr const& id() const noexcept;
@@ -64,13 +64,13 @@ namespace phlex::experimental {
                            stage processing_stage = stage::process,
                            products new_products = {});
     explicit product_store(product_store_const_ptr parent,
-                           std::size_t new_level_number,
-                           std::string const& new_layer_name,
+                           std::size_t data_cell_number,
+                           std::string const& child_layer_name,
                            std::string source,
                            products new_products);
     explicit product_store(product_store_const_ptr parent,
-                           std::size_t new_level_number,
-                           std::string const& new_layer_name,
+                           std::size_t data_cell_number,
+                           std::string const& child_layer_name,
                            std::string source,
                            stage processing_stage);
 

--- a/test/cached_execution.cpp
+++ b/test/cached_execution.cpp
@@ -11,9 +11,9 @@
 //      | \| \|
 //     A3 B2  C
 //
-// where A1, A2, and A3 are transforms that execute at the "run" level; B1 and B2 are
-// transforms that execute at the "subrun" level; and C is a transform that executes at
-// the event level.
+// where A1, A2, and A3 are transforms that execute at the "run" layer; B1 and B2 are
+// transforms that execute at the "subrun" layer; and C is a transform that executes at
+// the event layer.
 //
 // This test verifies that for each "run", "subrun", and "event", the corresponding
 // transforms execute only once.  This test assumes:

--- a/test/different_hierarchies.cpp
+++ b/test/different_hierarchies.cpp
@@ -43,11 +43,11 @@ using namespace phlex::experimental;
 namespace {
   void add(std::atomic<unsigned int>& counter, unsigned int number) { counter += number; }
 
-  // job -> run -> event levels
+  // job -> run -> event layers
   constexpr auto index_limit = 2u;
   constexpr auto number_limit = 5u;
 
-  // job -> trigger primitive levels
+  // job -> trigger primitive layers
   constexpr auto primitive_limit = 10u;
 
   void cells_to_process(framework_driver& driver)
@@ -55,7 +55,7 @@ namespace {
     auto job_store = product_store::base();
     driver.yield(job_store);
 
-    // job -> run -> event levels
+    // job -> run -> event layers
     for (unsigned i : std::views::iota(0u, index_limit)) {
       auto run_store = job_store->make_child(i, "run");
       driver.yield(run_store);
@@ -66,7 +66,7 @@ namespace {
       }
     }
 
-    // job -> trigger primitive levels
+    // job -> trigger primitive layers
     for (unsigned i : std::views::iota(0u, primitive_limit)) {
       auto tp_store = job_store->make_child(i, "trigger primitive");
       tp_store->add_product("number", i);


### PR DESCRIPTION
This PR is meant to address the remaining issues identified in #159.  Primarily, it removes the rest (I think) of the vestigial uses of "level".