### PR TITLE
`clang-tidy`: resolve `cppcoreguidelines-pro-bounds-avoid-unchecked-container-access`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-non-private-member-variables-in-classes,

--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -61,7 +61,9 @@
 - [x] [cppcoreguidelines-noexcept-move-operations](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/noexcept-move-operations.html) (8)
   - [PR #549](https://github.com/Framework-R-D/phlex/pull/549)
 - [ ] [cppcoreguidelines-owning-memory](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/owning-memory.html) (28)
-- [ ] [cppcoreguidelines-pro-bounds-avoid-unchecked-container-access](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.html) (113)
+- [x] [cppcoreguidelines-pro-bounds-avoid-unchecked-container-access](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.html) (113)
+  - [PR #553](https://github.com/Framework-R-D/phlex/pull/553) (partial)
+  - Disable check going forward.
 - [ ] [cppcoreguidelines-pro-type-const-cast](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-const-cast.html) (1)
 - [ ] [cppcoreguidelines-pro-type-cstyle-cast](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.html) (62)
 - [ ] [cppcoreguidelines-pro-type-member-init](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.html) (15)

--- a/phlex/core/detail/filter_impl.cpp
+++ b/phlex/core/detail/filter_impl.cpp
@@ -79,12 +79,11 @@ namespace phlex::experimental {
     }
 
     // Fill slots in the order of the input arguments to the downstream node.
-    for (auto ip_it = input_products_->cbegin(); auto& e : elem) {
-      auto const& ip = *ip_it++;
-      if (e or not resolve_in_store(ip, *store)) {
+    for (std::size_t i = 0; i != nargs_; ++i) {
+      if (elem[i] or not resolve_in_store((*input_products_)[i], *store)) {
         continue;
       }
-      e = store;
+      elem[i] = store;
     }
   }
 

--- a/phlex/core/detail/filter_impl.cpp
+++ b/phlex/core/detail/filter_impl.cpp
@@ -79,11 +79,12 @@ namespace phlex::experimental {
     }
 
     // Fill slots in the order of the input arguments to the downstream node.
-    for (std::size_t i = 0; i != nargs_; ++i) {
-      if (elem[i] or not resolve_in_store((*input_products_)[i], *store)) {
+    for (auto ip_it = input_products_->cbegin(); auto& e : elem) {
+      auto const& ip = *ip_it++;
+      if (e or not resolve_in_store(ip, *store)) {
         continue;
       }
-      elem[i] = store;
+      e = store;
     }
   }
 

--- a/phlex/core/filter.cpp
+++ b/phlex/core/filter.cpp
@@ -6,6 +6,7 @@
 #include "oneapi/tbb/flow_graph.h"
 
 #include <cassert>
+#include <ranges>
 
 using namespace phlex::experimental;
 using namespace oneapi::tbb;
@@ -69,8 +70,8 @@ namespace phlex::experimental {
       if (empty(stores)) {
         return {};
       }
-      for (std::size_t i = 0ull; i != nargs_; ++i) {
-        downstream_ports_[i]->try_put({stores[i], msg_id});
+      for (auto const& [port, store] : std::views::zip(downstream_ports_, stores)) {
+        port->try_put({store, msg_id});
       }
       // Decision must be erased while access is claimed
       decisions_.erase(a);

--- a/phlex/core/multilayer_join_node.hpp
+++ b/phlex/core/multilayer_join_node.hpp
@@ -7,6 +7,7 @@
 #include "oneapi/tbb/flow_graph.h"
 
 #include <cassert>
+#include <ranges>
 #include <set>
 #include <string>
 #include <utility>
@@ -109,8 +110,8 @@ namespace phlex::experimental {
     {
       std::vector<named_index_port> result;
       result.reserve(repeaters_.size());
-      for (std::size_t i = 0; i != repeaters_.size(); ++i) {
-        result.emplace_back(layers_[i], &repeaters_[i]->flush_port(), &repeaters_[i]->index_port());
+      for (auto const& [layer, repeater] : std::views::zip(layers_, repeaters_)) {
+        result.emplace_back(layer, &repeater->flush_port(), &repeater->index_port());
       }
       return result;
     }

--- a/phlex/model/data_cell_index.cpp
+++ b/phlex/model/data_cell_index.cpp
@@ -25,8 +25,8 @@ namespace {
 
     auto const* current = &id;
     std::vector<std::size_t> result(id.depth());
-    for (std::size_t i = id.depth(); i > 0; --i) {
-      result[i - 1] = current->number();
+    for (auto& r : result | std::views::reverse) {
+      r = current->number();
       current = current->parent().get();
     }
     return result;

--- a/phlex/model/product_matcher.cpp
+++ b/phlex/model/product_matcher.cpp
@@ -45,12 +45,13 @@ namespace phlex::experimental {
   {
   }
 
-  product_matcher::product_matcher(std::array<std::string, 4u> fields) :
-    layer_path_{std::move(fields[0])},
-    module_name_{std::move(fields[1])},
-    node_name_{std::move(fields[2])},
-    product_name_{std::move(fields[3])}
+  product_matcher::product_matcher(std::array<std::string, 4u> fields)
   {
+    auto& [lp, mn, nn, pn] = fields;
+    layer_path_ = std::move(lp);
+    module_name_ = std::move(mn);
+    node_name_ = std::move(nn);
+    product_name_ = std::move(pn);
   }
 
   std::string product_matcher::encode() const

--- a/plugins/layer_generator.cpp
+++ b/plugins/layer_generator.cpp
@@ -76,6 +76,7 @@ namespace phlex::experimental {
   {
     // First check if layer paths need to be rebased
     std::vector<size_t> indices_for_rebasing;
+    // We can use std::views::enumerate once the AppleClang C++ STL supports it.
     for (std::size_t i = 0ull, n = layer_paths_.size(); i != n; ++i) {
       auto const& layer = layer_paths_[i];
       if (layer.starts_with("/" + layer_name)) {

--- a/plugins/python/src/configwrap.cpp
+++ b/plugins/python/src/configwrap.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <optional>
+#include <ranges>
 #include <string>
 
 #include "phlex/configuration.hpp"

--- a/plugins/python/src/configwrap.cpp
+++ b/plugins/python/src/configwrap.cpp
@@ -94,6 +94,7 @@ static PyObject* pcm_subscript(py_config_map* pycmap, PyObject* pykey)
         if (!cvalue_size)
           return nullptr;
         pyvalue = PyTuple_New(*cvalue_size);
+        // We can use std::views::enumerate once the AppleClang C++ STL supports it.
         for (Py_ssize_t i = 0; i < *cvalue_size; ++i) {
           PyObject* item = PyLong_FromLong((long)cvalue[i]);
           PyTuple_SetItem(pyvalue, i, item);
@@ -104,6 +105,7 @@ static PyObject* pcm_subscript(py_config_map* pycmap, PyObject* pykey)
         if (!cvalue_size)
           return nullptr;
         pyvalue = PyTuple_New(*cvalue_size);
+        // We can use std::views::enumerate once the AppleClang C++ STL supports it.
         for (Py_ssize_t i = 0; i < *cvalue_size; ++i) {
           // Note Python3.14 is expected to add PyLong_FromInt64
           PyObject* item = PyLong_FromLongLong(cvalue[i]);
@@ -115,6 +117,7 @@ static PyObject* pcm_subscript(py_config_map* pycmap, PyObject* pykey)
         if (!cvalue_size)
           return nullptr;
         pyvalue = PyTuple_New(*cvalue_size);
+        // We can use std::views::enumerate once the AppleClang C++ STL supports it.
         for (Py_ssize_t i = 0; i < *cvalue_size; ++i) {
           // Note Python3.14 is expected to add PyLong_FromUInt64
           PyObject* item = PyLong_FromUnsignedLongLong(cvalue[i]);
@@ -126,6 +129,7 @@ static PyObject* pcm_subscript(py_config_map* pycmap, PyObject* pykey)
         if (!cvalue_size)
           return nullptr;
         pyvalue = PyTuple_New(*cvalue_size);
+        // We can use std::views::enumerate once the AppleClang C++ STL supports it.
         for (Py_ssize_t i = 0; i < *cvalue_size; ++i) {
           PyObject* item = PyFloat_FromDouble(cvalue[i]);
           PyTuple_SetItem(pyvalue, i, item);
@@ -136,6 +140,7 @@ static PyObject* pcm_subscript(py_config_map* pycmap, PyObject* pykey)
         if (!cvalue_size)
           return nullptr;
         pyvalue = PyTuple_New(*cvalue_size);
+        // We can use std::views::enumerate once the AppleClang C++ STL supports it.
         for (Py_ssize_t i = 0; i < *cvalue_size; ++i) {
           PyObject* item =
             PyUnicode_FromStringAndSize(cvalue[i].c_str(), (Py_ssize_t)cvalue[i].size());
@@ -148,6 +153,7 @@ static PyObject* pcm_subscript(py_config_map* pycmap, PyObject* pykey)
         if (!cvalue_size)
           return nullptr;
         pyvalue = PyTuple_New(*cvalue_size);
+        // We can use std::views::enumerate once the AppleClang C++ STL supports it.
         for (Py_ssize_t i = 0; i < *cvalue_size; ++i) {
           PyObject* item = PyDict_New();
           for (auto const& kv : cvalue[i]) {

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -780,11 +780,10 @@ static bool insert_input_converters(py_phlex_module* mod,
                                     std::vector<std::string> const& input_types)
 {
   // insert input converter nodes into the graph
-  for (size_t i = 0; i < (size_t)input_queries.size(); ++i) {
+  for (auto const [i, inp_pq, inp_type] :
+       std::views::zip(std::views::iota(size_t{}), input_queries, input_types)) {
     // TODO: this seems overly verbose and inefficient, but the function needs
     // to be properly types, so every option is made explicit
-    auto const& inp_pq = input_queries[i];
-    auto const& inp_type = input_types[i];
 
     std::string const& pyname = input_converter_name(cname, i);
     std::string output =
@@ -914,8 +913,8 @@ static PyObject* md_transform(py_phlex_module* mod, PyObject* args, PyObject* kw
   // all the same, so for now, simply raise an error if their is any ambiguity
   auto output_layer = static_cast<identifier>(input_queries[0].layer);
   if (1 < input_queries.size()) {
-    for (std::vector<product_query>::size_type iq = 1; iq < input_queries.size(); ++iq) {
-      if (static_cast<identifier>(input_queries[iq].layer) != output_layer) {
+    for (auto const& iq_pq : input_queries | std::views::drop(1)) {
+      if (static_cast<identifier>(iq_pq.layer) != output_layer) {
         PyErr_Format(PyExc_ValueError, "transform %s output layer is ambiguous", cname.c_str());
         Py_DECREF(callable);
         return nullptr;

--- a/test/form/toy_tracker.cpp
+++ b/test/form/toy_tracker.cpp
@@ -1,6 +1,7 @@
 #include "toy_tracker.hpp"
 #include "data_products/track_start.hpp"
 
+#include <algorithm>
 #include <cstdlib>
 
 ToyTracker::ToyTracker(int maxTracks) : m_maxTracks(maxTracks) {}
@@ -8,13 +9,13 @@ ToyTracker::ToyTracker(int maxTracks) : m_maxTracks(maxTracks) {}
 std::vector<TrackStart> ToyTracker::operator()()
 {
   int32_t const npx = generateRandom() % m_maxTracks;
-  std::vector<TrackStart> points(npx);
-  for (int nelement = 0; nelement < npx; ++nelement) {
-    points[nelement] =
-      TrackStart(static_cast<float>(generateRandom()) / static_cast<float>(random_max),
-                 static_cast<float>(generateRandom()) / static_cast<float>(random_max),
-                 static_cast<float>(generateRandom()) / static_cast<float>(random_max));
-  }
+  std::vector<TrackStart> points;
+  points.reserve(npx);
+  std::generate_n(std::back_inserter(points), npx, [this] {
+    return TrackStart(static_cast<float>(generateRandom()) / static_cast<float>(random_max),
+                      static_cast<float>(generateRandom()) / static_cast<float>(random_max),
+                      static_cast<float>(generateRandom()) / static_cast<float>(random_max));
+  });
 
   return points;
 }

--- a/test/type_distinction.cpp
+++ b/test/type_distinction.cpp
@@ -8,6 +8,7 @@
 
 #include "catch2/catch_test_macros.hpp"
 
+#include <ranges>
 #include <tuple>
 #include <vector>
 
@@ -30,11 +31,9 @@ namespace {
   auto add_vectors(std::vector<int> const& x, std::vector<int> const& y)
   {
     std::vector<int> res;
-    std::size_t const len = std::min(x.size(), y.size());
-
-    res.reserve(len);
-    for (std::size_t i = 0; i < len; ++i) {
-      res.push_back(x[i] + y[i]);
+    res.reserve(std::min(x.size(), y.size()));
+    for (auto const [xi, yi] : std::views::zip(x, y)) {
+      res.push_back(xi + yi);
     }
     return res;
   }


### PR DESCRIPTION
- **Use `front()` for first element access**
- **Use ranges/range-for to replace unchecked access**
- **Use structured bindings/`generate_n()` to replace unchecked access**
- **Ignore associative element access**
- **Use `at()` to replace unchecked access**
