### PR TITLE
Convert Boost JSON string to `std::string_view`

### DIFF
--- a/phlex/app/load_module.cpp
+++ b/phlex/app/load_module.cpp
@@ -11,6 +11,7 @@
 
 #include <functional>
 #include <string>
+#include <string_view>
 
 using namespace std::string_literals;
 
@@ -57,10 +58,10 @@ namespace phlex::experimental {
         if (auto const* cpp = raw_config.if_contains("cpp")) {
           std::string msg = fmt::format("Both 'cpp' and 'py' parameters specified for {}", label);
           if (auto const* cpp_value = cpp->if_string()) {
-            msg += fmt::format("\n  - cpp: {}", *cpp_value);
+            msg += fmt::format("\n  - cpp: {}", std::string_view(*cpp_value));
           }
           if (auto const* py_value = py->if_string()) {
-            msg += fmt::format("\n  - py: {}", *py_value);
+            msg += fmt::format("\n  - py: {}", std::string_view(*py_value));
           }
           throw std::runtime_error(msg);
         }


### PR DESCRIPTION
The `fmt::format(...)` function can represent a Boost JSON string as an array of `char`s instead of character string (e.g.):"

```
Both 'cpp' and 'py' parameters specified for malformed3
    - cpp: ['m', 'y', '_', 'o', 't', 'h', 'e', 'r', '_', 'p', 'y', 't', 'h', 'o', 'n', '_', 'p', 'h', 'l', 'e', 'x', '_', 'm', 'o', 'd', 'u', 'l', 'e']
```

This PR makes use of Boost JSON string's implicit conversion operator to `std::string_view` so that `fmt::format(...)` will form the output correctly (e.g.):

```
Both 'cpp' and 'py' parameters specified for malformed3
    - cpp: my_other_python_phlex_module
```