### PR TITLE
Enable TSAN/ASAN compiler options for only GNU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,7 @@ if(ENABLE_TSAN)
       -g
       -O1
       # Ensure no optimizations interfere with TSan
-      $<$<COMPILER_LANGUAGE:CXX>:-fno-omit-frame-pointer
-      -fno-optimize-sibling-calls>
+      "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-fno-omit-frame-pointer -fno-optimize-sibling-calls>"
       )
     add_link_options(-fsanitize=thread)
   else()
@@ -125,8 +124,7 @@ if(ENABLE_ASAN)
       -g
       -O1
       # Ensure no optimizations interfere with ASan
-      $<$<COMPILER_LANGUAGE:CXX>:-fno-omit-frame-pointer
-      -fno-optimize-sibling-calls>
+      "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-fno-omit-frame-pointer -fno-optimize-sibling-calls>"
       )
     add_link_options(-fsanitize=address)
   else()


### PR DESCRIPTION
The following C++ compile options were enabled for the `GNU`, `Clang`, and `AppleClang` compilers although they are only supported for `GNU`:

- `-fno-omit-frame-pointer`
- `-fno-optimize-sibling-calls`

This PR replaces the `$<COMPILER_LANGUAGE:CXX>` _[sic, should have been `COMPILE_LANGUAGE`]_ generator expression with `$<COMPILE_LANG_AND_ID:CXX,GNU>`.  It also guards the generator expression by using quotes as breaking generator expressions across multiple lines [can cause problems](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#whitespace-and-quoting) (I did not get successful builds without the quotes).