### PR TITLE
`clang-tidy`: resolve `concurrency-mt-unsafe`

### DIFF
--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -42,8 +42,10 @@
   - [PR #538](https://github.com/Framework-R-D/phlex/pull/538)
 - [ ] [clang-analyzer-cplusplus.NewDelete](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.html) (1)
 - [ ] [clang-analyzer-cplusplus.NewDeleteLeaks](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.html) (4)
-- [ ] [clang-analyzer-security.ArrayBound](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.ArrayBound.html) (2)
-- [ ] [concurrency-mt-unsafe](https://clang.llvm.org/extra/clang-tidy/checks/concurrency/mt-unsafe.html) (1)
+- [x] [clang-analyzer-security.ArrayBound](https://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.ArrayBound.html) (2)
+  - No longer found with current `clang-tidy` configuration.
+- [x] [concurrency-mt-unsafe](https://clang.llvm.org/extra/clang-tidy/checks/concurrency/mt-unsafe.html) (1)
+  - [PR #542](https://github.com/Framework-R-D/phlex/pull/542)
 - [ ] [cppcoreguidelines-avoid-const-or-ref-data-members](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.html) (26)
 - [ ] [cppcoreguidelines-avoid-non-const-global-variables](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-non-const-global-variables.html) (47)
 - [ ] [cppcoreguidelines-explicit-virtual-functions](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.html) (19)

--- a/plugins/python/src/pymodule.cpp
+++ b/plugins/python/src/pymodule.cpp
@@ -186,6 +186,7 @@ static bool initialize()
   // FIXME: Spack does not set PYTHONPATH or VIRTUAL_ENV, but it does set
   //        CMAKE_PREFIX_PATH. Add site-packages directories from CMAKE_PREFIX_PATH
   //        to sys.path so Python can find packages in Spack views.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe) - Single-threaded context
   if (char const* cmake_prefix_path = std::getenv("CMAKE_PREFIX_PATH")) {
     add_cmake_prefix_paths_to_syspath(cmake_prefix_path);
   }

--- a/plugins/python/src/pymodule.cpp
+++ b/plugins/python/src/pymodule.cpp
@@ -13,6 +13,7 @@
 #include "phlex/model/data_cell_index.hpp"
 #include "phlex/source.hpp"
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 
 using namespace phlex::experimental;


### PR DESCRIPTION
- `std::getenv()` is called in single-threaded context.
