### PR TITLE
Add `product_store::size()` accessor

### DIFF
--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -24,6 +24,7 @@ namespace phlex::experimental {
     auto begin() const noexcept { return products_.begin(); }
     auto end() const noexcept { return products_.end(); }
     auto size() const noexcept { return products_.size(); }
+    bool empty() const noexcept { return products_.empty(); }
 
     std::string const& layer_name() const noexcept;
     std::string const& source() const noexcept;

--- a/phlex/model/products.cpp
+++ b/phlex/model/products.cpp
@@ -13,6 +13,7 @@ namespace phlex::experimental {
   products::const_iterator products::begin() const noexcept { return products_.begin(); }
   products::const_iterator products::end() const noexcept { return products_.end(); }
   products::size_type products::size() const noexcept { return products_.size(); }
+  bool products::empty() const noexcept { return products_.empty(); }
 
   void products::throw_mismatched_type(std::string const& product_name,
                                        char const* requested_type,

--- a/phlex/model/products.hpp
+++ b/phlex/model/products.hpp
@@ -98,6 +98,7 @@ namespace phlex::experimental {
     const_iterator begin() const noexcept;
     const_iterator end() const noexcept;
     size_type size() const noexcept;
+    bool empty() const noexcept;
 
   private:
     static void throw_mismatched_type [[noreturn]] (std::string const& product_name,

--- a/test/product_store.cpp
+++ b/test/product_store.cpp
@@ -11,6 +11,8 @@ using namespace phlex::experimental;
 TEST_CASE("Product store insertion", "[data model]")
 {
   auto store = product_store::base();
+  CHECK(store->empty());
+
   constexpr int number = 4;
   std::vector many_numbers{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   store->add_product("number", number);


### PR DESCRIPTION
This is a necessary addition to allow FORM to reserve a vector size that equals the number of products in the store (e.g.):

```cpp
void save_to_output(product_store const& store)
{
  std::vector<some_type> products_to_save;
  products_to_save.reserve(store.size());
  // ...
}