### PR TITLE
Remove vestigial inheritance from `std::enable_shared_from_this`

### DIFF
--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -14,7 +14,7 @@
 
 namespace phlex::experimental {
 
-  class product_store : public std::enable_shared_from_this<product_store> {
+  class product_store {
   public:
     explicit product_store(data_cell_index_ptr id,
                            std::string source = "Source",


### PR DESCRIPTION
The `product_store` class' inheritance from `std::enable_shared_from_this` is no longer need as `shared_from_this()` is not used anymore.