### PR TITLE
Increase ruff's target python version to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ warn_unreachable = true
 disable_error_code = "annotation-unchecked"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py312"
 line-length = 99
 
 [tool.ruff.lint]


### PR DESCRIPTION
Increase ruff's target python version to 3.12. The default is 3.10, but out minimum required Python version (in spack etc.) is 3.12. This simplifies code development by allowing 3.12 language constructs.