### PR TITLE
`clang-tidy`: resolve `cppcoreguidelines-owning-memory`

### DIFF
--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -62,7 +62,8 @@
   - [PR #548](https://github.com/Framework-R-D/phlex/pull/548)
 - [x] [cppcoreguidelines-noexcept-move-operations](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/noexcept-move-operations.html) (8)
   - [PR #549](https://github.com/Framework-R-D/phlex/pull/549)
-- [ ] [cppcoreguidelines-owning-memory](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/owning-memory.html) (28)
+- [x] [cppcoreguidelines-owning-memory](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/owning-memory.html) (28)
+  - [PR #551](https://github.com/Framework-R-D/phlex/pull/551)
 - [x] [cppcoreguidelines-pro-bounds-avoid-unchecked-container-access](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.html) (113)
   - [PR #553](https://github.com/Framework-R-D/phlex/pull/553) (partial)
   - Disable check going forward.

--- a/form/root_storage/CMakeLists.txt
+++ b/form/root_storage/CMakeLists.txt
@@ -15,4 +15,8 @@ add_library(
 target_compile_definitions(root_storage PUBLIC USE_ROOT_STORAGE)
 
 # Link the ROOT libraries
-target_link_libraries(root_storage PUBLIC ROOT::Core ROOT::RIO ROOT::Tree storage)
+target_link_libraries(
+  root_storage
+  PUBLIC ROOT::Core ROOT::RIO ROOT::Tree storage
+  PRIVATE Microsoft.GSL::GSL
+)

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -61,7 +61,7 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
   if (dictInfo->Property() & EProperty::kIsFundamental) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     auto fundInfo = static_cast<TDataType*>(dictInfo); // Already checked to be fundamental
-    branchBuffer = new char[fundInfo->Size()];
+    branchBuffer = nullptr;
     branchStatus = m_tree->SetBranchAddress(col_name().c_str(),
                                             reinterpret_cast<void*>(&branchBuffer),
                                             nullptr,
@@ -74,7 +74,7 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
                                " (col_name='" + col_name() + "', type='" + DemangleName(type) +
                                "')");
     }
-    branchBuffer = klass->New();
+    branchBuffer = nullptr;
     branchStatus = m_tree->SetBranchAddress(
       col_name().c_str(), reinterpret_cast<void*>(&branchBuffer), klass, EDataType::kOther_t, true);
   }

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -63,43 +63,43 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
     auto fundInfo = static_cast<TDataType*>(dictInfo); // Already checked to be fundamental
     switch (fundInfo->GetType()) {
     case kChar_t:
-      branchBuffer = new char;
+      branchBuffer = new Char_t;
       break;
     case kUChar_t:
-      branchBuffer = new unsigned char;
+      branchBuffer = new UChar_t;
       break;
     case kShort_t:
-      branchBuffer = new short;
+      branchBuffer = new Short_t;
       break;
     case kUShort_t:
-      branchBuffer = new unsigned short;
+      branchBuffer = new UShort_t;
       break;
     case kInt_t:
-      branchBuffer = new int;
+      branchBuffer = new Int_t;
       break;
     case kUInt_t:
-      branchBuffer = new unsigned int;
+      branchBuffer = new UInt_t;
       break;
     case kLong_t:
-      branchBuffer = new long;
+      branchBuffer = new Long_t;
       break;
     case kULong_t:
-      branchBuffer = new unsigned long;
+      branchBuffer = new ULong_t;
       break;
     case kLong64_t:
-      branchBuffer = new int64_t;
+      branchBuffer = new Long64_t;
       break;
     case kULong64_t:
-      branchBuffer = new uint64_t;
+      branchBuffer = new ULong64_t;
       break;
     case kFloat_t:
-      branchBuffer = new float;
+      branchBuffer = new Float_t;
       break;
     case kDouble_t:
-      branchBuffer = new double;
+      branchBuffer = new Double_t;
       break;
     case kBool_t:
-      branchBuffer = new bool;
+      branchBuffer = new Bool_t;
       break;
     default:
       throw std::runtime_error(

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -9,6 +9,8 @@
 #include "TLeaf.h"
 #include "TTree.h"
 
+#include <gsl/pointers>
+
 #include <unordered_map>
 
 using namespace form::detail::experimental;
@@ -49,7 +51,7 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
   if (id > m_tree->GetEntries())
     return false;
 
-  void* branchBuffer = nullptr;
+  gsl::owner<void*> branchBuffer = nullptr;
   auto dictInfo = TDictionary::GetDictionary(type);
   int branchStatus = 0;
 
@@ -106,11 +108,8 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
         std::string{"ROOT_TBranch_ContainerImp::read unsupported fundamental type: "} +
         DemangleName(type));
     };
-    branchStatus = m_tree->SetBranchAddress(col_name().c_str(),
-                                            reinterpret_cast<void*>(branchBuffer),
-                                            nullptr,
-                                            EDataType(fundInfo->GetType()),
-                                            false);
+    branchStatus = m_tree->SetBranchAddress(
+      col_name().c_str(), branchBuffer, nullptr, EDataType(fundInfo->GetType()), false);
   } else {
     auto klass = TClass::GetClass(type);
     if (!klass) {
@@ -118,7 +117,7 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
                                " (col_name='" + col_name() + "', type='" + DemangleName(type) +
                                "')");
     }
-    branchBuffer = klass->New();
+    branchBuffer = gsl::owner<void*>(klass->New());
     branchStatus = m_tree->SetBranchAddress(
       col_name().c_str(), reinterpret_cast<void*>(&branchBuffer), klass, EDataType::kOther_t, true);
   }

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -61,12 +61,56 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
   if (dictInfo->Property() & EProperty::kIsFundamental) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     auto fundInfo = static_cast<TDataType*>(dictInfo); // Already checked to be fundamental
-    branchBuffer = nullptr;
+    switch (fundInfo->GetType()) {
+    case kChar_t:
+      branchBuffer = new char;
+      break;
+    case kUChar_t:
+      branchBuffer = new unsigned char;
+      break;
+    case kShort_t:
+      branchBuffer = new short;
+      break;
+    case kUShort_t:
+      branchBuffer = new unsigned short;
+      break;
+    case kInt_t:
+      branchBuffer = new int;
+      break;
+    case kUInt_t:
+      branchBuffer = new unsigned int;
+      break;
+    case kLong_t:
+      branchBuffer = new long;
+      break;
+    case kULong_t:
+      branchBuffer = new unsigned long;
+      break;
+    case kLong64_t:
+      branchBuffer = new int64_t;
+      break;
+    case kULong64_t:
+      branchBuffer = new uint64_t;
+      break;
+    case kFloat_t:
+      branchBuffer = new float;
+      break;
+    case kDouble_t:
+      branchBuffer = new double;
+      break;
+    case kBool_t:
+      branchBuffer = new bool;
+      break;
+    default:
+      throw std::runtime_error(
+        std::string{"ROOT_TBranch_ContainerImp::read unsupported fundamental type: "} +
+        DemangleName(type));
+    };
     branchStatus = m_tree->SetBranchAddress(col_name().c_str(),
-                                            reinterpret_cast<void*>(&branchBuffer),
+                                            reinterpret_cast<void*>(branchBuffer),
                                             nullptr,
                                             EDataType(fundInfo->GetType()),
-                                            true);
+                                            false);
   } else {
     auto klass = TClass::GetClass(type);
     if (!klass) {
@@ -74,7 +118,7 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
                                " (col_name='" + col_name() + "', type='" + DemangleName(type) +
                                "')");
     }
