### PR TITLE
run_phlex needs to depend publicly on the library its public headers use

### DIFF
--- a/phlex/app/CMakeLists.txt
+++ b/phlex/app/CMakeLists.txt
@@ -14,6 +14,7 @@ cet_make_library(
   # that will be including phlex/driver.hpp
   phlex::core
   Boost::json
+  Boost::boost
 )
 
 install(FILES load_module.hpp run.hpp version.hpp DESTINATION include/phlex/app)


### PR DESCRIPTION
This solves https://github.com/Framework-R-D/phlex/issues/240 by making the dependency of `run_phlex` on the libraries its own header uses/exposes public.  As far as the `phlex` header themselves this has no practical effect but it is __essential__ to find the headers on any external libraries they may use (and that might be install in their own location in some cases).  (In #240, this affects header from `fmt`)