### PR TITLE
Fix YAML indentation in handle-fix-commit action

### DIFF
--- a/.github/actions/handle-fix-commit/action.yaml
+++ b/.github/actions/handle-fix-commit/action.yaml
@@ -85,8 +85,8 @@ runs:
         rm -f ~/.git-credentials
         umask 077
         cat <<EOF > ~/.git-credentials
-https://x-access-token:${{ inputs.token }}@github.com
-EOF
+        https://x-access-token:${{ inputs.token }}@github.com
+        EOF
         git config --local credential.helper 'store --file ~/.git-credentials'
 
         git add -u


### PR DESCRIPTION
Indented lines in the bash script block that were starting at column 1,
causing a YAML syntax error. This resolves the failure in the Apply
formatting workflow introduced by commit 04601cc.

Co-authored-by: greenc-FNAL <2372949+greenc-FNAL@users.noreply.github.com>
