### PR TITLE
Fix stack-use-after-scope ASAN error

### DIFF
--- a/phlex/model/product_specification.cpp
+++ b/phlex/model/product_specification.cpp
@@ -60,7 +60,7 @@ namespace phlex::experimental {
     return {algorithm_name::create(""), s, type_id{}};
   }
 
-  product_specifications to_product_specifications(std::string const& name,
+  product_specifications to_product_specifications(std::string const name,
                                                    std::vector<std::string> output_labels,
                                                    std::vector<type_id> output_types)
   {
@@ -68,10 +68,9 @@ namespace phlex::experimental {
     product_specifications outputs;
     outputs.reserve(output_labels.size());
 
-    to_product_specification make_product_specification{name};
     // zip view isn't available until C++23 so we have to use a loop over the index
     for (std::size_t i = 0; i < output_labels.size(); ++i) {
-      outputs.push_back(make_product_specification(output_labels.at(i), output_types.at(i)));
+      outputs.emplace_back(name, output_labels[i], output_types[i]);
     }
     return outputs;
   }

--- a/phlex/model/product_specification.hpp
+++ b/phlex/model/product_specification.hpp
@@ -40,19 +40,7 @@ namespace phlex::experimental {
 
   using product_specifications = std::vector<product_specification>;
 
-  class to_product_specification {
-  public:
-    explicit to_product_specification(algorithm_name const& qualifier) : qualifier_{qualifier} {}
-    product_specification operator()(std::string const& name, type_id type) const
-    {
-      return product_specification{qualifier_, name, std::move(type)};
-    }
-
-  private:
-    algorithm_name const& qualifier_;
-  };
-
-  product_specifications to_product_specifications(std::string const& name,
+  product_specifications to_product_specifications(std::string name,
                                                    std::vector<std::string> output_labels,
                                                    std::vector<type_id> output_types);
 }


### PR DESCRIPTION
The `to_product_specifications(std::string const&, ...)` function was being invoked with a temporary object, and that temporary object was being unsafely cached by reference via the `to_product_specification` helper `struct`.  This PR removes the `to_product_specification` helper `struct`, and strings passed to the `to_product_specifications(...)` function are now passed by value.

---

Error fixed by this PR:

```console
37: ==87556==ERROR: AddressSanitizer: stack-use-after-scope on address 0x00016d9f6c77 at pc 0x000102723580 bp 0x00016d9f6a50 sp 0x00016d9f6a48                                                                                                                            
37: READ of size 1 at 0x00016d9f6c77 thread T0                                                                                                                                                                                                                            
37:     #0 0x00010272357c in phlex::experimental::to_product_specification::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, phlex::experimental::type_id) const product_specification.hpp:48                      
37:     #1 0x0001027227e8 in phlex::experimental::to_product_specifications(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, s
td::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, std::__1::vector<phlex::experimental::type_id, std::__1::allocator<phlex::experimental::type_id>>) product_specification.cpp:74                                
37:     #2 0x0001073188d0 in phlex::experimental::transform_node<phlex::experimental::algorithm_bits<std::__1::function<int (phlex::experimental::data_cell_index const&)>, int (*)(phlex::experimental::data_cell_index const&)>>::transform_node(phlex::experimental::al
gorithm_name, unsigned long, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, tbb::detail::d2::graph&, p
hlex::experimental::algorithm_bits<std::__1::function<int (phlex::experimental::data_cell_index const&)>, int (*)(phlex::experimental::data_cell_index const&)>, std::__1::vector<phlex::experimental::product_query, std::__1::allocator<phlex::experimental::product_que
ry>>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>) declared_transform.hpp:85
37:     #3 0x00010731819c in std::__1::unique_ptr<phlex::experimental::transform_node<phlex::experimental::algorithm_bits<std::__1::function<int (phlex::experimental::data_cell_index const&)>, int (*)(phlex::experimental::data_cell_index const&)>>, std::__1::default
_delete<phlex::experimental::transform_node<phlex::experimental::algorithm_bits<std::__1::function<int (phlex::experimental::data_cell_index const&)>, int (*)(phlex::experimental::data_cell_index const&)>>>> std::__1::make_unique[abi:ne200100]<phlex::experimental::t
ransform_node<phlex::experimental::algorithm_bits<std::__1::function<int (phlex::experimental::data_cell_index const&)>, int (*)(phlex::experimental::data_cell_index const&)>>, phlex::experimental::algorithm_name, unsigned long&, std::__1::vector<std::__1::basic_str
ing<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, tbb::detail::d2::graph&, phlex::experimental::algorithm_bits<std::__1::function<int (phlex:
:experimental::data_cell_index const&)>, int (*)(phlex::experimental::data_cell_index const&)>, std::__1::vector<phlex::experimental::product_query, std::__1::allocator<phlex::experimental::product_query>>, std::__1::vector<std::__1::basic_string<char, std::__1::cha
r_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, 0>(phlex::experimental::algorithm_name&&, unsigned long&, std::__1::vector<std::__1::basic_string<char, std::__1::
char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>&&, tbb::detail::d2::graph&, phlex::experimental::algorithm_bits<std::__1::function<int (phlex::experimental::dat
a_cell_index const&)>, int (*)(phlex::experimental::data_cell_index const&)>&&, std::__1::vector<phlex::experimental::product_query, std::__1::allocator<phlex::experimental::product_query>>&&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>
, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>&&) unique_ptr.h:767
37:     #4 0x000107317ce0 in auto phlex::experimental::registration_api<phlex::experimental::transform_node, phlex::experimental::algorithm_bits<std::__1::function<int (phlex::experimental::data_cell_index const&)>, int (*)(phlex::experimental::data_cell_index const
&)>>::input_family(std::__1::array<phlex::experimental::product_query, 1ul>)::'lambda'(auto, auto)::operator()<std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std
::__1::char_traits<char>, std::__1::allocator<char>>>>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>>
(auto, auto) const registration_api.hpp:67                                                                                          
37:     #5 0x000107317a08 in std::__1::unique_ptr<phlex::experimental::declared_transform, std::__1::default_delete<phlex::experimental::declared_transform>> std::__1::__invoke_void_return_wrapper<std::__1::unique_ptr<phlex::experimental::declared_transform, std::__
1::default_delete<phlex::experimental::declared_transform>>, false>::__call[abi:ne200100]<phlex::experimental::registration_api<phlex::experimental::transform_node, phlex::experimental::algorithm_bits<std::__1::function<int (phlex::experimental::data_cell_index cons
t&)>, int (*)(phlex::experimental::data_cell_index const&)>>::input_family(std::__1::array<phlex::experimental::product_query, 1ul>)::'lambda'(auto, auto)&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::_
_1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::ch
ar_traits<char>, std::__1::allocator<char>>>>>(phlex::experimental::registration_api<phlex::experimental::transform_node, phlex::experimental::algorithm_bits<std::__1::function<int (phlex::experimental::data_cell_index const&)>, int (*)(phlex::experimental::data_cel
l_index const&)>>::input_family(std::__1::array<phlex::experimental::product_query, 1ul>)::'lambda'(auto, auto)&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, 
std::__1::char_traits<char>, std::__1::allocator<char>>>>&&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char
>>>>&&) invoke.h:243                                                                                                                
37:     #6 0x00010733bbb4 in phlex::experimental::registrar<std::__1::unique_ptr<phlex::experimental::declared_transform, std::__1::default_delete<phlex::experimental::declared_transform>>>::create_node(std::__1::vector<std::__1::basic_string<char, std::__1::char_tr
aits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>) registrar.hpp:111
37:     #7 0x00010733cdd4 in void phlex::experimental::upstream_predicates<std::__1::unique_ptr<phlex::experimental::declared_transform, std::__1::default_delete<phlex::experimental::declared_transform>>, 1ul>::output_products<1ul>(std::__1::array<std::__1::basic_st
ring<char, std::__1::char_traits<char>, std::__1::allocator<char>>, 1ul>) upstream_predicates.hpp:47                                
37:     #8 0x0001073137f8 in create(phlex::experimental::graph_proxy<phlex::experimental::void_tag>&, phlex::experimental::configuration const&) last_index.cpp:14
37:     #9 0x0001025004f8 in phlex::experimental::load_module(phlex::experimental::framework_graph&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, boost::json::object) load_module.cpp:57
37:     #10 0x00010250e8a8 in phlex::experimental::run(boost::json::object const&, int) run.cpp:14                                  
37:     #11 0x0001024093f4 in main phlex.cpp:95                                                                                     
37:     #12 0x00018cb52b94 in start+0x17b8 (dyld:arm64e+0xfffffffffff3ab94)                                                          
37:                                                                                                                                 
37: Address 0x00016d9f6c77 is located in stack of thread T0 at offset 87 in frame                                                   
37:     #0 0x00010272241c in phlex::experimental::to_product_specifications(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>,
 std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, std::__1::vector<phlex::experimental::type_id, std::__1::allocator<phlex::experimental::type_id>>) product_specification.cpp:66
37:                                                                                                                                 
37:   This frame has 5 object(s):                                                                                                   
37:     [32, 40) 'make_product_specification' (line 71)                                                                             
37:     [64, 120) 'ref.tmp' (line 71) <== Memory access at offset 87 is inside this variable                                        
37:     [160, 184) 'agg.tmp'                                                                                                        
37:     [224, 344) 'ref.tmp20' (line 74)                                                                                            
37:     [384, 424) 'agg.tmp24'                                                                                                      
37: HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork                
37:       (longjmp and C++ exceptions *are* supported)                                                                              
37: SUMMARY: AddressSanitizer: stack-use-after-scope product_specification.hpp:48 in phlex::experimental::to_product_specification::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, phlex::experimental::type_id) 
const
```