### PR TITLE
Catch exceptions in main to ensure graceful exit and coverage data generation

### DIFF
--- a/phlex/app/phlex.cpp
+++ b/phlex/app/phlex.cpp
@@ -94,12 +94,10 @@ int main(int argc, char* argv[])
   }
   try {
     phlex::experimental::run(configurations, max_concurrency);
-  }
-  catch (std::exception const& e) {
+  } catch (std::exception const& e) {
     std::cerr << e.what() << '\n';
     return 1;
-  }
-  catch (...) {
+  } catch (...) {
     std::cerr << "Unknown exception caught.\n";
     return 1;
   }


### PR DESCRIPTION
The failure to catch exceptions (leading to a call to `terminate()`) was preventing the accumulation of test coverage statistics for failure cases.