-    branchBuffer = nullptr;
+    branchBuffer = klass->New();
     branchStatus = m_tree->SetBranchAddress(
       col_name().c_str(), reinterpret_cast<void*>(&branchBuffer), klass, EDataType::kOther_t, true);
   }

--- a/form/root_storage/root_ttree_write_container.cpp
+++ b/form/root_storage/root_ttree_write_container.cpp
@@ -6,19 +6,13 @@
 #include "TFile.h"
 #include "TTree.h"
 
+#include <gsl/pointers>
+
 using namespace form::detail::experimental;
 
 ROOT_TTree_Write_ContainerImp::ROOT_TTree_Write_ContainerImp(std::string const& name) :
   Storage_Write_Association(name)
 {
-}
-
-ROOT_TTree_Write_ContainerImp::~ROOT_TTree_Write_ContainerImp()
-{
-  if (m_tree != nullptr) {
-    m_tree->GetDirectory()->WriteTObject(m_tree);
-    delete m_tree;
-  }
 }
 
 void ROOT_TTree_Write_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
@@ -39,10 +33,10 @@ void ROOT_TTree_Write_ContainerImp::setupWrite(std::type_info const& /* type*/)
     throw std::runtime_error("ROOT_TTree_Write_ContainerImp::setupWrite no file attached");
   }
   if (m_tree == nullptr) {
-    m_tree = m_tfile->Get<TTree>(name().c_str());
+    m_tree.reset(m_tfile->Get<TTree>(name().c_str()));
   }
   if (m_tree == nullptr) {
-    m_tree = new TTree(name().c_str(), name().c_str());
+    m_tree.reset(gsl::owner<TTree*>{new TTree(name().c_str(), name().c_str())});
     m_tree->SetDirectory(m_tfile.get());
   }
   if (m_tree == nullptr) {
@@ -61,4 +55,12 @@ void ROOT_TTree_Write_ContainerImp::commit()
   throw std::runtime_error("ROOT_TTree_Write_ContainerImp::commit not implemented");
 }
 
-TTree* ROOT_TTree_Write_ContainerImp::getTTree() { return m_tree; }
+TTree* ROOT_TTree_Write_ContainerImp::getTTree() { return m_tree.get(); }
+
+void ROOT_TTree_Write_ContainerImp::TTreeDeleter::operator()(gsl::owner<TTree*> t) const
+{
+  if (t) {
+    t->GetDirectory()->WriteTObject(t);
+    delete t;
+  }
+}

