### PR TITLE
Simplify implementation for forming input arguments

### DIFF
--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -148,7 +148,7 @@ namespace phlex::experimental {
             .first;
       }
       ++calls_;
-      return std::invoke(ft, *it->second, std::get<Is>(input_).retrieve(messages)...);
+      return std::invoke(ft, *it->second, std::get<Is>(input_).retrieve(std::get<Is>(messages))...);
     }
 
     std::size_t num_calls() const final { return calls_.load(); }

--- a/phlex/core/declared_observer.hpp
+++ b/phlex/core/declared_observer.hpp
@@ -112,7 +112,7 @@ namespace phlex::experimental {
     void call(function_t const& ft, messages_t<N> const& messages, std::index_sequence<Is...>)
     {
       ++calls_;
-      return std::invoke(ft, std::get<Is>(input_).retrieve(messages)...);
+      return std::invoke(ft, std::get<Is>(input_).retrieve(std::get<Is>(messages))...);
     }
 
     std::size_t num_calls() const final { return calls_.load(); }

--- a/phlex/core/declared_predicate.hpp
+++ b/phlex/core/declared_predicate.hpp
@@ -115,7 +115,7 @@ namespace phlex::experimental {
     bool call(function_t const& ft, messages_t<N> const& messages, std::index_sequence<Is...>)
     {
       ++calls_;
-      return std::invoke(ft, std::get<Is>(input_).retrieve(messages)...);
+      return std::invoke(ft, std::get<Is>(input_).retrieve(std::get<Is>(messages))...);
     }
 
     std::size_t num_calls() const final { return calls_.load(); }

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -141,7 +141,7 @@ namespace phlex::experimental {
     template <std::size_t... Is>
     auto call(function_t const& ft, messages_t<N> const& messages, std::index_sequence<Is...>)
     {
-      return std::invoke(ft, std::get<Is>(input_).retrieve(messages)...);
+      return std::invoke(ft, std::get<Is>(input_).retrieve(std::get<Is>(messages))...);
     }
 
     std::size_t num_calls() const final { return calls_.load(); }

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -152,7 +152,7 @@ namespace phlex::experimental {
               std::index_sequence<Is...>)
     {
       ++calls_;
-      Object obj(std::get<Is>(input_).retrieve(messages)...);
+      Object obj(std::get<Is>(input_).retrieve(std::get<Is>(messages))...);
       std::size_t counter = 0;
       auto running_value = obj.initial_value();
       while (std::invoke(predicate, obj, running_value)) {

--- a/phlex/core/input_arguments.hpp
+++ b/phlex/core/input_arguments.hpp
@@ -12,34 +12,20 @@
 #include <vector>
 
 namespace phlex::experimental {
-  template <typename T, std::size_t JoinNodePort>
+  template <typename T>
   struct retriever {
     using handle_arg_t = detail::handle_value_type<T>;
     product_query query;
-    auto retrieve(auto const& messages) const
+    auto retrieve(message const& msg) const
     {
-      return std::get<JoinNodePort>(messages).store->template get_handle<handle_arg_t>(
-        query.spec.name());
+      return msg.store->get_handle<handle_arg_t>(query.spec.name());
     }
   };
-
-  template <typename InputTypes>
-  struct input_retriever_types_impl {
-    template <std::size_t... Is>
-    static std::tuple<retriever<std::tuple_element_t<Is, InputTypes>, Is>...> form_tuple(
-      std::index_sequence<Is...>);
-
-    using type = decltype(form_tuple(std::make_index_sequence<std::tuple_size_v<InputTypes>>{}));
-  };
-
-  template <typename InputTypes>
-  using input_retriever_types = typename input_retriever_types_impl<InputTypes>::type;
 
   template <typename InputTypes, std::size_t... Is>
   auto form_input_arguments_impl(product_queries const& args, std::index_sequence<Is...>)
   {
-    return std::make_tuple(
-      retriever<std::tuple_element_t<Is, InputTypes>, Is>{std::move(args[Is])}...);
+    return std::make_tuple(retriever<std::tuple_element_t<Is, InputTypes>>{args[Is]}...);
   }
 
   namespace detail {
@@ -54,6 +40,9 @@ namespace phlex::experimental {
     detail::verify_no_duplicate_input_products(algorithm_name, args);
     return form_input_arguments_impl<InputTypes>(args, std::make_index_sequence<N>{});
   }
+
+  template <typename InputTypes>
+  using input_retriever_types = decltype(form_input_arguments<InputTypes>({}, {}));
 }
 
 #endif // PHLEX_CORE_INPUT_ARGUMENTS_HPP


### PR DESCRIPTION
This PR simplifies input argument handling by removing the `JoinNodePort` template parameter from the product retriever. The `retrieve()` method now takes a single message instead of the full messages collection, eliminating unnecessary template complexity.

---

PR summary credit: Claude Sonnet 4.5