### PR TITLE
Remember to send flushes for unfolded data layers

### DIFF
--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -171,6 +171,10 @@ namespace phlex::experimental {
         auto child = g.make_child_for(counter++, std::move(new_products));
         message const child_msg{child, eom->make_child(child->id()), ++msg_counter_};
         output_port<0>(unfold_).try_put(child_msg);
+
+        // Every data cell needs a flush (for now)
+        message const child_flush_msg{child->make_flush(), nullptr, ++msg_counter_};
+        output_port<0>(unfold_).try_put(child_flush_msg);
       }
     }
 


### PR DESCRIPTION
Each processed data cell has a corresponding "flush" message that is emitted to indicate that that data cell is complete.  Such flush messages are not being emitted for data cells produced by an unfold node, yielding unnecessary caching:

```console
❯ ./phlex/bin/unfold_transform_fold
[2025-12-11 12:21:05.228] [info] Number of worker threads: 12
[2025-12-11 12:21:05.319] [warning] Transform clamp_node has 150 cached stores.
⋮
[2025-12-11 12:21:05.340] [info] Max. RSS: 1008.026 MB
```

This PR fixes this problem:

```console
❯ ./phlex/bin/unfold_transform_fold 
[2025-12-11 12:57:32.195] [info] Number of worker threads: 12
⋮
[2025-12-11 12:57:32.298] [info] Max. RSS: 164.839 MB
```