--- a/form/root_storage/root_ttree_write_container.hpp
+++ b/form/root_storage/root_ttree_write_container.hpp
@@ -16,7 +16,6 @@ namespace form::detail::experimental {
   class ROOT_TTree_Write_ContainerImp : public Storage_Write_Association {
   public:
     ROOT_TTree_Write_ContainerImp(std::string const& name);
-    ~ROOT_TTree_Write_ContainerImp() override;
 
     ROOT_TTree_Write_ContainerImp(ROOT_TTree_Write_ContainerImp const&) = delete;
     ROOT_TTree_Write_ContainerImp& operator=(ROOT_TTree_Write_ContainerImp const&) = delete;
@@ -31,8 +30,16 @@ namespace form::detail::experimental {
     TTree* getTTree();
 
   private:
+    // Be absolutely explicit about the ownership semantics of TTree*,
+    // since ROOT nominally manages the memory of TTree objects, but in
+    // practice we need to ensure objects are written to the TTree, and
+    //  the TTree itself is deleted at the right time.
+    struct TTreeDeleter {
+      void operator()(TTree* t) const;
+    };
+
     std::shared_ptr<TFile> m_tfile;
-    TTree* m_tree{nullptr};
+    std::unique_ptr<TTree, TTreeDeleter> m_tree;
   };
 
 } //namespace form::detail::experimental

--- a/form/root_storage/root_ttree_write_container.hpp
+++ b/form/root_storage/root_ttree_write_container.hpp
@@ -32,12 +32,15 @@ namespace form::detail::experimental {
   private:
     // Be absolutely explicit about the ownership semantics of TTree*,
     // since ROOT nominally manages the memory of TTree objects, but in
-    // practice we need to ensure objects are written to the TTree, and
-    //  the TTree itself is deleted at the right time.
+    // practice we need to ensure objects are written to the TTree—and
+    // the TTree itself is deleted—at the right time i.e. before its
+    //  containing TFile is deleted.
     struct TTreeDeleter {
       void operator()(TTree* t) const;
     };
 
+    // Ordering of members is critical here:
+    // the TTree must be deleted before the TFile.
     std::shared_ptr<TFile> m_tfile;
     std::unique_ptr<TTree, TTreeDeleter> m_tree;
   };

--- a/form/storage/CMakeLists.txt
+++ b/form/storage/CMakeLists.txt
@@ -13,5 +13,9 @@ add_library(
 )
 
 if(FORM_USE_ROOT_STORAGE)
-  target_link_libraries(storage PUBLIC core root_storage)
+  target_link_libraries(
+    storage
+    PUBLIC core
+    PRIVATE root_storage
+  )
 endif()

--- a/form/storage/CMakeLists.txt
+++ b/form/storage/CMakeLists.txt
@@ -13,5 +13,5 @@ add_library(
 )
 
 if(FORM_USE_ROOT_STORAGE)
-  target_link_libraries(storage core root_storage)
+  target_link_libraries(storage PUBLIC core root_storage)
 endif()

--- a/form/storage/CMakeLists.txt
+++ b/form/storage/CMakeLists.txt
@@ -13,9 +13,5 @@ add_library(
 )
 
 if(FORM_USE_ROOT_STORAGE)
-  target_link_libraries(
-    storage
-    PUBLIC core
-    PRIVATE root_storage
-  )
+  target_link_libraries(storage PUBLIC core PRIVATE root_storage)
 endif()

--- a/form/storage/storage_reader.cpp
+++ b/form/storage/storage_reader.cpp
@@ -41,12 +41,10 @@ int StorageReader::getIndex(Token const& token,
     }
     auto const& type = typeid(std::string);
     int entry = 1;
-    void const* data = nullptr;
-    while (cont->second->read(entry, &data, type)) {
-      m_indexMaps[token.containerName()].insert(
-        std::make_pair(*(static_cast<std::string const*>(data)), entry));
-      delete static_cast<std::string const*>(
-        data); //FIXME: smart pointer?  The overhead to delete an arbitrary type is not much prettier
+    void const* rawData = nullptr;
+    while (cont->second->read(entry, &rawData, type)) {
+      std::unique_ptr<std::string const> data(static_cast<std::string const*>(rawData));
+      m_indexMaps[token.containerName()].insert(std::make_pair(*data, entry));
       entry++;
     }
   }

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -1241,26 +1241,19 @@ static PyObject* sc_provide(py_phlex_source* src, PyObject* args, PyObject* kwds
   // is fixed, so there is no combinatorics problem.
   std::string const& out_type = output_types[0];
   if (out_type == "bool") {
-    auto* pyc = new provider_cb_bool{callable};
-    src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+    src->ph_source->provide(functor_name, provider_cb_bool{callable}).output_product(opq.value());
   } else if (out_type == "int32_t") {
-    auto* pyc = new provider_cb_int{callable};
-    src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+    src->ph_source->provide(functor_name, provider_cb_int{callable}).output_product(opq.value());
   } else if (out_type == "uint32_t") {
-    auto* pyc = new provider_cb_uint{callable};
-    src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+    src->ph_source->provide(functor_name, provider_cb_uint{callable}).output_product(opq.value());
   } else if (out_type == "int64_t") {
-    auto* pyc = new provider_cb_long{callable};
-    src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+    src->ph_source->provide(functor_name, provider_cb_long{callable}).output_product(opq.value());
   } else if (out_type == "uint64_t") {
-    auto* pyc = new provider_cb_ulong{callable};
-    src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+    src->ph_source->provide(functor_name, provider_cb_ulong{callable}).output_product(opq.value());
   } else if (out_type == "float") {
-    auto* pyc = new provider_cb_float{callable};
-    src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+    src->ph_source->provide(functor_name, provider_cb_float{callable}).output_product(opq.value());
   } else if (out_type == "double") {
-    auto* pyc = new provider_cb_double{callable};
-    src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+    src->ph_source->provide(functor_name, provider_cb_double{callable}).output_product(opq.value());
   } else if (out_type.compare(0, 7, "ndarray") == 0 || out_type.compare(0, 4, "list") == 0) {
     // TODO: just like for input types, these are hard-coded, but should be handled by
     // an IDL instead.
@@ -1270,23 +1263,22 @@ static PyObject* sc_provide(py_phlex_source* src, PyObject* args, PyObject* kwds
       return nullptr;
     }
     if (*dtype == "[int32_t]") {
-      auto* pyc = new provider_cb_vint{callable};
-      src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+      src->ph_source->provide(functor_name, provider_cb_vint{callable}).output_product(opq.value());
     } else if (*dtype == "[uint32_t]") {
-      auto* pyc = new provider_cb_vuint{callable};
-      src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+      src->ph_source->provide(functor_name, provider_cb_vuint{callable})
+        .output_product(opq.value());
     } else if (*dtype == "[int64_t]") {
-      auto* pyc = new provider_cb_vlong{callable};
-      src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+      src->ph_source->provide(functor_name, provider_cb_vlong{callable})
+        .output_product(opq.value());
     } else if (*dtype == "[uint64_t]") {
-      auto* pyc = new provider_cb_vulong{callable};
-      src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+      src->ph_source->provide(functor_name, provider_cb_vulong{callable})
+        .output_product(opq.value());
     } else if (*dtype == "[float]") {
-      auto* pyc = new provider_cb_vfloat{callable};
-      src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+      src->ph_source->provide(functor_name, provider_cb_vfloat{callable})
+        .output_product(opq.value());
     } else if (*dtype == "[double]") {
-      auto* pyc = new provider_cb_vdouble{callable};
-      src->ph_source->provide(functor_name, *pyc).output_product(opq.value());
+      src->ph_source->provide(functor_name, provider_cb_vdouble{callable})
+        .output_product(opq.value());
     } else {
       PyErr_Format(PyExc_TypeError, "unsupported collection output type \"%s\"", out_type.c_str());
       return nullptr;

--- a/test/form/CMakeLists.txt
+++ b/test/form/CMakeLists.txt
@@ -2,6 +2,12 @@
 
 if(FORM_USE_ROOT_STORAGE)
   add_subdirectory(data_products)
+
+  find_package(ROOT REQUIRED COMPONENTS Core)
+  add_library(form_test_utils INTERFACE)
+  target_link_libraries(form_test_utils INTERFACE ROOT::Core)
+  target_include_directories(form_test_utils INTERFACE ${PROJECT_SOURCE_DIR})
+
   cet_test(
       WriteVector
       SOURCE
@@ -39,7 +45,9 @@ if(FORM_USE_ROOT_STORAGE)
       toy_tracker.cpp
       LIBRARIES
       form
+      root_storage
       form_test_data_products
+      form_test_utils
       TEST_WORKDIR
       form_root_schema_test
   )
@@ -51,7 +59,9 @@ if(FORM_USE_ROOT_STORAGE)
      form_root_schema_read_test.cpp
      LIBRARIES
      form
+     root_storage
      form_test_data_products_schema_evolution
+     form_test_utils
      DIRTY_WORKDIR
      TEST_WORKDIR
      form_root_schema_test
@@ -100,5 +110,6 @@ target_include_directories(form_basics_test PRIVATE ${PROJECT_SOURCE_DIR}/form)
 cet_test(form_storage_test USE_CATCH2_MAIN SOURCE form_storage_test.cpp LIBRARIES
          root_storage
          storage
+         form_test_utils
 )
 target_include_directories(form_storage_test PRIVATE ${PROJECT_SOURCE_DIR}/form)

--- a/test/form/CMakeLists.txt
+++ b/test/form/CMakeLists.txt
@@ -21,7 +21,6 @@ if(FORM_USE_ROOT_STORAGE)
       SOURCE
       reader.cpp
       LIBRARIES
-      Microsoft.GSL::GSL
       form
       form_test_data_products
       TEST_ARGS

--- a/test/form/CMakeLists.txt
+++ b/test/form/CMakeLists.txt
@@ -21,6 +21,7 @@ if(FORM_USE_ROOT_STORAGE)
       SOURCE
       reader.cpp
       LIBRARIES
+      Microsoft.GSL::GSL
       form
       form_test_data_products
       TEST_ARGS

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -2,6 +2,9 @@
 
 #include "test/form/test_utils.hpp"
 
+#include "TFile.h"
+#include "TTree.h"
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <cmath>
@@ -110,4 +113,248 @@ TEST_CASE("FORM Container setup error handling")
     CHECK_THROWS_AS(readContainer->setFile(wrongFile), std::runtime_error);
     CHECK_THROWS_AS(writeContainer->setFile(wrongFile), std::runtime_error);
   }
+}
+
+// ============================================================
+// Helpers for fundamental scalar type round-trip tests.
+//
+// test_utils.hpp uses TClass::GetClass<T>(), which returns nullptr
+// for fundamental types (int, float, etc.), so we bypass it and write
+// branches directly via the ROOT API with an explicit leaf-type character.
+// This guarantees the on-disk EDataType matches the switch case we intend
+// to exercise in root_tbranch_read_container.cpp::read().
+// ============================================================
+namespace {
+  char const* const kFundTestTree = "FundTestTree";
+
+  template <typename T>
+  void writeFundamentalDirect(std::string const& fileName,
+                              std::string const& branchName,
+                              std::string const& leafSpec,
+                              T value)
+  {
+    TFile f(fileName.c_str(), "RECREATE");
+    TTree t(kFundTestTree, kFundTestTree);
+    T val = value;
+    t.Branch(branchName.c_str(), &val, (branchName + leafSpec).c_str());
+    t.Fill();
+    f.Write();
+  }
+
+  template <typename T>
+  std::unique_ptr<T const> readFundamental(std::string const& fileName,
+                                           std::string const& branchName)
+  {
+    auto const technology = form::technology::ROOT_TTREE;
+    auto file = createFile(technology, fileName, 'i');
+    auto container = createReadContainer(technology, std::string(kFundTestTree) + "/" + branchName);
+    container->setFile(file);
+    void const* rawPtr = nullptr;
+    if (!container->read(0, &rawPtr, typeid(T)))
+      return nullptr;
+    return std::unique_ptr<T const>(static_cast<T const*>(rawPtr));
+  }
+} // namespace
+
+// The switch in root_tbranch_read_container.cpp::read() handles all 13 ROOT
+// fundamental EDataType values. Each SECTION below exercises one distinct case
+// by writing a branch with the matching ROOT leaf-type character and reading it
+// back through the FORM read container.
+//
+// The switch's `default:` branch is a defensive guard against future ROOT
+// EDataType values not yet in the enumeration; it is not reachable with the
+// current ROOT release and is therefore not tested here.
+TEST_CASE("Root branch read: fundamental scalar types round-trip", "[form]")
+{
+  SECTION("Char_t — kChar_t, leaf type /B")
+  {
+    Char_t const expected = 42;
+    writeFundamentalDirect<Char_t>("fund_char.root", "val", "/B", expected);
+    auto result = readFundamental<Char_t>("fund_char.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("UChar_t — kUChar_t, leaf type /b")
+  {
+    UChar_t const expected = 200;
+    writeFundamentalDirect<UChar_t>("fund_uchar.root", "val", "/b", expected);
+    auto result = readFundamental<UChar_t>("fund_uchar.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("Short_t — kShort_t, leaf type /S")
+  {
+    Short_t const expected = -1000;
+    writeFundamentalDirect<Short_t>("fund_short.root", "val", "/S", expected);
+    auto result = readFundamental<Short_t>("fund_short.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("UShort_t — kUShort_t, leaf type /s")
+  {
+    UShort_t const expected = 60000;
+    writeFundamentalDirect<UShort_t>("fund_ushort.root", "val", "/s", expected);
+    auto result = readFundamental<UShort_t>("fund_ushort.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("Int_t — kInt_t, leaf type /I")
+  {
+    Int_t const expected = -42000;
+    writeFundamentalDirect<Int_t>("fund_int.root", "val", "/I", expected);
+    auto result = readFundamental<Int_t>("fund_int.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("UInt_t — kUInt_t, leaf type /i")
+  {
+    UInt_t const expected = 3000000000u;
+    writeFundamentalDirect<UInt_t>("fund_uint.root", "val", "/i", expected);
+    auto result = readFundamental<UInt_t>("fund_uint.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("Long_t — kLong_t, leaf type /G")
+  {
+    Long_t const expected = -9000000000L;
+    writeFundamentalDirect<Long_t>("fund_long.root", "val", "/G", expected);
+    auto result = readFundamental<Long_t>("fund_long.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("ULong_t — kULong_t, leaf type /g")
+  {
+    ULong_t const expected = 9000000000UL;
+    writeFundamentalDirect<ULong_t>("fund_ulong.root", "val", "/g", expected);
+    auto result = readFundamental<ULong_t>("fund_ulong.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("Long64_t — kLong64_t, leaf type /L")
+  {
+    Long64_t const expected = -4000000000LL;
+    writeFundamentalDirect<Long64_t>("fund_long64.root", "val", "/L", expected);
+    auto result = readFundamental<Long64_t>("fund_long64.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("ULong64_t — kULong64_t, leaf type /l")
+  {
+    ULong64_t const expected = 8000000000ULL;
+    writeFundamentalDirect<ULong64_t>("fund_ulong64.root", "val", "/l", expected);
+    auto result = readFundamental<ULong64_t>("fund_ulong64.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("Float_t — kFloat_t, leaf type /F")
+  {
+    Float_t const expected = 3.14f;
+    writeFundamentalDirect<Float_t>("fund_float.root", "val", "/F", expected);
+    auto result = readFundamental<Float_t>("fund_float.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("Double_t — kDouble_t, leaf type /D")
+  {
+    Double_t const expected = 2.718281828;
+    writeFundamentalDirect<Double_t>("fund_double.root", "val", "/D", expected);
+    auto result = readFundamental<Double_t>("fund_double.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+
+  SECTION("Bool_t — kBool_t, leaf type /O")
+  {
+    Bool_t const expected = true;
+    writeFundamentalDirect<Bool_t>("fund_bool.root", "val", "/O", expected);
+    auto result = readFundamental<Bool_t>("fund_bool.root", "val");
+    REQUIRE(result != nullptr);
+    CHECK(*result == expected);
+  }
+}
+
+TEST_CASE("Root branch read: returns false when id exceeds entry count", "[form]")
+{
+  int const technology = form::technology::ROOT_TTREE;
+  std::vector<int> data = {1, 2, 3};
+  form::test::write(technology, data);
+
+  auto file = createFile(technology, form::test::testFileName, 'i');
+  auto container =
+    createReadContainer(technology, form::test::makeTestBranchName<std::vector<int>>());
+  container->setFile(file);
+  void const* rawPtr = nullptr;
+
+  // One entry exists (id 0). id=2 strictly exceeds GetEntries()==1.
+  CHECK_FALSE(container->read(2, &rawPtr, typeid(std::vector<int>)));
+}
+
+TEST_CASE("Root branch read: throws when the named tree is absent from the file", "[form]")
+{
+  int const technology = form::technology::ROOT_TTREE;
+  std::vector<int> data = {42};
+  form::test::write(technology, data);
+
+  auto file = createFile(technology, form::test::testFileName, 'i');
+  auto container = createReadContainer(technology, "NonExistentTree/someBranch");
+  container->setFile(file);
+  void const* rawPtr = nullptr;
+  CHECK_THROWS_AS(container->read(0, &rawPtr, typeid(std::vector<int>)), std::runtime_error);
+}
+
+TEST_CASE("Root branch read: throws when the named branch is absent from the tree", "[form]")
+{
+  int const technology = form::technology::ROOT_TTREE;
+  std::vector<int> data = {42};
+  form::test::write(technology, data);
+
+  auto file = createFile(technology, form::test::testFileName, 'i');
+  auto container =
+    createReadContainer(technology, std::string(form::test::testTreeName) + "/NonExistentBranch");
+  container->setFile(file);
+  void const* rawPtr = nullptr;
+  CHECK_THROWS_AS(container->read(0, &rawPtr, typeid(std::vector<int>)), std::runtime_error);
+}
+
+TEST_CASE("Root branch read: throws for a type with no ROOT dictionary", "[form]")
+{
+  // A locally-defined struct has no ROOT reflection dictionary.
+  // TDictionary::GetDictionary(typeid(LocalType)) returns nullptr, which
+  // exercises the "unsupported type" error path in read().
+  struct LocalType {};
+
+  int const technology = form::technology::ROOT_TTREE;
+  std::vector<int> data = {42};
+  form::test::write(technology, data);
+
+  auto file = createFile(technology, form::test::testFileName, 'i');
+  auto container =
+    createReadContainer(technology, form::test::makeTestBranchName<std::vector<int>>());
+  container->setFile(file);
+  void const* rawPtr = nullptr;
+  CHECK_THROWS_AS(container->read(0, &rawPtr, typeid(LocalType)), std::runtime_error);
+}
+
+TEST_CASE("Root TTree write container: fill and commit are not implemented", "[form]")
+{
+  int const technology = form::technology::ROOT_TTREE;
+  auto file = createFile(technology, "testTTreeWriteOps.root", 'o');
+  auto writeAssoc = createWriteAssociation(technology, "testTTreeWriteOpsTree");
+  writeAssoc->setFile(file);
+  writeAssoc->setupWrite();
+
+  void const* dummy = nullptr;
+  CHECK_THROWS_AS(writeAssoc->fill(dummy), std::runtime_error);
+  CHECK_THROWS_AS(writeAssoc->commit(), std::runtime_error);
 }

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -7,7 +7,6 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <cmath>
 #include <numeric>
 #include <vector>
 
@@ -37,11 +36,7 @@ TEST_CASE("Storage_Container sharing an Association", "[form]")
 
   auto [piResult, indexResult] = form::test::read<std::vector<float>, std::string>(technology);
 
-  float const originalSum = std::accumulate(piData.begin(), piData.end(), 0.f);
-  float const readSum = std::accumulate(piResult->begin(), piResult->end(), 0.f);
-  float const floatDiff = readSum - originalSum;
-
-  SECTION("float container sum") { CHECK(fabs(floatDiff) < std::numeric_limits<float>::epsilon()); }
+  SECTION("float container") { CHECK(*piResult == piData); }
 
   SECTION("index") { CHECK(*indexResult == indexData); }
 }
@@ -59,21 +54,9 @@ TEST_CASE("Storage_Container multiple containers in Association", "[form]")
   auto [piResult, magicResult, indexResult] =
     form::test::read<std::vector<float>, std::vector<int>, std::string>(technology);
 
-  SECTION("float container")
-  {
-    float const originalSum = std::accumulate(piData.begin(), piData.end(), 0.f);
-    float const readSum = std::accumulate(piResult->begin(), piResult->end(), 0.f);
-    float const floatDiff = readSum - originalSum;
-    CHECK(fabs(floatDiff) < std::numeric_limits<float>::epsilon());
-  }
+  SECTION("float container") { CHECK(*piResult == piData); }
 
-  SECTION("int container")
-  {
-    int const originalMagic = std::accumulate(magicData.begin(), magicData.end(), 0);
-    int const readMagic = std::accumulate(magicResult->begin(), magicResult->end(), 0);
-    int const magicDiff = readMagic - originalMagic;
-    CHECK(magicDiff == 0);
-  }
+  SECTION("int container") { CHECK(*magicResult == magicData); }
 
   SECTION("index data") { CHECK(*indexResult == indexData); }
 }

--- a/test/form/reader.cpp
+++ b/test/form/reader.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <format>
 #include <fstream>
+#include <gsl/pointers>
 #include <map>
 #include <sstream>
 #include <utility>
@@ -80,11 +81,11 @@ int main(int argc, char** argv)
   for (int nevent = 0; nevent < NUMBER_EVENT; nevent++) {
     std::cout << "PHLEX: Read Event No. " << nevent << '\n';
 
-    std::vector<float> const* track_x = nullptr;
+    gsl::owner<std::vector<float> const*> track_x = nullptr;
 
     for (int nseg = 0; nseg < NUMBER_SEGMENT; nseg++) {
 
-      std::vector<float> const* track_start_x = nullptr;
+      gsl::owner<std::vector<float> const*> track_start_x = nullptr;
       std::string const seg_id_text = std::format("[EVENT={:08X};SEG={:08X}]", nevent, nseg);
 
       std::string const& segment_id = seg_id_text;
@@ -95,24 +96,24 @@ int main(int argc, char** argv)
         "trackStart", track_start_x, &typeid(std::vector<float>)};
 
       form.read(creator, segment_id, pb);
-      track_start_x =
-        static_cast<std::vector<float> const*>(pb.data); //FIXME: Can this be done by FORM?
+      track_start_x = static_cast<gsl::owner<std::vector<float> const*>>(
+        pb.data); //FIXME: Can this be done by FORM?
 
-      std::vector<int> const* track_n_hits = nullptr;
+      gsl::owner<std::vector<int> const*> track_n_hits = nullptr;
 
       form::experimental::product_with_name pb_int = {
         "trackNumberHits", track_n_hits, &typeid(std::vector<int>)};
 
       form.read(creator, segment_id, pb_int);
-      track_n_hits = static_cast<std::vector<int> const*>(pb_int.data);
+      track_n_hits = static_cast<gsl::owner<std::vector<int> const*>>(pb_int.data);
 
-      std::vector<TrackStart> const* start_points = nullptr;
+      gsl::owner<std::vector<TrackStart> const*> start_points = nullptr;
 
       form::experimental::product_with_name pb_points = {
         "trackStartPoints", start_points, &typeid(std::vector<TrackStart>)};
 
       form.read(creator, segment_id, pb_points);
-      start_points = static_cast<std::vector<TrackStart> const*>(pb_points.data);
+      start_points = static_cast<gsl::owner<std::vector<TrackStart> const*>>(pb_points.data);
 
       float check = 0.0;
       for (float val : *track_start_x)
@@ -167,7 +168,8 @@ int main(int argc, char** argv)
       "trackStartX", track_x, &typeid(std::vector<float>)};
 
     form.read(creator, event_id, pb);
-    track_x = static_cast<std::vector<float> const*>(pb.data); //FIXME: Can this be done by FORM?
+    track_x = static_cast<gsl::owner<std::vector<float> const*>>(
+      pb.data); //FIXME: Can this be done by FORM?
 
     float check = 0.0;
     for (float val : *track_x)

--- a/test/form/reader.cpp
+++ b/test/form/reader.cpp
@@ -8,8 +8,8 @@
 #include <cmath>
 #include <format>
 #include <fstream>
-#include <gsl/pointers>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <utility>
 #include <vector>
@@ -81,11 +81,11 @@ int main(int argc, char** argv)
   for (int nevent = 0; nevent < NUMBER_EVENT; nevent++) {
     std::cout << "PHLEX: Read Event No. " << nevent << '\n';
 
-    gsl::owner<std::vector<float> const*> track_x = nullptr;
+    std::unique_ptr<std::vector<float> const> track_x;
 
     for (int nseg = 0; nseg < NUMBER_SEGMENT; nseg++) {
 
-      gsl::owner<std::vector<float> const*> track_start_x = nullptr;
+      void const* rawPtr = nullptr;
       std::string const seg_id_text = std::format("[EVENT={:08X};SEG={:08X}]", nevent, nseg);
 
       std::string const& segment_id = seg_id_text;
@@ -93,27 +93,27 @@ int main(int argc, char** argv)
       std::string const creator = "Toy_Tracker";
 
       form::experimental::product_with_name pb = {
-        "trackStart", track_start_x, &typeid(std::vector<float>)};
+        "trackStart", rawPtr, &typeid(std::vector<float>)};
 
       form.read(creator, segment_id, pb);
-      track_start_x = static_cast<gsl::owner<std::vector<float> const*>>(
-        pb.data); //FIXME: Can this be done by FORM?
+      std::unique_ptr<std::vector<float> const> track_start_x(
+        static_cast<std::vector<float> const*>(pb.data));
 
-      gsl::owner<std::vector<int> const*> track_n_hits = nullptr;
-
+      rawPtr = nullptr;
       form::experimental::product_with_name pb_int = {
-        "trackNumberHits", track_n_hits, &typeid(std::vector<int>)};
+        "trackNumberHits", rawPtr, &typeid(std::vector<int>)};
 
       form.read(creator, segment_id, pb_int);
-      track_n_hits = static_cast<gsl::owner<std::vector<int> const*>>(pb_int.data);
+      std::unique_ptr<std::vector<int> const> track_n_hits(
+        static_cast<std::vector<int> const*>(pb_int.data));
 
-      gsl::owner<std::vector<TrackStart> const*> start_points = nullptr;
-
+      rawPtr = nullptr;
       form::experimental::product_with_name pb_points = {
-        "trackStartPoints", start_points, &typeid(std::vector<TrackStart>)};
+        "trackStartPoints", rawPtr, &typeid(std::vector<TrackStart>)};
 
       form.read(creator, segment_id, pb_points);
-      start_points = static_cast<gsl::owner<std::vector<TrackStart> const*>>(pb_points.data);
+      std::unique_ptr<std::vector<TrackStart> const> start_points(
+        static_cast<std::vector<TrackStart> const*>(pb_points.data));
 
       float check = 0.0;
       for (float val : *track_start_x)
@@ -151,10 +151,6 @@ int main(int argc, char** argv)
                   << '\n';
         all_passed = false;
       }
-
-      delete track_start_x;
-      delete track_n_hits;
-      delete start_points;
     }
     std::cout << "PHLEX: Read Event segments done " << nevent << '\n';
 
@@ -164,12 +160,12 @@ int main(int argc, char** argv)
 
     std::string const creator = "Toy_Tracker_Event";
 
+    void const* rawEvtPtr = nullptr;
     form::experimental::product_with_name pb = {
-      "trackStartX", track_x, &typeid(std::vector<float>)};
+      "trackStartX", rawEvtPtr, &typeid(std::vector<float>)};
 
     form.read(creator, event_id, pb);
-    track_x = static_cast<gsl::owner<std::vector<float> const*>>(
-      pb.data); //FIXME: Can this be done by FORM?
+    track_x.reset(static_cast<std::vector<float> const*>(pb.data));
 
     float check = 0.0;
     for (float val : *track_x)
@@ -192,8 +188,6 @@ int main(int argc, char** argv)
       std::cerr << "VERIFY FAIL: no expected checksum for event=" << nevent << '\n';
       all_passed = false;
     }
-
-    delete track_x; //FIXME: PHLEX owns this memory!
 
     std::cout << "PHLEX: Read Event done " << nevent << '\n';
   }

--- a/test/form/test_utils.hpp
+++ b/test/form/test_utils.hpp
@@ -82,13 +82,12 @@ namespace form::test {
   {
     auto container = createReadContainer(technology, makeTestBranchName<PROD>());
     container->setFile(file);
-    void const* dataPtr = new PROD();
-    void const** dataPtrPtr = &dataPtr;
+    void const* rawPtr = nullptr;
 
-    if (!container->read(0, dataPtrPtr, typeid(PROD)))
+    if (!container->read(0, &rawPtr, typeid(PROD)))
       throw std::runtime_error("Failed to read a " + getTypeName<PROD>());
 
-    return std::unique_ptr<PROD const>(static_cast<PROD const*>(dataPtr));
+    return std::unique_ptr<PROD const>(static_cast<PROD const*>(rawPtr));
   }
 
   template <class... PRODS>


### PR DESCRIPTION
- **Follow C++ Core Guidelines for owning pointers when demangling symbols**
- **Follow C++ Core Guidelines in `test/form/reader.cpp`**
- **Avoid unnecessary (and likely problematic) `new()` in `doRead()`**
- **Clarify and simplify `getIndex()` while avoiding raw `delete`**
- **Qualify linkage as explicity `PUBLIC`**
- **Avoid unnecessary (and likely problematic) `new()` operations**
- **Use `unique_ptr` with a custom deleter for clarity and consistency**
- **Follow C++ Core Guidelines for owning pointers**
