### PR TITLE
Add missing `TBB::tbb` dependency for phlex_model library

### DIFF
--- a/phlex/model/CMakeLists.txt
+++ b/phlex/model/CMakeLists.txt
@@ -19,6 +19,7 @@ cet_make_library(
   PRIVATE
   phlex::graph
   phlex::utilities
+  TBB::tbb
   )
 
 install(


### PR DESCRIPTION
The `phlex_model` library depends on `TBB::tbb`.