### PR TITLE
Use native CMake functionality for stripping trailing whitespace

### DIFF
--- a/Modules/NProc.cmake
+++ b/Modules/NProc.cmake
@@ -2,7 +2,11 @@
 # The newline is trimmed from the result using the `tr -d '\n'` command.
 
 if(APPLE)
-  execute_process(COMMAND sysctl -n hw.logicalcpu COMMAND tr -d '\n' OUTPUT_VARIABLE NPROC)
+  execute_process(
+    COMMAND sysctl -n hw.logicalcpu
+    OUTPUT_VARIABLE NPROC
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
 elseif(LINUX)
-  execute_process(COMMAND nproc COMMAND tr -d '\n' OUTPUT_VARIABLE NPROC)
+  execute_process(COMMAND nproc OUTPUT_VARIABLE NPROC OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()


### PR DESCRIPTION
Hat tip to @greenc-FNAL 