### PR TITLE
`clang-tidy`: resolve `clang-analyzer-core` problems

### DIFF
--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -36,6 +36,7 @@
   - _a.k.a._ [bugprone-unhandled-self-assignment](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/unhandled-self-assignment.html) with option `WarnOnlyIfThisHasSuspiciousField` set to `false`
   - [PR #526](https://github.com/Framework-R-D/phlex/pull/526)
 - [ ] [clang-analyzer-core.CallAndMessage](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.CallAndMessage.html) (1)
+  - [PR #525](https://github.com/Framework-R-D/phlex/pull/525)
 - [ ] [clang-analyzer-core.NullDereference](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.NullDereference.html) (1)
 - [ ] [clang-analyzer-cplusplus.NewDelete](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.html) (1)
 - [ ] [clang-analyzer-cplusplus.NewDeleteLeaks](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.html) (4)

--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -35,9 +35,11 @@
 - [x] [cert-oop54-cpp](https://clang.llvm.org/extra/clang-tidy/checks/cert/oop54-cpp.html) (2)
   - _a.k.a._ [bugprone-unhandled-self-assignment](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/unhandled-self-assignment.html) with option `WarnOnlyIfThisHasSuspiciousField` set to `false`
   - [PR #526](https://github.com/Framework-R-D/phlex/pull/526)
-- [ ] [clang-analyzer-core.CallAndMessage](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.CallAndMessage.html) (1)
+- [x] [clang-analyzer-core.CallAndMessage](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.CallAndMessage.html) (1)
   - [PR #525](https://github.com/Framework-R-D/phlex/pull/525)
-- [ ] [clang-analyzer-core.NullDereference](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.NullDereference.html) (1)
+  - [PR #538](https://github.com/Framework-R-D/phlex/pull/538)
+- [x] [clang-analyzer-core.NullDereference](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.NullDereference.html) (1)
+  - [PR #538](https://github.com/Framework-R-D/phlex/pull/538)
 - [ ] [clang-analyzer-cplusplus.NewDelete](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.html) (1)
 - [ ] [clang-analyzer-cplusplus.NewDeleteLeaks](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.html) (4)
 - [ ] [clang-analyzer-security.ArrayBound](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.ArrayBound.html) (2)

--- a/phlex/core/detail/repeater_node.cpp
+++ b/phlex/core/detail/repeater_node.cpp
@@ -18,6 +18,8 @@ namespace phlex::experimental::detail {
                 } else if (tagged.is_a<indexed_end_token>()) {
                   key = handle_flush_token(tagged.cast_to<indexed_end_token>());
                 } else {
+                  // Should never receive unknown message types
+                  assert(tagged.is_a<index_message>()); // Hint to static analyzers
                   key = handle_index_message(tagged.cast_to<index_message>());
                 }
 

--- a/phlex/core/filter.cpp
+++ b/phlex/core/filter.cpp
@@ -5,6 +5,8 @@
 #include "fmt/std.h"
 #include "oneapi/tbb/flow_graph.h"
 
+#include <cassert>
+
 using namespace phlex::experimental;
 using namespace oneapi::tbb;
 
@@ -47,6 +49,7 @@ namespace phlex::experimental {
       msg_id = msg.id;
       data_.update(msg.id, msg.store);
     } else {
+      assert(t.is_a<predicate_result>()); // Hint to static analyzers
       auto const& result = t.cast_to<predicate_result>();
       decisions_.update(result);
       msg_id = result.msg_id;

--- a/plugins/python/src/lifelinewrap.cpp
+++ b/plugins/python/src/lifelinewrap.cpp
@@ -8,11 +8,12 @@ using namespace phlex::experimental;
 static py_lifeline_t* ll_new(PyTypeObject* pytype, PyObject*, PyObject*)
 {
   py_lifeline_t* pyobj = (py_lifeline_t*)pytype->tp_alloc(pytype, 0);
-  if (!pyobj)
+  if (pyobj) {
+    pyobj->m_view = nullptr;
+    new (&pyobj->m_source) std::shared_ptr<void>{};
+  } else {
     PyErr_Print();
-  pyobj->m_view = nullptr;
-  new (&pyobj->m_source) std::shared_ptr<void>{};
-
+  }
   return pyobj;
 }
 


### PR DESCRIPTION
- **Record out-of-band (partial) fix for `clang-analyzer-core.CallAndMessage`**
- **`clang-tidy`: resolve `clang-analyzer-core.NullDereference`**
- **clang-tidy: resolve remaining `clang-analyzer-core.CallAndMessage` triggers**
