### PR TITLE
Rename `product_store::id()` to `product_store::index()`

### DIFF
--- a/form/form_module.cpp
+++ b/form/form_module.cpp
@@ -55,7 +55,7 @@ namespace {
       std::string creator = store.source();
 
       // Extract segment ID (partition) - extract once for entire store
-      std::string segment_id = store.id()->to_string();
+      std::string segment_id = store.index()->to_string();
 
       std::cout << "\n=== FormOutputModule::save_data_products ===\n";
       std::cout << "Creator: " << creator << "\n";

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -85,20 +85,20 @@ namespace phlex::experimental {
               auto const& msg = most_derived(messages);
               auto const& [store, original_message_id] = std::tie(msg.store, msg.original_id);
 
-              if (not store->is_flush() and not store->id()->parent(partition_)) {
+              if (not store->is_flush() and not store->index()->parent(partition_)) {
                 return;
               }
 
               if (store->is_flush()) {
                 // Downstream nodes always get the flush.
                 get<0>(outputs).try_put(msg);
-                if (store->id()->layer_name() != partition_) {
+                if (store->index()->layer_name() != partition_) {
                   return;
                 }
               }
 
               auto const& fold_index =
-                store->is_flush() ? store->id() : store->id()->parent(partition_);
+                store->is_flush() ? store->index() : store->index()->parent(partition_);
               assert(fold_index);
               auto const& id_hash_for_counter = fold_index->hash();
 
@@ -106,7 +106,7 @@ namespace phlex::experimental {
                 counter_for(id_hash_for_counter).set_flush_value(store, original_message_id);
               } else {
                 call(ft, messages, std::make_index_sequence<N>{});
-                counter_for(id_hash_for_counter).increment(store->id()->layer_hash());
+                counter_for(id_hash_for_counter).increment(store->index()->layer_hash());
               }
 
               if (auto counter = done_with(id_hash_for_counter)) {
@@ -136,7 +136,7 @@ namespace phlex::experimental {
     template <std::size_t... Is>
     void call(function_t const& ft, messages_t<N> const& messages, std::index_sequence<Is...>)
     {
-      auto const& parent_id = *most_derived(messages).store->id()->parent(partition_);
+      auto const& parent_id = *most_derived(messages).store->index()->parent(partition_);
       // FIXME: Not the safest approach!
       auto it = results_.find(parent_id);
       if (it == results_.end()) {
@@ -163,7 +163,7 @@ namespace phlex::experimental {
 
     void commit_(product_store& store)
     {
-      auto& result = results_.at(*store.id());
+      auto& result = results_.at(*store.index());
       if constexpr (requires { send(*result); }) {
         store.add_product(output()[0].name(), send(*result));
       } else {

--- a/phlex/core/declared_observer.hpp
+++ b/phlex/core/declared_observer.hpp
@@ -74,15 +74,15 @@ namespace phlex::experimental {
                   auto const& msg = most_derived(messages);
                   auto const& [store, message_id] = std::tie(msg.store, msg.id);
                   if (store->is_flush()) {
-                    flag_for(store->id()->hash()).flush_received(message_id);
+                    flag_for(store->index()->hash()).flush_received(message_id);
                   } else if (accessor a; needs_new(store, a)) {
                     call(ft, messages, std::make_index_sequence<N>{});
                     a->second = true;
-                    flag_for(store->id()->hash()).mark_as_processed();
+                    flag_for(store->index()->hash()).mark_as_processed();
                   }
 
                   if (done_with(store)) {
-                    cached_hashes_.erase(store->id()->hash());
+                    cached_hashes_.erase(store->index()->hash());
                   }
                   return {};
                 }}
@@ -102,10 +102,10 @@ namespace phlex::experimental {
 
     bool needs_new(product_store_const_ptr const& store, accessor& a)
     {
-      if (cached_hashes_.count(store->id()->hash()) > 0ull) {
+      if (cached_hashes_.count(store->index()->hash()) > 0ull) {
         return false;
       }
-      return cached_hashes_.insert(a, store->id()->hash());
+      return cached_hashes_.insert(a, store->index()->hash());
     }
 
     template <std::size_t... Is>

--- a/phlex/core/declared_predicate.hpp
+++ b/phlex/core/declared_predicate.hpp
@@ -81,17 +81,17 @@ namespace phlex::experimental {
           auto const& [store, message_id] = std::tie(msg.store, msg.id);
           predicate_result result{};
           if (store->is_flush()) {
-            flag_for(store->id()->hash()).flush_received(message_id);
-          } else if (const_accessor a; results_.find(a, store->id()->hash())) {
+            flag_for(store->index()->hash()).flush_received(message_id);
+          } else if (const_accessor a; results_.find(a, store->index()->hash())) {
             result = {msg.eom, message_id, a->second.result};
-          } else if (accessor a; results_.insert(a, store->id()->hash())) {
+          } else if (accessor a; results_.insert(a, store->index()->hash())) {
             bool const rc = call(ft, messages, std::make_index_sequence<N>{});
             result = a->second = {msg.eom, message_id, rc};
-            flag_for(store->id()->hash()).mark_as_processed();
+            flag_for(store->index()->hash()).mark_as_processed();
           }
 
           if (done_with(store)) {
-            results_.erase(store->id()->hash());
+            results_.erase(store->index()->hash());
           }
           return result;
         }}

--- a/phlex/core/declared_provider.cpp
+++ b/phlex/core/declared_provider.cpp
@@ -25,7 +25,7 @@ namespace phlex::experimental {
         spdlog::warn("Store with hash {} is null!", hash);
         continue;
       }
-      spdlog::debug(" => ID: {} (hash: {})", store->id()->to_string(), hash);
+      spdlog::debug(" => ID: {} (hash: {})", store->index()->to_string(), hash);
     }
   }
 }

--- a/phlex/core/declared_provider.hpp
+++ b/phlex/core/declared_provider.hpp
@@ -73,11 +73,11 @@ namespace phlex::experimental {
           auto& [stay_in_graph, to_output] = output;
 
           if (msg.store->is_flush()) {
-            flag_for(msg.store->id()->hash()).flush_received(msg.original_id);
+            flag_for(msg.store->index()->hash()).flush_received(msg.original_id);
             stay_in_graph.try_put(msg);
           } else {
             // Check cache first
-            auto index_hash = msg.store->id()->hash();
+            auto index_hash = msg.store->index()->hash();
             if (const_accessor ca; cache_.find(ca, index_hash)) {
               // Cache hit - reuse the cached store
               message const new_msg{ca->second, msg.eom, msg.id};
@@ -87,13 +87,13 @@ namespace phlex::experimental {
             }
 
             // Cache miss - compute the result
-            auto result = std::invoke(ft, *msg.store->id());
+            auto result = std::invoke(ft, *msg.store->index());
             ++calls_;
 
             products new_products;
             new_products.add(output_.name(), std::move(result));
             auto store = std::make_shared<product_store>(
-              msg.store->id(), this->full_name(), std::move(new_products));
+              msg.store->index(), this->full_name(), std::move(new_products));
 
             // Store in cache
             cache_.emplace(index_hash, store);
@@ -101,11 +101,11 @@ namespace phlex::experimental {
             message const new_msg{store, msg.eom, msg.id};
             stay_in_graph.try_put(new_msg);
             to_output.try_put(new_msg);
-            flag_for(msg.store->id()->hash()).mark_as_processed();
+            flag_for(msg.store->index()->hash()).mark_as_processed();
           }
 
           if (done_with(msg.store)) {
-            cache_.erase(msg.store->id()->hash());
+            cache_.erase(msg.store->index()->hash());
           }
         }}
     {

--- a/phlex/core/declared_transform.cpp
+++ b/phlex/core/declared_transform.cpp
@@ -23,7 +23,7 @@ namespace phlex::experimental {
         spdlog::warn("Store with hash {} is null!", hash);
         continue;
       }
-      spdlog::debug(" => ID: {} (hash: {})", store->id()->to_string(), hash);
+      spdlog::debug(" => ID: {} (hash: {})", store->index()->to_string(), hash);
     }
   }
 }

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -93,31 +93,31 @@ namespace phlex::experimental {
                      std::tie(msg.store, msg.eom, msg.id);
                    auto& [stay_in_graph, to_output] = output;
                    if (store->is_flush()) {
-                     flag_for(store->id()->hash()).flush_received(msg.original_id);
+                     flag_for(store->index()->hash()).flush_received(msg.original_id);
                      stay_in_graph.try_put(msg);
                      to_output.try_put(msg);
                    } else {
                      accessor a;
-                     if (stores_.insert(a, store->id()->hash())) {
+                     if (stores_.insert(a, store->index()->hash())) {
                        auto result = call(ft, messages, std::make_index_sequence<N>{});
                        ++calls_;
-                       ++product_count_[store->id()->layer_hash()];
+                       ++product_count_[store->index()->layer_hash()];
                        products new_products;
                        new_products.add_all(output_, std::move(result));
                        a->second = std::make_shared<product_store>(
-                         store->id(), this->full_name(), std::move(new_products));
+                         store->index(), this->full_name(), std::move(new_products));
 
                        message const new_msg{a->second, msg.eom, message_id};
                        stay_in_graph.try_put(new_msg);
                        to_output.try_put(new_msg);
-                       flag_for(store->id()->hash()).mark_as_processed();
+                       flag_for(store->index()->hash()).mark_as_processed();
                      } else {
                        stay_in_graph.try_put({a->second, msg.eom, message_id});
                      }
                    }
 
                    if (done_with(store)) {
-                     stores_.erase(store->id()->hash());
+                     stores_.erase(store->index()->hash());
                    }
                  }}
     {

--- a/phlex/core/declared_unfold.cpp
+++ b/phlex/core/declared_unfold.cpp
@@ -18,7 +18,7 @@ namespace phlex::experimental {
 
   product_store_const_ptr generator::make_child(std::size_t const i, products new_products)
   {
-    auto child_index = parent_->id()->make_child(i, child_layer_name_);
+    auto child_index = parent_->index()->make_child(i, child_layer_name_);
     ++child_counts_[child_index->layer_hash()];
     return std::make_shared<product_store>(child_index, node_name_, std::move(new_products));
   }
@@ -52,7 +52,7 @@ namespace phlex::experimental {
         spdlog::warn("Store with hash {} is null!", hash);
         continue;
       }
-      spdlog::debug(" => ID: {} (hash: {})", store->id()->to_string(), hash);
+      spdlog::debug(" => ID: {} (hash: {})", store->index()->to_string(), hash);
     }
   }
 }

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -109,20 +109,20 @@ namespace phlex::experimental {
           auto const& msg = most_derived(messages);
           auto const& store = msg.store;
           if (store->is_flush()) {
-            flag_for(store->id()->hash()).flush_received(msg.id);
+            flag_for(store->index()->hash()).flush_received(msg.id);
             std::get<0>(output).try_put(msg);
-          } else if (accessor a; stores_.insert(a, store->id()->hash())) {
+          } else if (accessor a; stores_.insert(a, store->index()->hash())) {
             std::size_t const original_message_id{msg_counter_};
             generator g{msg.store, this->full_name(), child_layer_name_};
-            call(p, ufold, msg.store->id(), g, msg.eom, messages, std::make_index_sequence<N>{});
+            call(p, ufold, msg.store->index(), g, msg.eom, messages, std::make_index_sequence<N>{});
 
             message const flush_msg{g.flush_store(), msg.eom, ++msg_counter_, original_message_id};
             std::get<0>(output).try_put(flush_msg);
-            flag_for(store->id()->hash()).mark_as_processed();
+            flag_for(store->index()->hash()).mark_as_processed();
           }
 
           if (done_with(store)) {
-            stores_.erase(store->id()->hash());
+            stores_.erase(store->index()->hash());
           }
         }}
     {
@@ -169,7 +169,7 @@ namespace phlex::experimental {
         }
         ++product_count_;
         auto child = g.make_child_for(counter++, std::move(new_products));
-        message const child_msg{child, eom->make_child(child->id()), ++msg_counter_};
+        message const child_msg{child, eom->make_child(child->index()), ++msg_counter_};
         output_port<0>(unfold_).try_put(child_msg);
 
         // Every data cell needs a flush (for now)

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -16,9 +16,9 @@ namespace phlex::experimental {
   layer_sentry::layer_sentry(flush_counters& counters,
                              message_sender& sender,
                              product_store_ptr store) :
-    counters_{counters}, sender_{sender}, store_{store}, depth_{store_->id()->depth()}
+    counters_{counters}, sender_{sender}, store_{store}, depth_{store_->index()->depth()}
   {
-    counters_.update(store_->id());
+    counters_.update(store_->index());
   }
 
   layer_sentry::~layer_sentry()
@@ -26,7 +26,7 @@ namespace phlex::experimental {
     // To consider: We may want to skip the following logic if the framework prematurely
     //              needs to shut down.  Keeping it enabled allows in-flight folds to
     //              complete.  However, in some cases it may not be desirable to do this.
-    auto flush_result = counters_.extract(store_->id());
+    auto flush_result = counters_.extract(store_->index());
     auto flush_store = store_->make_flush();
     if (not flush_result.empty()) {
       flush_store->add_product("[flush]",
@@ -172,7 +172,7 @@ namespace phlex::experimental {
   product_store_ptr framework_graph::accept(product_store_ptr store)
   {
     assert(store);
-    auto const new_depth = store->id()->depth();
+    auto const new_depth = store->index()->depth();
     while (not empty(layers_) and new_depth <= layers_.top().depth()) {
       layers_.pop();
       eoms_.pop();

--- a/phlex/core/message.cpp
+++ b/phlex/core/message.cpp
@@ -14,7 +14,7 @@ namespace phlex::experimental {
   {
     assert(a.store);
     assert(b.store);
-    if (a.store->id()->depth() > b.store->id()->depth()) {
+    if (a.store->index()->depth() > b.store->index()->depth()) {
       return a;
     }
     return b;

--- a/phlex/core/message_sender.cpp
+++ b/phlex/core/message_sender.cpp
@@ -18,13 +18,13 @@ namespace phlex::experimental {
     assert(store);
     assert(not store->is_flush());
     auto const message_id = ++calls_;
-    original_message_ids_.try_emplace(store->id(), message_id);
+    original_message_ids_.try_emplace(store->index(), message_id);
     auto parent_eom = eoms_.top();
     end_of_message_ptr current_eom{};
     if (parent_eom == nullptr) {
-      current_eom = eoms_.emplace(end_of_message::make_base(&hierarchy_, store->id()));
+      current_eom = eoms_.emplace(end_of_message::make_base(&hierarchy_, store->index()));
     } else {
-      current_eom = eoms_.emplace(parent_eom->make_child(store->id()));
+      current_eom = eoms_.emplace(parent_eom->make_child(store->index()));
     }
     return {store, current_eom, message_id, -1ull};
   }
@@ -43,7 +43,7 @@ namespace phlex::experimental {
     assert(store);
     assert(store->is_flush());
 
-    auto h = original_message_ids_.extract(store->id());
+    auto h = original_message_ids_.extract(store->index());
     assert(h);
     return h.mapped();
   }

--- a/phlex/core/multiplexer.cpp
+++ b/phlex/core/multiplexer.cpp
@@ -17,12 +17,12 @@ namespace {
   product_store_const_ptr store_for(product_store_const_ptr store,
                                     std::string const& port_product_layer)
   {
-    if (store->id()->layer_name() == port_product_layer) {
+    if (store->index()->layer_name() == port_product_layer) {
       // This store's layer matches what is expected by the port
       return store;
     }
 
-    if (auto index = store->id()->parent(port_product_layer)) {
+    if (auto index = store->index()->parent(port_product_layer)) {
       // This store has a parent layer that matches what is expected by the port
       return std::make_shared<product_store>(index, store->source());
     }
@@ -51,7 +51,7 @@ namespace phlex::experimental {
     auto const& [store, eom, message_id, _] = msg;
     if (debug_) {
       spdlog::debug("Multiplexing {} with ID {} (is flush: {})",
-                    store->id()->to_string(),
+                    store->index()->to_string(),
                     message_id,
                     store->is_flush());
     }

--- a/phlex/core/store_counters.cpp
+++ b/phlex/core/store_counters.cpp
@@ -27,7 +27,7 @@ namespace phlex::experimental {
 
   bool detect_flush_flag::done_with(product_store_const_ptr const& store)
   {
-    auto const h = store->id()->hash();
+    auto const h = store->index()->hash();
     if (const_flag_accessor fa; flags_.find(fa, h) && fa->second->is_complete()) {
       flags_.erase(fa);
       return true;

--- a/phlex/model/product_store.cpp
+++ b/phlex/model/product_store.cpp
@@ -31,7 +31,7 @@ namespace phlex::experimental {
 
   std::string const& product_store::layer_name() const noexcept { return id_->layer_name(); }
   std::string const& product_store::source() const noexcept { return source_; }
-  data_cell_index_ptr const& product_store::id() const noexcept { return id_; }
+  data_cell_index_ptr const& product_store::index() const noexcept { return id_; }
   bool product_store::is_flush() const noexcept { return stage_ == stage::flush; }
 
   bool product_store::contains_product(std::string const& product_name) const
@@ -41,7 +41,7 @@ namespace phlex::experimental {
 
   product_store_ptr const& more_derived(product_store_ptr const& a, product_store_ptr const& b)
   {
-    if (a->id()->depth() > b->id()->depth()) {
+    if (a->index()->depth() > b->index()->depth()) {
       return a;
     }
     return b;

--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -31,7 +31,7 @@ namespace phlex::experimental {
     std::string const& layer_name() const noexcept;
     std::string const& source() const noexcept;
     product_store_ptr make_flush() const;
-    data_cell_index_ptr const& id() const noexcept;
+    data_cell_index_ptr const& index() const noexcept;
     bool is_flush() const noexcept;
 
     // Product interface

--- a/test/product_store.cpp
+++ b/test/product_store.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Product store derivation", "[data model]")
   }
 
   auto root = product_store::base();
-  auto trunk = std::make_shared<product_store>(root->id()->make_child(1, "trunk"));
+  auto trunk = std::make_shared<product_store>(root->index()->make_child(1, "trunk"));
   SECTION("Compare different generations")
   {
     CHECK(trunk == more_derived(root, trunk));
@@ -57,15 +57,15 @@ TEST_CASE("Product store derivation", "[data model]")
   }
   SECTION("Compare siblings (right is always favored)")
   {
-    auto bole = std::make_shared<product_store>(root->id()->make_child(2, "bole"));
+    auto bole = std::make_shared<product_store>(root->index()->make_child(2, "bole"));
     CHECK(bole == more_derived(trunk, bole));
     CHECK(trunk == more_derived(bole, trunk));
   }
 
-  auto limb = std::make_shared<product_store>(trunk->id()->make_child(2, "limb"));
-  auto branch = std::make_shared<product_store>(limb->id()->make_child(3, "branch"));
-  auto twig = std::make_shared<product_store>(branch->id()->make_child(4, "twig"));
-  auto leaf = std::make_shared<product_store>(twig->id()->make_child(5, "leaf"));
+  auto limb = std::make_shared<product_store>(trunk->index()->make_child(2, "limb"));
+  auto branch = std::make_shared<product_store>(limb->index()->make_child(3, "branch"));
+  auto twig = std::make_shared<product_store>(branch->index()->make_child(4, "twig"));
+  auto leaf = std::make_shared<product_store>(twig->index()->make_child(5, "leaf"));
 
   auto order_a = std::make_tuple(root, trunk, limb, branch, twig, leaf);
   auto order_b = std::make_tuple(leaf, twig, branch, limb, trunk, root);

--- a/test/products_for_output.hpp
+++ b/test/products_for_output.hpp
@@ -13,7 +13,7 @@ namespace phlex::experimental::test {
     void save(product_store const& store) const
     {
       std::ostringstream oss;
-      oss << "Saving data for store id: " << store.id() << " from source: " << store.source();
+      oss << "Saving data for store id: " << store.index() << " from source: " << store.source();
       for (auto const& [product_name, _] : store) {
         oss << "\n -> Product name: " << product_name;
       }


### PR DESCRIPTION
This is to better express that a given product store corresponds to a given data-cell index.

*N.B.* There are no functionality changes with this PR; just a renaming of a member function.