### PR TITLE
`clang-tidy`: resolve `bugprone-implicit-widening-of-multiplication-result`

### DIFF
--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -3,7 +3,7 @@
 1. `bugprone-*`
 
    - [x] [bugprone-exception-escape](https://github.com/Framework-R-D/phlex/pull/491) (3)
-   - [ ] bugprone-implicit-widening-of-multiplication-result (11)
+   - [x] bugprone-implicit-widening-of-multiplication-result (11)
    - [ ] bugprone-macro-parentheses (398)
    - [x] [bugprone-multi-level-implicit-pointer-conversion](https://github.com/Framework-R-D/phlex/pull/494) (4)
    - [ ] bugprone-narrowing-conversions (34)

--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -3,7 +3,7 @@
 1. `bugprone-*`
 
    - [x] [bugprone-exception-escape](https://github.com/Framework-R-D/phlex/pull/491) (3)
-   - [x] bugprone-implicit-widening-of-multiplication-result (11)
+   - [x] [bugprone-implicit-widening-of-multiplication-result](https://github.com/Framework-R-D/phlex/pull/496) (11)
    - [ ] bugprone-macro-parentheses (398)
    - [x] [bugprone-multi-level-implicit-pointer-conversion](https://github.com/Framework-R-D/phlex/pull/494) (4)
    - [ ] bugprone-narrowing-conversions (34)

--- a/test/cached_execution.cpp
+++ b/test/cached_execution.cpp
@@ -38,9 +38,9 @@ using namespace phlex;
 
 namespace {
   // Provider functions
-  std::size_t provide_number(data_cell_index const& index) { return 2uz * index.number(); }
-  std::size_t provide_another(data_cell_index const& index) { return 3uz * index.number(); }
-  std::size_t provide_still(data_cell_index const& index) { return 4uz * index.number(); }
+  int provide_number(data_cell_index const& index) { return 2 * index.number(); }
+  int provide_another(data_cell_index const& index) { return 3 * index.number(); }
+  int provide_still(data_cell_index const& index) { return 4 * index.number(); }
 
   int call_one(int) noexcept { return 1; }
   int call_two(int, int) noexcept { return 2; }
@@ -48,9 +48,9 @@ namespace {
 
 TEST_CASE("Cached function calls", "[data model]")
 {
-  constexpr std::size_t n_runs{1uz};
-  constexpr int n_subruns{2};
-  constexpr int n_events{5000};
+  constexpr unsigned int n_runs{1};
+  constexpr unsigned int n_subruns{2u};
+  constexpr unsigned int n_events{5000u};
 
   experimental::layer_generator gen;
   gen.add_layer("run", {"job", n_runs});
@@ -97,8 +97,8 @@ TEST_CASE("Cached function calls", "[data model]")
   CHECK(g.execution_count("A2") == n_runs);
   CHECK(g.execution_count("A3") == n_runs);
 
-  CHECK(g.execution_count("B1") == n_runs * n_subruns);
-  CHECK(g.execution_count("B2") == n_runs * n_subruns);
+  CHECK(g.execution_count("B1") == std::size_t{n_runs} * n_subruns);
+  CHECK(g.execution_count("B2") == std::size_t{n_runs} * n_subruns);
 
-  CHECK(g.execution_count("C") == n_runs * n_subruns * n_events);
+  CHECK(g.execution_count("C") == std::size_t{n_runs} * n_subruns * n_events);
 }

--- a/test/cached_execution.cpp
+++ b/test/cached_execution.cpp
@@ -38,9 +38,9 @@ using namespace phlex;
 
 namespace {
   // Provider functions
-  int provide_number(data_cell_index const& index) { return 2 * index.number(); }
-  int provide_another(data_cell_index const& index) { return 3 * index.number(); }
-  int provide_still(data_cell_index const& index) { return 4 * index.number(); }
+  std::size_t provide_number(data_cell_index const& index) { return 2uz * index.number(); }
+  std::size_t provide_another(data_cell_index const& index) { return 3uz * index.number(); }
+  std::size_t provide_still(data_cell_index const& index) { return 4uz * index.number(); }
 
   int call_one(int) noexcept { return 1; }
   int call_two(int, int) noexcept { return 2; }
@@ -48,9 +48,9 @@ namespace {
 
 TEST_CASE("Cached function calls", "[data model]")
 {
-  constexpr unsigned int n_runs{1};
-  constexpr unsigned int n_subruns{2u};
-  constexpr unsigned int n_events{5000u};
+  constexpr std::size_t n_runs{1uz};
+  constexpr int n_subruns{2};
+  constexpr int n_events{5000};
 
   experimental::layer_generator gen;
   gen.add_layer("run", {"job", n_runs});
@@ -97,8 +97,8 @@ TEST_CASE("Cached function calls", "[data model]")
   CHECK(g.execution_count("A2") == n_runs);
   CHECK(g.execution_count("A3") == n_runs);
 
-  CHECK(g.execution_count("B1") == std::size_t{n_runs} * n_subruns);
-  CHECK(g.execution_count("B2") == std::size_t{n_runs} * n_subruns);
+  CHECK(g.execution_count("B1") == n_runs * n_subruns);
+  CHECK(g.execution_count("B2") == n_runs * n_subruns);
 
-  CHECK(g.execution_count("C") == std::size_t{n_runs} * n_subruns * n_events);
+  CHECK(g.execution_count("C") == n_runs * n_subruns * n_events);
 }

--- a/test/cached_execution.cpp
+++ b/test/cached_execution.cpp
@@ -97,8 +97,8 @@ TEST_CASE("Cached function calls", "[data model]")
   CHECK(g.execution_count("A2") == n_runs);
   CHECK(g.execution_count("A3") == n_runs);
 
-  CHECK(g.execution_count("B1") == n_runs * n_subruns);
-  CHECK(g.execution_count("B2") == n_runs * n_subruns);
+  CHECK(g.execution_count("B1") == std::size_t(n_runs * n_subruns));
+  CHECK(g.execution_count("B2") == std::size_t(n_runs * n_subruns));
 
-  CHECK(g.execution_count("C") == n_runs * n_subruns * n_events);
+  CHECK(g.execution_count("C") == std::size_t(n_runs * n_subruns * n_events));
 }

--- a/test/cached_execution.cpp
+++ b/test/cached_execution.cpp
@@ -97,8 +97,8 @@ TEST_CASE("Cached function calls", "[data model]")
   CHECK(g.execution_count("A2") == n_runs);
   CHECK(g.execution_count("A3") == n_runs);
 
-  CHECK(g.execution_count("B1") == std::size_t(n_runs * n_subruns));
-  CHECK(g.execution_count("B2") == std::size_t(n_runs * n_subruns));
+  CHECK(g.execution_count("B1") == std::size_t{n_runs} * n_subruns);
+  CHECK(g.execution_count("B2") == std::size_t{n_runs} * n_subruns);
 
-  CHECK(g.execution_count("C") == std::size_t(n_runs * n_subruns * n_events));
+  CHECK(g.execution_count("C") == std::size_t{n_runs} * n_subruns * n_events);
 }

--- a/test/demo-giantdata/waveforms.hpp
+++ b/test/demo-giantdata/waveforms.hpp
@@ -9,7 +9,7 @@ namespace demo {
 
   struct Waveform {
     // We should be set to the number of samples on a wire.
-    std::array<double, 3ull * 1024ull> samples;
+    std::array<double, std::size_t{3} * 1024> samples;
   };
 
   struct Waveforms {

--- a/test/demo-giantdata/waveforms.hpp
+++ b/test/demo-giantdata/waveforms.hpp
@@ -9,7 +9,7 @@ namespace demo {
 
   struct Waveform {
     // We should be set to the number of samples on a wire.
-    std::array<double, 3 * 1024> samples;
+    std::array<double, 3ull * 1024ull> samples;
   };
 
   struct Waveforms {

--- a/test/demo-giantdata/waveforms.hpp
+++ b/test/demo-giantdata/waveforms.hpp
@@ -9,7 +9,7 @@ namespace demo {
 
   struct Waveform {
     // We should be set to the number of samples on a wire.
-    std::array<double, std::size_t{3} * 1024> samples;
+    std::array<double, 3uz * 1024> samples;
   };
 
   struct Waveforms {

--- a/test/different_hierarchies.cpp
+++ b/test/different_hierarchies.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Different hierarchies used with fold", "[graph]")
 
   g.execute();
 
-  CHECK(g.execution_count("run_add") == index_limit * number_limit);
+  CHECK(g.execution_count("run_add") == std::size_t(index_limit * number_limit));
   CHECK(g.execution_count("job_add") == index_limit * number_limit + top_level_event_limit);
   CHECK(g.execution_count("verify_run_sum") == index_limit);
   CHECK(g.execution_count("verify_job_sum") == 1);

--- a/test/different_hierarchies.cpp
+++ b/test/different_hierarchies.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Different hierarchies used with fold", "[graph]")
 
   g.execute();
 
-  CHECK(g.execution_count("run_add") == std::size_t(index_limit * number_limit));
+  CHECK(g.execution_count("run_add") == std::size_t{index_limit} * number_limit);
   CHECK(g.execution_count("job_add") == index_limit * number_limit + top_level_event_limit);
   CHECK(g.execution_count("verify_run_sum") == index_limit);
   CHECK(g.execution_count("verify_job_sum") == 1);

--- a/test/fold.cpp
+++ b/test/fold.cpp
@@ -76,8 +76,8 @@ TEST_CASE("Different data layers of fold", "[graph]")
 
   g.execute();
 
-  CHECK(g.execution_count("run_add") == std::size_t(index_limit * number_limit));
-  CHECK(g.execution_count("job_add") == std::size_t(index_limit * number_limit));
+  CHECK(g.execution_count("run_add") == std::size_t{index_limit} * number_limit);
+  CHECK(g.execution_count("job_add") == std::size_t{index_limit} * number_limit);
   CHECK(g.execution_count("two_layer_job_add") == index_limit);
   CHECK(g.execution_count("verify_run_sum") == index_limit);
   CHECK(g.execution_count("verify_two_layer_job_sum") == 1);

--- a/test/fold.cpp
+++ b/test/fold.cpp
@@ -76,8 +76,8 @@ TEST_CASE("Different data layers of fold", "[graph]")
 
   g.execute();
 
-  CHECK(g.execution_count("run_add") == index_limit * number_limit);
-  CHECK(g.execution_count("job_add") == index_limit * number_limit);
+  CHECK(g.execution_count("run_add") == std::size_t(index_limit * number_limit));
+  CHECK(g.execution_count("job_add") == std::size_t(index_limit * number_limit));
   CHECK(g.execution_count("two_layer_job_add") == index_limit);
   CHECK(g.execution_count("verify_run_sum") == index_limit);
   CHECK(g.execution_count("verify_two_layer_job_sum") == 1);

--- a/test/hierarchical_nodes.cpp
+++ b/test/hierarchical_nodes.cpp
@@ -121,8 +121,8 @@ TEST_CASE("Hierarchical nodes", "[graph]")
 
   g.execute();
 
-  CHECK(g.execution_count("square") == index_limit * number_limit);
-  CHECK(g.execution_count("add") == index_limit * number_limit);
+  CHECK(g.execution_count("square") == std::size_t(index_limit * number_limit));
+  CHECK(g.execution_count("add") == std::size_t(index_limit * number_limit));
   CHECK(g.execution_count("get_the_time") == index_limit);
   CHECK(g.execution_count("scale") == index_limit);
   CHECK(g.execution_count("print_result") == index_limit);

--- a/test/hierarchical_nodes.cpp
+++ b/test/hierarchical_nodes.cpp
@@ -121,8 +121,8 @@ TEST_CASE("Hierarchical nodes", "[graph]")
 
   g.execute();
 
-  CHECK(g.execution_count("square") == std::size_t(index_limit * number_limit));
-  CHECK(g.execution_count("add") == std::size_t(index_limit * number_limit));
+  CHECK(g.execution_count("square") == std::size_t{index_limit} * number_limit);
+  CHECK(g.execution_count("add") == std::size_t{index_limit} * number_limit);
   CHECK(g.execution_count("get_the_time") == index_limit);
   CHECK(g.execution_count("scale") == index_limit);
   CHECK(g.execution_count("print_result") == index_limit);


### PR DESCRIPTION
Multiplications in test assertions and a compile-time array extent were done in `unsigned int` before widening to `std::size_t`. Cast one operand before multiplying so arithmetic happens in the correct type throughout.

**Before:**
```cpp
CHECK(g.execution_count("square") == std::size_t(index_limit * number_limit));
std::array<double, 3ull * 1024ull> samples;
```

**After:**
```cpp
CHECK(g.execution_count("square") == std::size_t{index_limit} * number_limit);
std::array<double, std::size_t{3} * 1024> samples;
```

- **`test/hierarchical_nodes.cpp`, `test/fold.cpp`, `test/different_hierarchies.cpp`, `test/cached_execution.cpp`**: Replace `std::size_t(a * b)` with `std::size_t{a} * b` in `execution_count` assertions.
- **`test/demo-giantdata/waveforms.hpp`**: Replace `3ull * 1024ull` array extent with `std::size_t{3} * 1024`.
- **`docs/dev/clang-tidy-fixes-2026-04.md`**: Mark check as resolved and link this PR, consistent with other completed entries.