### PR TITLE
Install one more header file

### DIFF
--- a/phlex/CMakeLists.txt
+++ b/phlex/CMakeLists.txt
@@ -21,6 +21,7 @@ cet_make_library(
   )
 
 install(FILES concurrency.hpp module.hpp source.hpp DESTINATION include/phlex)
+install(FILES detail/plugin_macros.hpp DESTINATION include/phlex/detail)
 
 cet_make_library(
   LIBRARY_NAME


### PR DESCRIPTION
The `phlex/detail/plugin_macros.hpp` header was omitted from installation whenever it was first introduced in commit https://github.com/Framework-R-D/phlex/commit/71457e063215ce5ffe4a381869b64b59e39229cb.