### PR TITLE
Fix race condition in `async_driver`

### DIFF
--- a/phlex/utilities/async_driver.hpp
+++ b/phlex/utilities/async_driver.hpp
@@ -28,6 +28,7 @@ namespace phlex::experimental {
       if (gear_ == states::off) {
         thread_ = std::jthread{[this] {
           try {
+            gear_ = states::drive;
             driver_(*this);
           } catch (...) {
             cached_exception_ = std::current_exception();
@@ -35,7 +36,6 @@ namespace phlex::experimental {
           gear_ = states::park;
           cv_.notify_one();
         }};
-        gear_ = states::drive;
       } else {
         cv_.notify_one();
       }


### PR DESCRIPTION
It can happen that the function executed by the `async_driver` throws an exception before the driver updates its state from "off" to "drive".  When this happens, the state of the driver goes from "off" to "park" (due to the exception), and then to "drive".  This is an error, and it causes a race condition.  Instead, the states should go from "off" to "drive" (on the thread that invokes the driver function) to "park" (which can happen either due to normal completion or an exception).

This PR implements this fix.