### PR TITLE
Remove restriction on number of threads for `framework_graph`

### DIFF
--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -57,14 +57,6 @@ namespace phlex::experimental {
          }},
     multiplexer_{graph_}
   {
-    // FIXME: This requirement is in place so that the yielding driver can be used.
-    //        At least 2 threads are required for that to work.
-    //        It would be better if the specified concurrency would be applied to an
-    //        arena in which the user-facing work is done.
-    if (max_parallelism < 2) {
-      throw std::runtime_error("Must choose concurrency level of at least 2.");
-    }
-
     // FIXME: Should the loading of env levels happen in the phlex app only?
     spdlog::cfg::load_env_levels();
     spdlog::info("Number of worker threads: {}", max_allowed_parallelism::active_value());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,6 +92,7 @@ cet_test(
   LIBRARIES
   phlex::core
   Boost::json
+  layer_generator
   )
 cet_test(
   function_registration

--- a/test/framework_graph.cpp
+++ b/test/framework_graph.cpp
@@ -1,4 +1,5 @@
 #include "phlex/core/framework_graph.hpp"
+#include "plugins/layer_generator.hpp"
 
 #include "catch2/catch_test_macros.hpp"
 
@@ -16,4 +17,25 @@ TEST_CASE("Catch other exceptions", "[graph]")
 {
   framework_graph g{[](framework_driver&) { throw 2.5; }};
   CHECK_THROWS_AS(g.execute(), double);
+}
+
+TEST_CASE("Make progress with one thread", "[graph]")
+{
+  layer_generator gen;
+  gen.add_layer("spill", {"job", 1000});
+
+  framework_graph g{driver_for_test(gen), 1};
+  g.provide(
+     "provide_number",
+     [](data_cell_index const& index) -> unsigned int { return index.number(); },
+     concurrency::unlimited)
+    .output_product("number"_in("spill"));
+  g.observe(
+     "observe_number", [](unsigned int const /*number*/) {}, concurrency::unlimited)
+    .input_family("number"_in("spill"));
+  g.execute();
+
+  CHECK(gen.emitted_cells("/job/spill") == 1000);
+  CHECK(g.execution_counts("provide_number") == 1000);
+  CHECK(g.execution_counts("observe_number") == 1000);
 }


### PR DESCRIPTION
Previous implementations of `async_driver` required at least 2 threads to be configured for the oneTBB task scheduler.  After switching to a `std::[j]thread` implementation of the `async_driver`, the restriction on the number of threads used by the oneTBB task scheduler can be removed.