### PR TITLE
Avoid fixed-size `long` integral types for macOS

### DIFF
--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -426,8 +426,15 @@ namespace {
   BASIC_CONVERTER(bool, bool, PyBool_FromLong, pylong_as_bool)
   BASIC_CONVERTER(int, std::int32_t, PyLong_FromLong, PyLong_AsLong)
   BASIC_CONVERTER(uint, std::uint32_t, PyLong_FromLong, pylong_or_int_as_ulong)
+#if defined(__APPLE__) && defined(__MACH__)
+  // This is a temporary workaround until we have a solution for handling translation of types
+  // between C++ and Python.
+  BASIC_CONVERTER(long, long, PyLong_FromLong, pylong_as_strictlong)
+  BASIC_CONVERTER(ulong, unsigned long, PyLong_FromUnsignedLong, pylong_or_int_as_ulong)
+#else
   BASIC_CONVERTER(long, std::int64_t, PyLong_FromLong, pylong_as_strictlong)
   BASIC_CONVERTER(ulong, std::uint64_t, PyLong_FromUnsignedLong, pylong_or_int_as_ulong)
+#endif
   BASIC_CONVERTER(float, float, PyFloat_FromDouble, PyFloat_AsDouble)
   BASIC_CONVERTER(double, double, PyFloat_FromDouble, PyFloat_AsDouble)
 


### PR DESCRIPTION
As mentioned in a Slack discussion:

> The fixed-width integer type `std::int64_t` is a typedef (https://en.cppreference.com/w/cpp/types/integer.html).   In particular, `std::int64_t` on macOS is a typedef to `long long`.  So there is a mismatch between the `long` that the Python system expects, and the `long long` that is calculated by the `type_id` system.

This PR is to work around the problem until we have consistent treatment of types between C++ and Python.