### PR TITLE
improve error handling consistency

### DIFF
--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -345,28 +345,24 @@ namespace {
         Py_DECREF(phlexmod);
       }
 
-      if (!normalizer) {
-        std::string msg;
-        if (msg_from_py_error(msg, false))
-          throw std::runtime_error("unable to retrieve the phlex type normalizer: " + msg);
-      }
+      if (!normalizer)
+        return "";
     }
 
     PyObject* norm = PyObject_CallOneArg(normalizer, pyobj);
-    if (!norm) {
-      std::string msg;
-      if (msg_from_py_error(msg, false))
-        throw std::runtime_error("normalization error: " + msg);
-    }
+    if (!norm)
+      return "";
 
-    std::string ann = PyUnicode_AsUTF8(norm);
+    char const* ann = PyUnicode_AsUTF8(norm);
     Py_DECREF(norm);
+    if (!ann)
+      return "";
 
     return ann;
   }
 
   // retrieve C++ (matching) types from annotations
-  static void annotations_to_strings(PyObject* callable,
+  static bool annotations_to_strings(PyObject* callable,
                                      std::vector<std::string>& input_types,
                                      std::vector<std::string>& output_types)
   {
@@ -383,21 +379,32 @@ namespace {
     }
     Py_DECREF(sann);
 
+    bool conversion_ok = true;
     if (annot && PyDict_Check(annot)) {
       // Variant guarantees OrderedDict with "return" last
       PyObject *key, *value;
       Py_ssize_t pos = 0;
 
       while (PyDict_Next(annot, &pos, &key, &value)) {
+        std::string const& ann = annotation_as_text(value);
+        if (ann.empty() && PyErr_Occurred()) {
+          conversion_ok = false;
+          break;
+        }
+
         char const* key_str = PyUnicode_AsUTF8(key);
         if (strcmp(key_str, "return") == 0) {
-          output_types.push_back(annotation_as_text(value));
+          output_types.push_back(ann);
         } else {
-          input_types.push_back(annotation_as_text(value));
+          input_types.push_back(ann);
         }
       }
+    } else {
+      conversion_ok = false;
     }
+
     Py_XDECREF(annot);
+    return conversion_ok;
   }
 
   // converters of builtin types; TODO: this is a basic subset only, b/c either
@@ -715,7 +722,8 @@ static PyObject* parse_args(PyObject* args,
 
   // retrieve C++ (matching) types from annotations
   input_types.reserve(input_queries.size());
-  annotations_to_strings(callable, input_types, output_types);
+  if (!annotations_to_strings(callable, input_types, output_types))
+    return nullptr; // Python error already set
 
   // ignore None as Python's conventional "void" return, which is meaningless in C++
   if (output_types.size() == 1 && output_types[0] == "None")
@@ -1179,7 +1187,8 @@ static PyObject* sc_provide(py_phlex_source* src, PyObject* args, PyObject* kwds
   // retrieve C++ (matching) types from annotations
   std::vector<std::string> input_types;
   std::vector<std::string> output_types;
-  annotations_to_strings(callable, input_types, output_types);
+  if (!annotations_to_strings(callable, input_types, output_types))
+    return nullptr; // Python error already set
 
   // provider needs to take a single "data_cell_input"
   if (input_types.size() != 1 || input_types[0] != "data_cell_index") {
@@ -1207,11 +1216,8 @@ static PyObject* sc_provide(py_phlex_source* src, PyObject* args, PyObject* kwds
   auto opq = validate_query(output);
   if (!opq.has_value()) {
     // LCOV_EXCL_START
-    // validate_query _will_ have set a python exception with details about the
-    //  error, so just propagate it as a C++ exception
-    std::string msg{"(unknown)"};
-    msg_from_py_error(msg, false);
-    throw std::runtime_error("output specification error: " + msg);
+    // validate_query has set a python exception with details about the error
+    return nullptr;
     // LCOV_EXCL_STOP
   }
 

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -345,8 +345,13 @@ namespace {
         Py_DECREF(phlexmod);
       }
 
+      // LCOV_EXCL_START
+      // this would only fail if the phlex installation were broken and
+      // only exists to get a proper error message instead of a segfault
+      // in that rather unlikely case
       if (!normalizer)
         return "";
+      // LCOV_EXCL_STOP
     }
 
     PyObject* norm = PyObject_CallOneArg(normalizer, pyobj);
@@ -401,6 +406,8 @@ namespace {
       }
     } else {
       conversion_ok = false;
+      if (!PyErr_Occurred())
+        PyErr_SetString(PyExc_TypeError, "unknown annotation formatting");
     }
 
     Py_XDECREF(annot);
@@ -1215,10 +1222,8 @@ static PyObject* sc_provide(py_phlex_source* src, PyObject* args, PyObject* kwds
   // translate and validate the output query
   auto opq = validate_query(output);
   if (!opq.has_value()) {
-    // LCOV_EXCL_START
     // validate_query has set a python exception with details about the error
     return nullptr;
-    // LCOV_EXCL_STOP
   }
 
   // insert provider node (TODO: as in transform and observe, we'll leak the

--- a/test/python/pyprovide.py
+++ b/test/python/pyprovide.py
@@ -5,6 +5,8 @@ product can be injected into the execution graph and used by subsequent
 algorithms.
 """
 
+from typing import Dict, List
+
 import numpy as np
 import numpy.typing as npt
 
@@ -101,6 +103,24 @@ def PHLEX_REGISTER_PROVIDERS(s, config):
         assert not "supposed to be here"
     except TypeError as e:
         assert "unsupported collection output type" in str(e)
+
+    # annotations with ambiguous (union) type fail annotation processing
+    try:
+        funky = List[int] | Dict[int, int]
+        f = Variant(lambda di: 42, {"di": "data_cell_index", "return": funky}, "f")
+        s.provide(f, {"creator": "a", "layer": "b", "suffix": "c"})
+        assert not "supposed to be here"
+    except TypeError as e:
+        assert "must be unambiguous" in str(e)
+
+    # annotations with a surrogate string fail UTF-8 conversion
+    try:
+        surrogate = b"\x80".decode("gbk", errors="surrogateescape")
+        f = Variant(lambda di: 42, {"di": "data_cell_index", "return": surrogate}, "f")
+        s.provide(f, {"creator": "a", "layer": "b", "suffix": "c"})
+        assert not "supposed to be here"
+    except UnicodeEncodeError as e:
+        assert "surrogates not allowed" in str(e)
 
 
 def PHLEX_REGISTER_ALGORITHMS(m, config):

--- a/test/python/test_mismatch.py
+++ b/test/python/test_mismatch.py
@@ -1,5 +1,7 @@
 """Test mismatch between input labels and types."""
 
+from typing import Dict, List
+
 from phlex import Variant
 
 
@@ -11,26 +13,29 @@ def mismatch_func(a: int, b: int) -> int:
 def PHLEX_REGISTER_ALGORITHMS(m, config):
     """Register algorithms."""
     # test a range of possible errors in the annotation and product specifications
-    funky = b'\x80'.decode('gbk', errors='surrogateescape')
-
-    funky_input1 = Variant(mismatch_func, {"a": funky, "b": int, "return": int}, "funky_input1")
-    funky_input2 = Variant(mismatch_func, {"a": int, "b": funky, "return": int}, "funky_input2")
-    funky_return = Variant(mismatch_func, {"a": int, "b": int, "return": funky}, "funky_return")
+    funky1 = List[int] | Dict[int, int]
+    funky2 = b'\x80'.decode('gbk', errors='surrogateescape')
 
     test_count = 0
-    for f in (funky_input1, funky_input2, funky_return):
-        try:
-            m.transform(
-                f,
-                input_family=[{"creator": "input", "layer": "event", "suffix": "i"},
-                              {"creator": "input", "layer": "event", "suffix": "j"}],
-                output_product_suffixes=["sum"],
-            )
-            assert not "supposed to be here"
-        except UnicodeEncodeError as e:
-            test_count += 1
-            assert 'surrogates not allowed' in str(e) # consequence of C++ assuming UTF-8
-    assert test_count == 3
+    for funky, exc, err in ((funky1, TypeError, "must be unambiguous"),
+                            (funky2, UnicodeEncodeError, "surrogates not allowed")):
+        funky_input1 = Variant(mismatch_func, {"a": funky, "b": int, "return": int}, "finp1")
+        funky_input2 = Variant(mismatch_func, {"a": int, "b": funky, "return": int}, "finp2")
+        funky_return = Variant(mismatch_func, {"a": int, "b": int, "return": funky}, "fret")
+
+        for f in (funky_input1, funky_input2, funky_return):
+            try:
+                m.transform(
+                    f,
+                    input_family=[{"creator": "input", "layer": "event", "suffix": "i"},
+                                  {"creator": "input", "layer": "event", "suffix": "j"}],
+                    output_product_suffixes=["sum"],
+                )
+                assert not "supposed to be here"
+            except exc as e:
+                test_count += 1
+                assert err in str(e)
+    assert test_count == 6
 
     # input_family has 1 element, but function takes 2 arguments
     # This should trigger the error in modulewrap.cpp

--- a/test/python/test_mismatch.py
+++ b/test/python/test_mismatch.py
@@ -15,10 +15,12 @@ def PHLEX_REGISTER_ALGORITHMS(m, config):
     # test a range of possible errors in the annotation and product specifications
     funky1 = List[int] | Dict[int, int]
     funky2 = b'\x80'.decode('gbk', errors='surrogateescape')
+    funky3 = "" # empty string
 
     test_count = 0
     for funky, exc, err in ((funky1, TypeError, "must be unambiguous"),
-                            (funky2, UnicodeEncodeError, "surrogates not allowed")):
+                            (funky2, UnicodeEncodeError, "surrogates not allowed"),
+                            (funky3, TypeError, "unsupported"),):
         funky_input1 = Variant(mismatch_func, {"a": funky, "b": int, "return": int}, "finp1")
         funky_input2 = Variant(mismatch_func, {"a": int, "b": funky, "return": int}, "finp2")
         funky_return = Variant(mismatch_func, {"a": int, "b": int, "return": funky}, "fret")
@@ -35,10 +37,25 @@ def PHLEX_REGISTER_ALGORITHMS(m, config):
             except exc as e:
                 test_count += 1
                 assert err in str(e)
-    assert test_count == 6
+    assert test_count == 9
+
+    # annotations aren't a dictionary
+    funky_func = Variant(mismatch_func, {"a": int, "b": int, "return": int}, "ff")
+    funky_func.__annotations__ = [int, int, int]
+    try:
+        m.transform(
+            funky_func,
+            input_family=[{"creator": "input", "layer": "event", "suffix": "i"},
+                          {"creator": "input", "layer": "event", "suffix": "j"}],
+            output_product_suffixes=["sum"],
+        )
+        assert not "supposed to be here"
+    except TypeError as e:
+        assert "unknown annotation formatting" in str(e)
 
     # input_family has 1 element, but function takes 2 arguments
-    # This should trigger the error in modulewrap.cpp
+    # This should trigger the error in modulewrap.cpp (this final error is
+    # checked by cmake by verify output code and message log)
     m.transform(
         mismatch_func,
         input_family=[{"creator": "input", "layer": "event", "suffix": "a"}],

--- a/test/python/test_mismatch.py
+++ b/test/python/test_mismatch.py
@@ -1,5 +1,7 @@
 """Test mismatch between input labels and types."""
 
+from phlex import Variant
+
 
 def mismatch_func(a: int, b: int) -> int:
     """Add two integers."""
@@ -8,6 +10,28 @@ def mismatch_func(a: int, b: int) -> int:
 
 def PHLEX_REGISTER_ALGORITHMS(m, config):
     """Register algorithms."""
+    # test a range of possible errors in the annotation and product specifications
+    funky = b'\x80'.decode('gbk', errors='surrogateescape')
+
+    funky_input1 = Variant(mismatch_func, {"a": funky, "b": int, "return": int}, "funky_input1")
+    funky_input2 = Variant(mismatch_func, {"a": int, "b": funky, "return": int}, "funky_input2")
+    funky_return = Variant(mismatch_func, {"a": int, "b": int, "return": funky}, "funky_return")
+
+    test_count = 0
+    for f in (funky_input1, funky_input2, funky_return):
+        try:
+            m.transform(
+                f,
+                input_family=[{"creator": "input", "layer": "event", "suffix": "i"},
+                              {"creator": "input", "layer": "event", "suffix": "j"}],
+                output_product_suffixes=["sum"],
+            )
+            assert not "supposed to be here"
+        except UnicodeEncodeError as e:
+            test_count += 1
+            assert 'surrogates not allowed' in str(e) # consequence of C++ assuming UTF-8
+    assert test_count == 3
+
     # input_family has 1 element, but function takes 2 arguments
     # This should trigger the error in modulewrap.cpp
     m.transform(


### PR DESCRIPTION
Originally noticed by @greenc-FNAL, see here: https://github.com/Framework-R-D/phlex/pull/495#discussion_r3054542041, there are cases in the current code where a C++ exception is thrown where to code can still be reasonably be expected to return to Python for error handling. This PR removes two cases of throwing C++ exceptions in favor of setting Python exceptions and returning `nullptr`.