### PR TITLE
refactor: replace technology if-else chain with C++20 lookup table

### DIFF
--- a/form/form_module.cpp
+++ b/form/form_module.cpp
@@ -119,13 +119,11 @@ PHLEX_REGISTER_ALGORITHMS(m, config)
   std::cout << "  output_file: " << output_file << "\n";
   std::cout << "  technology: " << tech_string << "\n";
 
-  // Using a static map for O(1) lookup
-  static std::unordered_map<std::string_view, int> const tech_lookup = {
+  std::unordered_map<std::string_view, int> const tech_lookup = {
     {"ROOT_TTREE", form::technology::ROOT_TTREE},
     {"ROOT_RNTUPLE", form::technology::ROOT_RNTUPLE},
     {"HDF5", form::technology::HDF5}};
 
-  // C++20 allows finding a string_view key efficiently
   auto it = tech_lookup.find(tech_string);
 
   if (it == tech_lookup.end()) {


### PR DESCRIPTION
**Summary**： 
This is a **refactor and clean-up test** to modernize the module registration logic.

**Why**
- Cleaner Code: Replaced a verbose if-else block with a declarative std::unordered_map.
- Modern Standards: Leveraged the project's C++20 configuration to use std::string_view for efficient, zero-allocation lookups.
- Scalability: Makes it easier to add or modify supported technologies in the future without nesting more logic.