### PR TITLE
Restore integer representation of `nproc` value

### DIFF
--- a/Modules/NProc.cmake
+++ b/Modules/NProc.cmake
@@ -1,6 +1,8 @@
+# This CMake module returns the result of 'nproc' (or its equivalent on Apple).
+# The newline is trimmed from the result using the `tr -d '\n'` command.
+
 if(APPLE)
-  execute_process(COMMAND sysctl -n hw.logicalcpu OUTPUT_VARIABLE NPROC)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  # When CMake 3.25 is mandated, we can use elseif(LINUX)
-  execute_process(COMMAND nproc OUTPUT_VARIABLE NPROC)
+  execute_process(COMMAND sysctl -n hw.logicalcpu COMMAND tr -d '\n' OUTPUT_VARIABLE NPROC)
+elseif(LINUX)
+  execute_process(COMMAND nproc COMMAND tr -d '\n' OUTPUT_VARIABLE NPROC)
 endif()

--- a/test/max-parallelism/check_parallelism_default.jsonnet.in
+++ b/test/max-parallelism/check_parallelism_default.jsonnet.in
@@ -10,7 +10,7 @@
   modules: {
     verify: {
       cpp: 'check_parallelism',
-      expected_parallelism: '@NPROC@',
+      expected_parallelism: @NPROC@,
     },
   },
 }


### PR DESCRIPTION
Also trims newline from the returned value of nproc (or its equivalent)

This PR addresses the failure:

```
43: Error retrieving parameter 'expected_parallelism':                                                                              
43: not a number [boost.json:26 at /Users/kyleknoepfel/work/phlex-devel/local/.spack-env/._view/dlpaqk7urgh5dyallqyurp23btjxmoxo/include/boost/json/value.hpp:2370:30 in function 'typename std::enable_if<std::is_arithmetic<T>::value && !std::is_same<T, bool>::value
, T>::type boost::json::value::to_number(system::error_code &) const [T = unsigned long]']
```