### PR TITLE
Add workflow_dispatch to all relevant workflows

### DIFF
--- a/.github/REUSABLE_WORKFLOWS.md
+++ b/.github/REUSABLE_WORKFLOWS.md
@@ -12,6 +12,19 @@ Additionally, you can configure your own fork of Phlex to run CI checks on local
 
 If you are a Phlex-affiliated developer working on a dependent package of Phlex, or on a different Cetmodules-using package, or on Cetmodules itself, you may be able to invoke these workflows on your own project following the information in this guide. However, this is only supported for Phlex-affiliated developers, and even then on a best effort basis. We do **not** support or encourage others to utilize these workflows at this time.
 
+#### Running Workflows Manually (`workflow_dispatch`)
+
+Most workflows in this repository can be run manually on any branch, tag, or commit. This is useful for testing changes without creating a pull request or for applying fixes to a specific branch.
+
+To run a workflow manually:
+
+1.  Navigate to the **Actions** tab of the Phlex repository (or your fork).
+1.  In the left sidebar, click the workflow you want to run (e.g., **Clang-Format Check**).
+1.  Above the list of workflow runs, you will see a banner that says "This workflow has a `workflow_dispatch` event trigger." Click the **Run workflow** dropdown on the right.
+1.  Use the **Branch/tag** dropdown to select the branch you want to run the workflow on.
+1.  Some workflows have additional inputs (e.g., the `cmake-build` workflow allows you to specify build combinations). Fill these out as needed.
+1.  Click the **Run workflow** button.
+
 ### For Contributors Working on a Fork of Phlex
 
 If you are developing on a fork of `Framework-R-D/phlex` itself, the CI/CD workflows will run automatically on your pull requests within the fork, just as they do on the main repository. You do not need to use the `uses:` syntax described below.

--- a/.github/workflows/actionlint-check.yaml
+++ b/.github/workflows/actionlint-check.yaml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
   workflow_call:
     inputs:
       checkout-path:
@@ -99,6 +104,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
         path: ${{ env.local_checkout_path }}
 
     - name: Announce actionlint check

--- a/.github/workflows/clang-format-check.yaml
+++ b/.github/workflows/clang-format-check.yaml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
 
 jobs:
   pre-check:
@@ -22,7 +27,9 @@ jobs:
 
   detect-changes:
     needs: pre-check
-    if: github.event_name != 'workflow_dispatch' && needs.pre-check.outputs.is_act != 'true'
+    if: >
+      github.event_name != 'workflow_dispatch' &&
+      needs.pre-check.outputs.is_act != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,9 +65,11 @@ jobs:
   clang-format-check:
     needs: [pre-check, detect-changes]
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      needs.pre-check.outputs.is_act == 'true' ||
-      (needs.detect-changes.result == 'success' && needs.detect-changes.outputs.has_changes == 'true')
+      needs.detect-changes.result == 'skipped' ||
+      (
+        needs.detect-changes.result == 'success' &&
+        needs.detect-changes.outputs.has_changes == 'true'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,6 +78,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
         path: phlex-src
 
     - name: Announce clang-format check

--- a/.github/workflows/clang-format-fix.yaml
+++ b/.github/workflows/clang-format-fix.yaml
@@ -5,39 +5,52 @@ on:
   issue_comment:
     types:
       - created
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
 
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  parse-command:
+  pre-check:
     runs-on: ubuntu-latest
-    name: Parse bot command
+    name: Parse command
     if: >
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '@phlexbot format')
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        (
+          startsWith(github.event.comment.body, '@phlexbot format') ||
+          startsWith(github.event.comment.body, '@phlexbot clang-format-fix')
+        )
+      )
     outputs:
-      ref: ${{ steps.get_pr.outputs.ref }}
-      sha: ${{ steps.get_pr.outputs.sha }}
-      repo: ${{ steps.get_pr.outputs.repo }}
+      ref: ${{ (github.event_name == 'workflow_dispatch' && (github.event.inputs.ref || github.ref)) || steps.get_pr.outputs.ref }}
+      repo: ${{ steps.get_pr.outputs.repo || github.repository }}
 
     steps:
       - name: Get PR Info
+        if: github.event_name == 'issue_comment'
         id: get_pr
         uses: Framework-R-D/phlex/.github/actions/get-pr-info@main
 
   apply_formatting:
     runs-on: ubuntu-latest
     name: Apply formatting
