### PR TITLE
`clang-tidy`: resolve `bugprone-return-const-ref-from-parameter`

### DIFF
--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -9,6 +9,6 @@
    - [ ] bugprone-narrowing-conversions (34)
    - [x] [bugprone-random-generator-seed](https://github.com/Framework-R-D/phlex/pull/490) (1)
    - [x] [bugprone-reserved-identifier](https://github.com/Framework-R-D/phlex/pull/489) (1)
-   - [ ] bugprone-return-const-ref-from-parameter (163)
+   - [x] [bugprone-return-const-ref-from-parameter](https://github.com/Framework-R-D/phlex/pull/499) (163)
    - [x] [bugprone-throwing-static-initialization](https://github.com/Framework-R-D/phlex/pull/472) (11)
    - [ ] bugprone-unchecked-optional-access (15)

--- a/phlex/core/message.cpp
+++ b/phlex/core/message.cpp
@@ -17,9 +17,9 @@ namespace phlex::experimental {
     assert(a.store);
     assert(b.store);
     if (a.store->index()->depth() > b.store->index()->depth()) {
-      return a;
+      return a; // NOLINT(bugprone-return-const-ref-from-parameter)
     }
-    return b;
+    return b; // NOLINT(bugprone-return-const-ref-from-parameter)
   }
 
   std::size_t port_index_for(product_queries const& input_products,

--- a/phlex/core/message.hpp
+++ b/phlex/core/message.hpp
@@ -67,7 +67,10 @@ namespace phlex::experimental {
   PHLEX_CORE_EXPORT message const& more_derived(message const& a, message const& b);
 
   // Non-template overload for single message case
-  inline message const& most_derived(message const& msg) { return msg; }
+  inline message const& most_derived(message const& msg)
+  {
+    return msg; // NOLINT(bugprone-return-const-ref-from-parameter)
+  }
 
   PHLEX_CORE_EXPORT std::size_t port_index_for(product_queries const& input_products,
                                                product_query const& input_product);

--- a/phlex/model/data_layer_hierarchy.cpp
+++ b/phlex/model/data_layer_hierarchy.cpp
@@ -9,7 +9,7 @@ namespace {
   std::string const& maybe_name(std::string const& name)
   {
     static std::string const unnamed{"(unnamed)"};
-    return empty(name) ? unnamed : name;
+    return empty(name) ? unnamed : name; // NOLINT(bugprone-return-const-ref-from-parameter)
   }
 }
 

--- a/phlex/model/product_store.cpp
+++ b/phlex/model/product_store.cpp
@@ -32,9 +32,9 @@ namespace phlex::experimental {
   product_store_ptr const& more_derived(product_store_ptr const& a, product_store_ptr const& b)
   {
     if (a->index()->depth() > b->index()->depth()) {
-      return a;
+      return a; // NOLINT(bugprone-return-const-ref-from-parameter)
     }
-    return b;
+    return b; // NOLINT(bugprone-return-const-ref-from-parameter)
   }
 
   algorithm_name product_store::default_source()

--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -66,8 +66,8 @@ namespace phlex::experimental {
   // Non-template overload for single product_store_ptr case
   inline product_store_ptr const& most_derived(product_store_ptr const& store)
   {
-    return store;
-  } // NOLINT(bugprone-return-const-ref-from-parameter)
+    return store; // NOLINT(bugprone-return-const-ref-from-parameter)
+  }
 
   // Generic most_derived for tuples
   template <std::size_t I, typename Tuple>

--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -64,7 +64,10 @@ namespace phlex::experimental {
                                                            product_store_ptr const& b);
 
   // Non-template overload for single product_store_ptr case
-  inline product_store_ptr const& most_derived(product_store_ptr const& store) { return store; }
+  inline product_store_ptr const& most_derived(product_store_ptr const& store)
+  {
+    return store;
+  } // NOLINT(bugprone-return-const-ref-from-parameter)
 
   // Generic most_derived for tuples
   template <std::size_t I, typename Tuple>


### PR DESCRIPTION
All existing ocurrences were intentional, and have been marked as such with `NOLINT`.
