### PR TITLE
Revert to `cmake-build` workflow from the `main` branch

### DIFF
--- a/.github/workflows/cmake-build.yaml
+++ b/.github/workflows/cmake-build.yaml
@@ -217,7 +217,7 @@ jobs:
 
     - name: Configure CMake
       id: configure
-      uses: knoepfel/phlex/.github/actions/configure-cmake@cpp23-for-containers
+      uses: Framework-R-D/phlex/.github/actions/configure-cmake@main
       with:
         source-path: ${{ env.local_checkout_path }}
         build-path: ${{ env.local_build_path }}


### PR DESCRIPTION
Per comment [here](https://github.com/Framework-R-D/phlex/pull/284#discussion_r2770814695).  Note that this PR retains the use of C++23.  The `cmake-build.yaml` file that supports C++23 has now been merged with the `main` branch, so it is no longer necessary to use the same file from my fork.