### PR TITLE
Fix Jsonnet Library Loading On MacOS

### DIFF
--- a/Modules/Findjsonnet.cmake
+++ b/Modules/Findjsonnet.cmake
@@ -38,8 +38,9 @@ if(${CMAKE_FIND_PACKAGE_NAME}_FOUND)
       )
 
   # On macOS, fix jsonnet libraries if they have incorrect install_name
-  # This should be removed when the Spack recipe is updated to create
-  # the correct install_name.
+  #
+  # This should be removed when the Spack recipe is updated to create the
+  # correct install_name.
   if(APPLE)
     foreach(_lib ${${CMAKE_FIND_PACKAGE_NAME}_LIBRARY}
                  ${${CMAKE_FIND_PACKAGE_NAME}_CLIBRARY}


### PR DESCRIPTION
Jsonnet libraries from Spack have incorrect install_name entries on macOS (bare filenames instead of @rpath-relative paths). This prevents the dynamic linker from finding them at runtime despite correct RPATH settings in executables.

Add logic to Findjsonnet.cmake to detect and fix these libraries during CMake configuration using install_name_tool, ensuring they use @rpath-relative references compatible with macOS dyld.