### PR TITLE
Fix real heap leaks in py_callback registrations; suppress Boost false positive

### DIFF
--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -40,8 +40,10 @@
   - [PR #538](https://github.com/Framework-R-D/phlex/pull/538)
 - [x] [clang-analyzer-core.NullDereference](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.NullDereference.html) (1)
   - [PR #538](https://github.com/Framework-R-D/phlex/pull/538)
-- [ ] [clang-analyzer-cplusplus.NewDelete](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.html) (1)
-- [ ] [clang-analyzer-cplusplus.NewDeleteLeaks](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.html) (4)
+- [x] [clang-analyzer-cplusplus.NewDelete](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.html) (1)
+  - [PR #451](https://github.com/Framework-R-D/phlex/issues/451)
+- [x] [clang-analyzer-cplusplus.NewDeleteLeaks](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.html) (4)
+  - [PR #451](https://github.com/Framework-R-D/phlex/issues/451)
 - [x] [clang-analyzer-security.ArrayBound](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.ArrayBound.html) (2)
   - No longer found with current `clang-tidy` configuration.
 - [x] [concurrency-mt-unsafe](https://clang.llvm.org/extra/clang-tidy/checks/concurrency/mt-unsafe.html) (1)

--- a/phlex/app/load_module.cpp
+++ b/phlex/app/load_module.cpp
@@ -114,6 +114,9 @@ namespace phlex::experimental {
   {
     configuration const config{raw_config};
     auto const& spec = config.get<std::string>("cpp");
+    // False positive: clang-analyzer cannot trace ownership through Boost's is_any_ofF<char>
+    // internal reference counting in classification.hpp.
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks,clang-analyzer-cplusplus.NewDelete)
     create_driver = plugin_loader<detail::driver_creator_t>(spec, "create_driver");
     driver_proxy const proxy{};
     return create_driver(proxy, config);

--- a/phlex/app/load_module.cpp
+++ b/phlex/app/load_module.cpp
@@ -117,6 +117,9 @@ namespace phlex::experimental {
   {
     configuration const config{raw_config};
     auto const& spec = config.get<std::string>("cpp");
+    // False positive: clang-analyzer cannot trace ownership through Boost's is_any_of<char>
+    // internal reference counting in classification.hpp.
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks,clang-analyzer-cplusplus.NewDelete)
     create_driver = plugin_loader<detail::driver_shim_t>(spec, "create_driver");
     driver_proxy const proxy{};
     driver_bundle result;

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -943,20 +943,18 @@ static PyObject* md_transform(py_phlex_module* mod, PyObject* args, PyObject* kw
 
   switch (input_queries.size()) {
   case 1: {
-    auto* pyc = new py_callback_1{callable}; // TODO: leaks, but has program lifetime
-    mod->ph_module->transform(pyname, *pyc, concurrency::serial)
+    mod->ph_module->transform(pyname, py_callback_1{callable}, concurrency::serial)
       .input_family(
         product_query{.creator = identifier(c0), .layer = pq0.layer, .suffix = identifier(suff0)})
       .output_product_suffixes(pyoutput);
     break;
   }
   case 2: {
-    auto* pyc = new py_callback_2{callable};
     auto pq1 = input_queries[1];
     std::string c1 = input_converter_name(cname, 1);
     std::string suff1 =
       "py_" + (pq1.suffix ? std::string{static_cast<std::string_view>(*pq1.suffix)} : "");
-    mod->ph_module->transform(pyname, *pyc, concurrency::serial)
+    mod->ph_module->transform(pyname, py_callback_2{callable}, concurrency::serial)
       .input_family(
         product_query{.creator = identifier(c0), .layer = pq0.layer, .suffix = identifier(suff0)},
         product_query{.creator = identifier(c1), .layer = pq1.layer, .suffix = identifier(suff1)})
@@ -964,7 +962,6 @@ static PyObject* md_transform(py_phlex_module* mod, PyObject* args, PyObject* kw
     break;
   }
   case 3: {
-    auto* pyc = new py_callback_3{callable};
     auto pq1 = input_queries[1];
     std::string c1 = input_converter_name(cname, 1);
     std::string suff1 =
@@ -973,7 +970,7 @@ static PyObject* md_transform(py_phlex_module* mod, PyObject* args, PyObject* kw
     std::string c2 = input_converter_name(cname, 2);
     std::string suff2 =
       "py_" + (pq2.suffix ? std::string{static_cast<std::string_view>(*pq2.suffix)} : "");
-    mod->ph_module->transform(pyname, *pyc, concurrency::serial)
+    mod->ph_module->transform(pyname, py_callback_3{callable}, concurrency::serial)
       .input_family(
         product_query{.creator = identifier(c0), .layer = pq0.layer, .suffix = identifier(suff0)},
         product_query{.creator = identifier(c1), .layer = pq1.layer, .suffix = identifier(suff1)},
@@ -1032,26 +1029,23 @@ static PyObject* md_observe(py_phlex_module* mod, PyObject* args, PyObject* kwds
 
   switch (input_queries.size()) {
   case 1: {
-    auto* pyc = new py_callback_1v{callable};
-    mod->ph_module->observe(cname, *pyc, concurrency::serial)
+    mod->ph_module->observe(cname, py_callback_1v{callable}, concurrency::serial)
       .input_family(
         product_query{.creator = identifier(c0), .layer = pq0.layer, .suffix = identifier(suff0)});
     break;
   }
   case 2: {
-    auto* pyc = new py_callback_2v{callable};
     auto pq1 = input_queries[1];
     std::string c1 = input_converter_name(cname, 1);
     std::string suff1 =
       "py_" + (pq1.suffix ? std::string{static_cast<std::string_view>(*pq1.suffix)} : "");
-    mod->ph_module->observe(cname, *pyc, concurrency::serial)
+    mod->ph_module->observe(cname, py_callback_2v{callable}, concurrency::serial)
       .input_family(
         product_query{.creator = identifier(c0), .layer = pq0.layer, .suffix = identifier(suff0)},
         product_query{.creator = identifier(c1), .layer = pq1.layer, .suffix = identifier(suff1)});
     break;
   }
   case 3: {
-    auto* pyc = new py_callback_3v{callable};
     auto pq1 = input_queries[1];
     std::string c1 = input_converter_name(cname, 1);
     std::string suff1 =
@@ -1060,7 +1054,7 @@ static PyObject* md_observe(py_phlex_module* mod, PyObject* args, PyObject* kwds
     std::string c2 = input_converter_name(cname, 2);
     std::string suff2 =
       "py_" + (pq2.suffix ? std::string{static_cast<std::string_view>(*pq2.suffix)} : "");
-    mod->ph_module->observe(cname, *pyc, concurrency::serial)
+    mod->ph_module->observe(cname, py_callback_3v{callable}, concurrency::serial)
       .input_family(
         product_query{.creator = identifier(c0), .layer = pq0.layer, .suffix = identifier(suff0)},
         product_query{.creator = identifier(c1), .layer = pq1.layer, .suffix = identifier(suff1)},

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -992,9 +992,11 @@ static PyObject* md_transform(py_phlex_module* mod, PyObject* args, PyObject* kw
   std::string const& out_type = output_types[0];
   std::string const& output = output_suffixes[0];
   if (!insert_output_converter(mod, cname, out_pq, out_type, output)) {
+    Py_DECREF(callable);
     return nullptr; // error already set
   }
 
+  Py_DECREF(callable);
   Py_RETURN_NONE;
 }
 
@@ -1013,6 +1015,7 @@ static PyObject* md_observe(py_phlex_module* mod, PyObject* args, PyObject* kwds
 
   if (!output_types.empty()) {
     PyErr_Format(PyExc_TypeError, "an observer should not have an output type");
+    Py_DECREF(callable);
     return nullptr;
   }
 
@@ -1068,6 +1071,7 @@ static PyObject* md_observe(py_phlex_module* mod, PyObject* args, PyObject* kwds
   }
   }
 
+  Py_DECREF(callable);
   Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
plugins/python/src/modulewrap.cpp
- In md_transform() and md_observe(), six heap allocations of the form
  'auto* pyc = new py_callback_N{callable}; register(*pyc, ...)' were
  real memory leaks.  The registration methods (transform(), observe())
  accept their callable argument by value: graph_proxy<T>::observe()
  passes it by value into glue<T>::observe(), which constructs an
  algorithm_bits wrapping std::function via delegate(), and ultimately
  stores a copy of the callable object inside the TBB flow-graph node.
  The original heap-allocated py_callback_N object was therefore never
  referenced again after registration and was never freed.

  Since py_callback's destructor is intentionally a no-op (Python
  reference-count cleanup is deferred to the Phlex shutdown hook; see
  the ~py_callback() comment), constructing a temporary and passing it
  directly is safe and avoids the allocation entirely:

    Before: auto* pyc = new py_callback_1{callable};
            mod->ph_module->transform(pyname, *pyc, concurrency::serial)
    After:  mod->ph_module->transform(pyname, py_callback_1{callable}, concurrency::serial)

  This also removes the pre-existing 'TODO: leaks, but has program
  lifetime' comment in the case-1 branch of md_transform(); that
  reasoning was incorrect because the callable is copied into the graph
  at registration time, so the raw pointer was always orphaned.

phlex/app/load_module.cpp
- clang-analyzer-cplusplus.NewDeleteLeaks and .NewDelete reported three
  warnings at the call to plugin_loader<driver_creator_t>() in
  load_driver().  The trace leads into boost::split() and ultimately
  into Boost.StringAlgo's is_any_ofF<char> copy constructor
  (classification.hpp), which uses 'new' internally and manages the
  allocation via its own reference-counting scheme.  The analyser cannot
  follow that ownership chain through the Boost internals and
  misidentifies the allocation as leaked.  The contradictory pair of
  'potential leak' and 'attempt to release already released memory' for
  the same object at the same site confirms the report is spurious.

  Suppressed with NOLINTNEXTLINE and an explanatory comment.