-    needs: parse-command
-    if: ${{ needs.parse-command.result == 'success' }}
+    needs: pre-check
+    if: ${{ needs.pre-check.result == 'success' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: phlex-src
-          ref: ${{ needs.parse-command.outputs.ref }}
-          repository: ${{ needs.parse-command.outputs.repo }}
+          ref: ${{ needs.pre-check.outputs.ref }}
+          repository: ${{ needs.pre-check.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
 
       - uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
@@ -53,5 +66,5 @@ jobs:
           tool: clang-format
           working-directory: phlex-src
           token: ${{ secrets.WORKFLOW_PAT }}
-          pr-info-ref: ${{ needs.parse-command.outputs.ref }}
-          pr-info-repo: ${{ needs.parse-command.outputs.repo }}
+          pr-info-ref: ${{ needs.pre-check.outputs.ref }}
+          pr-info-repo: ${{ needs.pre-check.outputs.repo }}

--- a/.github/workflows/clang-tidy-check.yaml
+++ b/.github/workflows/clang-tidy-check.yaml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
 
 jobs:
 
@@ -66,6 +71,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
         path: phlex-src
 
     - name: Setup build environment

--- a/.github/workflows/clang-tidy-fix.yaml
+++ b/.github/workflows/clang-tidy-fix.yaml
@@ -5,27 +5,41 @@ on:
   issue_comment:
     types:
       - created
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
+      tidy-checks:
+        description: "A comma-separated list of clang-tidy checks to apply."
+        required: false
+        type: string
 
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  parse-command:
+  pre-check:
     runs-on: ubuntu-latest
-    name: Parse bot command
+    name: Parse command
     if: >
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '@phlexbot tidy-fix')
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '@phlexbot tidy-fix')
+      )
     outputs:
-      tidy_checks: ${{ steps.parse_comment.outputs.tidy_checks }}
-      ref: ${{ steps.get_pr.outputs.ref }}
-      sha: ${{ steps.get_pr.outputs.sha }}
-      repo: ${{ steps.get_pr.outputs.repo }}
+      ref: ${{ (github.event_name == 'workflow_dispatch' && (github.event.inputs.ref || github.ref)) || steps.get_pr.outputs.ref }}
+      repo: ${{ steps.get_pr.outputs.repo || github.repository }}
+      tidy_checks: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tidy-checks || steps.parse_comment.outputs.tidy_checks }}
 
     steps:
       - id: parse_comment
         name: Parse comment for tidy checks
+        if: github.event_name == 'issue_comment'
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
@@ -35,14 +49,15 @@ jobs:
             echo "tidy_checks=$tidy_checks" >> "$GITHUB_OUTPUT"
           fi
       - name: Get PR Info
+        if: github.event_name == 'issue_comment'
         id: get_pr
         uses: Framework-R-D/phlex/.github/actions/get-pr-info@main
 
   apply_tidy_fixes:
     runs-on: ubuntu-24.04
     name: Apply clang-tidy fixes
-    needs: parse-command
-    if: ${{ needs.parse-command.result == 'success' }}
+    needs: pre-check
+    if: ${{ needs.pre-check.result == 'success' }}
 
     container:
       image: ghcr.io/framework-r-d/phlex-ci:latest
