### PR TITLE
`clang-tidy`: resolve `cppcoreguidelines-avoid-const-or-ref-data-members`

### DIFF
--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -46,7 +46,8 @@
   - No longer found with current `clang-tidy` configuration.
 - [x] [concurrency-mt-unsafe](https://clang.llvm.org/extra/clang-tidy/checks/concurrency/mt-unsafe.html) (1)
   - [PR #542](https://github.com/Framework-R-D/phlex/pull/542)
-- [ ] [cppcoreguidelines-avoid-const-or-ref-data-members](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.html) (26)
+- [x] [cppcoreguidelines-avoid-const-or-ref-data-members](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.html) (26)
+  - [PR #543](https://github.com/Framework-R-D/phlex/pull/543)
 - [ ] [cppcoreguidelines-avoid-non-const-global-variables](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-non-const-global-variables.html) (47)
 - [ ] [cppcoreguidelines-explicit-virtual-functions](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.html) (19)
 - [ ] [cppcoreguidelines-init-variables](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/init-variables.html) (9)

--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -48,7 +48,8 @@
   - No longer found with current `clang-tidy` configuration.
 - [x] [concurrency-mt-unsafe](https://clang.llvm.org/extra/clang-tidy/checks/concurrency/mt-unsafe.html) (1)
   - [PR #542](https://github.com/Framework-R-D/phlex/pull/542)
-- [ ] [cppcoreguidelines-avoid-const-or-ref-data-members](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.html) (26)
+- [x] [cppcoreguidelines-avoid-const-or-ref-data-members](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.html) (26)
+  - [PR #543](https://github.com/Framework-R-D/phlex/pull/543)
 - [x] [cppcoreguidelines-avoid-non-const-global-variables](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-non-const-global-variables.html) (47)
   - [PR #544](https://github.com/Framework-R-D/phlex/pull/544)
 - [x] [cppcoreguidelines-explicit-virtual-functions](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.html) (19)

--- a/form/form_module.cpp
+++ b/form/form_module.cpp
@@ -101,8 +101,11 @@ namespace {
     }
 
   private:
+    // Algorithm configuration fixed at construction; intentionally immutable for object lifetime.
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::string const m_output_file;
     int const m_technology;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::unique_ptr<form::experimental::form_writer_interface> m_form_interface;
   };
 

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -51,6 +51,8 @@ namespace phlex::experimental {
     product_store_const_ptr make_child(std::size_t i, products new_products);
     product_store_ptr parent_;
     algorithm_name node_name_;
+    // References declared_unfold::child_layer_, which outlives this short-lived object.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::string const& child_layer_name_;
     std::map<data_cell_index::hash_type, std::size_t> child_counts_;
   };

--- a/phlex/core/detail/filter_impl.hpp
+++ b/phlex/core/detail/filter_impl.hpp
@@ -45,6 +45,8 @@ namespace phlex::experimental {
     bool claim(accessor& a, std::size_t msg_id);
 
   private:
+    // Fixed at construction; decision_map is already non-copyable via concurrent_hash_map.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     unsigned int const total_decisions_;
     decisions_t results_;
   };

--- a/phlex/core/glue.hpp
+++ b/phlex/core/glue.hpp
@@ -151,10 +151,11 @@ namespace phlex::experimental {
     }
 
   private:
-    tbb::flow::graph& graph_;
-    node_catalog& nodes_;
+    // Non-owning references to framework-owned resources; glue<T> is a short-lived builder.
+    tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    node_catalog& nodes_;     // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::shared_ptr<T> bound_obj_;
-    std::vector<std::string>& errors_;
+    std::vector<std::string>& errors_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     configuration const* config_;
   };
 }

--- a/phlex/core/graph_proxy.hpp
+++ b/phlex/core/graph_proxy.hpp
@@ -130,10 +130,11 @@ namespace phlex::experimental {
     }
 
     configuration const* config_;
-    tbb::flow::graph& graph_;
-    node_catalog& nodes_;
+    // Non-owning references to framework-owned resources; graph_proxy<T> is a short-lived builder.
+    tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    node_catalog& nodes_;     // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::shared_ptr<T> bound_obj_;
-    std::vector<std::string>& errors_;
+    std::vector<std::string>& errors_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
 }
 

--- a/phlex/core/index_router.hpp
+++ b/phlex/core/index_router.hpp
@@ -68,9 +68,12 @@ namespace phlex::experimental {
       std::size_t depth() const;
 
     private:
+      // Non-owning references to externally-owned state; layer_scope is an RAII guard.
+      // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
       flush_counters& counters_;
       flusher_t& flusher_;
       multilayer_slots const& slots_;
+      // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
       data_cell_index_ptr index_;
       std::size_t message_id_;
     };

--- a/phlex/core/multilayer_join_node.hpp
+++ b/phlex/core/multilayer_join_node.hpp
@@ -118,8 +118,11 @@ namespace phlex::experimental {
   private:
     std::vector<std::unique_ptr<detail::repeater_node>> repeaters_;
     tbb::flow::join_node<args_t, tbb::flow::tag_matching> join_;
+    // Immutable after construction; tbb::flow::join_node is already non-movable.
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::string const name_;
     std::vector<identifier> const layers_;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
 
   namespace detail {

--- a/phlex/core/registration_api.hpp
+++ b/phlex/core/registration_api.hpp
@@ -94,7 +94,8 @@ namespace phlex::experimental {
     algorithm_name name_;
     AlgorithmBits alg_;
     concurrency concurrency_;
-    tbb::flow::graph& graph_;
+    // Non-owning reference to the TBB graph; this class is a short-lived registration builder.
+    tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     registrar<node_ptr> registrar_;
   };
 
@@ -152,7 +153,8 @@ namespace phlex::experimental {
     algorithm_name name_;
     AlgorithmBits alg_;
     concurrency concurrency_;
-    tbb::flow::graph& graph_;
+    // Non-owning reference to the TBB graph; this class is a short-lived registration builder.
+    tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     registrar<declared_provider_ptr> registrar_;
   };
 
@@ -221,7 +223,8 @@ namespace phlex::experimental {
     algorithm_name name_;
     AlgorithmBits alg_;
     concurrency concurrency_;
-    tbb::flow::graph& graph_;
+    // Non-owning reference to the TBB graph; this class is a short-lived registration builder.
+    tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::string partition_;
     init_tuple init_;
     registrar<declared_fold_ptr> registrar_;
@@ -297,7 +300,8 @@ namespace phlex::experimental {
     registrar<declared_unfold_ptr> registrar_;
     algorithm_name name_;
     std::size_t concurrency_;
-    tbb::flow::graph& graph_;
+    // Non-owning reference to the TBB graph; this class is a short-lived registration builder.
+    tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     Predicate predicate_;
     Unfold unfold_;
     std::string destination_layer_;
@@ -324,7 +328,8 @@ namespace phlex::experimental {
 
   private:
     algorithm_name name_;
-    tbb::flow::graph& graph_;
+    // Non-owning reference to the TBB graph; this class is a short-lived registration builder.
+    tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     detail::output_function_t ft_;
     concurrency concurrency_;
     registrar<declared_output_ptr> reg_;

--- a/phlex/model/fixed_hierarchy.hpp
+++ b/phlex/model/fixed_hierarchy.hpp
@@ -34,8 +34,12 @@ namespace phlex {
                      experimental::async_driver<data_cell_index_ptr>& d);
 
     data_cell_index_ptr index_;
+    // Non-owning references to the enclosing hierarchy and driver; data_cell_cursor is a
+    // short-lived view and does not manage their lifetimes.
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     fixed_hierarchy const& hierarchy_;
     experimental::async_driver<data_cell_index_ptr>& driver_;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
 
   class PHLEX_MODEL_EXPORT fixed_hierarchy {

--- a/phlex/utilities/thread_counter.hpp
+++ b/phlex/utilities/thread_counter.hpp
@@ -22,7 +22,8 @@ namespace phlex::experimental {
     ~thread_counter() { --counter_; }
 
   private:
-    counter_type& counter_;
+    // Non-owning reference to externally-owned counter; thread_counter is an RAII guard.
+    counter_type& counter_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     value_type max_;
   };
 }

--- a/test/filter.cpp
+++ b/test/filter.cpp
@@ -48,6 +48,8 @@ namespace {
     }
     void collect(unsigned int const num) { actual.push_back(num); }
     tbb::concurrent_vector<unsigned int> actual;
+    // Immutable test expectation set at construction; intentionally prevents accidental mutation.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::vector<unsigned int> const expected;
   };
 
@@ -77,8 +79,11 @@ namespace {
 
   struct not_in_range {
     explicit not_in_range(unsigned int const b, unsigned int const e) : begin{b}, end{e} {}
+    // Immutable range bounds set at construction; intentionally prevents accidental mutation.
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     unsigned int const begin;
     unsigned int const end;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
     bool eval(unsigned int const i) const noexcept { return not in_range(begin, end, i); }
   };
 }


### PR DESCRIPTION
- Audit all occurrences
- All occurrences found to be justified
- Add justification comments and ignore via `NOLINT*` annotations