@@ -52,8 +67,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: phlex-src
-          ref: ${{ needs.parse-command.outputs.ref }}
-          repository: ${{ needs.parse-command.outputs.repo }}
+          ref: ${{ needs.pre-check.outputs.ref }}
+          repository: ${{ needs.pre-check.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Setup build environment
@@ -67,7 +82,7 @@ jobs:
 
       - name: Apply clang-tidy fixes using CMake target
         env:
-          PHLEX_TIDY_CHECKS: ${{ needs.parse-command.outputs.tidy_checks }}
+          PHLEX_TIDY_CHECKS: ${{ needs.pre-check.outputs.tidy_checks }}
         run: |
           . /entrypoint.sh
           cd "$GITHUB_WORKSPACE/phlex-build"
@@ -89,8 +104,8 @@ jobs:
           tool: clang-tidy
           working-directory: phlex-src
           token: ${{ secrets.WORKFLOW_PAT }}
-          pr-info-ref: ${{ needs.parse-command.outputs.ref }}
-          pr-info-repo: ${{ needs.parse-command.outputs.repo }}
+          pr-info-ref: ${{ needs.pre-check.outputs.ref }}
+          pr-info-repo: ${{ needs.pre-check.outputs.repo }}
 
   clang-tidy-pr-comments:
     needs: apply_tidy_fixes

--- a/.github/workflows/cmake-build.yaml
+++ b/.github/workflows/cmake-build.yaml
@@ -10,6 +10,10 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
     inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
       build-combinations:
         description: |
           A space- or comma-separated list of build combinations to run.
@@ -89,7 +93,7 @@ jobs:
 
     outputs:
       is_act: ${{ steps.detect_act.outputs.is_act }}
-      sha: ${{ (github.event_name == 'workflow_call' && inputs.ref) || steps.pr.outputs.sha || github.sha }}
+      sha: ${{ (github.event_name == 'workflow_dispatch' && (github.event.inputs.ref || github.ref)) || (github.event_name == 'workflow_call' && inputs.ref) || steps.pr.outputs.sha || github.sha }}
       repo: ${{ (github.event_name == 'workflow_call' && inputs.repo) || steps.pr.outputs.repo || github.repository }}
 
     steps:

--- a/.github/workflows/cmake-format-check.yaml
+++ b/.github/workflows/cmake-format-check.yaml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
   workflow_call:
     inputs:
       checkout-path:
@@ -83,16 +88,18 @@ jobs:
   cmake-format-check:
     needs: [pre-check, detect-changes]
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_call' && inputs.skip-relevance-check == 'true') ||
-      needs.pre-check.outputs.is_act == 'true' ||
-      (needs.detect-changes.result == 'success' && needs.detect-changes.outputs.has_changes == 'true')
+      needs.detect-changes.result == 'skipped' ||
+      (
+        needs.detect-changes.result == 'success' &&
+        needs.detect-changes.outputs.has_changes == 'true'
+      )
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
         path: ${{ env.local_checkout_path }}
 
     - name: Set up Python

--- a/.github/workflows/cmake-format-fix.yaml
+++ b/.github/workflows/cmake-format-fix.yaml
@@ -5,6 +5,12 @@ on:
   issue_comment:
     types:
       - created
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
   workflow_call:
     inputs:
       checkout-path:
@@ -28,37 +34,43 @@ env:
   local_checkout_path: ${{ (github.event_name == 'workflow_call' && inputs.checkout-path) || format('{0}-src', github.event.repository.name) }}
 
 jobs:
-  parse-command:
+  pre-check:
     runs-on: ubuntu-latest
-    name: Parse bot command
+    name: Parse command
     if: >
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' ||
       (
-        startsWith(github.event.comment.body, '@phlexbot format') ||
-        startsWith(github.event.comment.body, format('@{0}bot format', github.event.repository.name))
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        (
+          startsWith(github.event.comment.body, '@phlexbot format') ||
+          startsWith(github.event.comment.body, '@phlexbot cmake-format-fix') ||
+          startsWith(github.event.comment.body, format('@{0}bot format', github.event.repository.name))
+        )
       )
     outputs:
-      ref: ${{ steps.get_pr.outputs.ref }}
-      repo: ${{ steps.get_pr.outputs.repo }}
+      ref: ${{ (github.event_name == 'workflow_call' && inputs.ref) || (github.event_name == 'workflow_dispatch' && (github.event.inputs.ref || github.ref)) || steps.get_pr.outputs.ref }}
+      repo: ${{ (github.event_name == 'workflow_call' && inputs.repo) || (github.event_name == 'workflow_dispatch' && github.repository) || steps.get_pr.outputs.repo }}
 
     steps:
       - name: Get PR Info
+        if: github.event_name == 'issue_comment'
         id: get_pr
         uses: Framework-R-D/phlex/.github/actions/get-pr-info@main
 
   apply_cmake_formatting:
     runs-on: ubuntu-latest
     name: Apply CMake formatting
-    needs: parse-command
-    if: github.event_name == 'workflow_call' || needs.parse-command.result == 'success'
+    needs: pre-check
+    if: needs.pre-check.result == 'success'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ${{ env.local_checkout_path }}
-          ref: ${{ (github.event_name == 'workflow_call' && inputs.ref) || needs.parse-command.outputs.ref }}
-          repository: ${{ (github.event_name == 'workflow_call' && inputs.repo) || needs.parse-command.outputs.repo }}
+          ref: ${{ needs.pre-check.outputs.ref }}
+          repository: ${{ needs.pre-check.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Set up Python
@@ -80,5 +92,5 @@ jobs:
           tool: cmake-format
           working-directory: ${{ env.local_checkout_path }}
           token: ${{ secrets.WORKFLOW_PAT }}
-          pr-info-ref: ${{ (github.event_name == 'workflow_call' && inputs.ref) || needs.parse-command.outputs.ref }}
-          pr-info-repo: ${{ (github.event_name == 'workflow_call' && inputs.repo) || needs.parse-command.outputs.repo }}
+          pr-info-ref: ${{ needs.pre-check.outputs.ref }}
+          pr-info-repo: ${{ needs.pre-check.outputs.repo }}

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 3 * * 0'  # weekly (UTC) — adjust as needed
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
   workflow_call:
     inputs:
       checkout-path:
@@ -65,6 +70,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
           path: ${{ env.local_checkout_path }}
           fetch-depth: 0
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -9,6 +9,10 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
     inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
       phlex-coverage-compiler:
         description: 'Compiler to use for coverage build (gcc or clang)'
         required: false
@@ -107,6 +111,7 @@ jobs:
     - name: Check out source code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
         path: phlex-src
 
     - name: Setup build environment

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
   workflow_call:
     inputs:
       checkout-path:
@@ -83,10 +88,11 @@ jobs:
   python-check:
     needs: [pre-check, detect-changes]
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_call' && inputs.skip-relevance-check == 'true') ||
-      needs.pre-check.outputs.is_act == 'true' ||
-      (needs.detect-changes.result == 'success' && needs.detect-changes.outputs.has_changes == 'true')
+      needs.detect-changes.result == 'skipped' ||
+      (
+        needs.detect-changes.result == 'success' &&
+        needs.detect-changes.outputs.has_changes == 'true'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -95,6 +101,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
         path: ${{ env.local_checkout_path }}
 
     - name: Set up Python

--- a/.github/workflows/python-fix.yaml
+++ b/.github/workflows/python-fix.yaml
@@ -5,6 +5,12 @@ on:
   issue_comment:
     types:
       - created
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, ref, or SHA to checkout. Defaults to the repository's default branch."
+        required: false
+        type: string
   workflow_call:
     inputs:
       checkout-path:
@@ -28,35 +34,40 @@ env:
   local_checkout_path: ${{ (github.event_name == 'workflow_call' && inputs.checkout-path) || format('{0}-src', github.event.repository.name) }}
 
 jobs:
-  parse-command:
+  pre-check:
     runs-on: ubuntu-latest
-    name: Parse bot command
+    name: Parse command
     if: >
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' ||
       (
-        startsWith(github.event.comment.body, '@phlexbot python-fix') ||
-        startsWith(github.event.comment.body, format('@{0}bot python-fix', github.event.repository.name))
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        (
+          startsWith(github.event.comment.body, '@phlexbot python-fix') ||
+          startsWith(github.event.comment.body, format('@{0}bot python-fix', github.event.repository.name))
+        )
       )
     outputs:
-      ref: ${{ steps.get_pr.outputs.ref }}
-      repo: ${{ steps.get_pr.outputs.repo }}
+      ref: ${{ (github.event_name == 'workflow_call' && inputs.ref) || (github.event_name == 'workflow_dispatch' && (github.event.inputs.ref || github.ref)) || steps.get_pr.outputs.ref }}
+      repo: ${{ (github.event_name == 'workflow_call' && inputs.repo) || (github.event_name == 'workflow_dispatch' && github.repository) || steps.get_pr.outputs.repo }}
     steps:
       - name: Get PR Info
+        if: github.event_name == 'issue_comment'
         id: get_pr
         uses: Framework-R-D/phlex/.github/actions/get-pr-info@main
 
   apply_fixes:
     runs-on: ubuntu-latest
     name: Apply fixes
-    needs: parse-command
-    if: github.event_name == 'workflow_call' || needs.parse-command.result == 'success'
+    needs: pre-check
+    if: needs.pre-check.result == 'success'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ${{ env.local_checkout_path }}
-          ref: ${{ (github.event_name == 'workflow_call' && inputs.ref) || needs.parse-command.outputs.ref }}
-          repository: ${{ (github.event_name == 'workflow_call' && inputs.repo) || needs.parse-command.outputs.repo }}
+          ref: ${{ needs.pre-check.outputs.ref }}
+          repository: ${{ needs.pre-check.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Set up Python
@@ -84,5 +95,5 @@ jobs:
           tool: 'Python linting'
           working-directory: ${{ env.local_checkout_path }}
           token: ${{ secrets.WORKFLOW_PAT }}
-          pr-info-ref: ${{ (github.event_name == 'workflow_call' && inputs.ref) || needs.parse-command.outputs.ref }}
-          pr-info-repo: ${{ (github.event_name == 'workflow_call' && inputs.repo) || needs.parse-command.outputs.repo }}
+          pr-info-ref: ${{ needs.pre-check.outputs.ref }}
+          pr-info-repo: ${{ needs.pre-check.outputs.repo }}


### PR DESCRIPTION
This change adds a `workflow_dispatch` trigger to all relevant workflows, allowing them to be run manually on a specific branch.

For each workflow, a `ref` input has been added to the `workflow_dispatch` trigger to specify the branch, tag, or SHA to checkout. The checkout steps have been updated to use this input when the workflow is manually triggered.

For the "fix" workflows, the jobs have been refactored to handle both `issue_comment` and `workflow_dispatch` triggers, ensuring the correct branch is checked out and modified in either case.

The relevance checks in the "check" workflows are now bypassed when the workflow is triggered manually.

The `REUSABLE_WORKFLOWS.md` documentation has been updated to include instructions for using the new `workflow_dispatch` triggers.

Co-authored-by: greenc-FNAL <2372949+greenc-FNAL@users.noreply.github.com>
