### PR TITLE
`clang-tidy`: resolve `cppguidelines-pro-type-*cast*`

### DIFF
--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -66,11 +66,19 @@
 - [x] [cppcoreguidelines-pro-bounds-avoid-unchecked-container-access](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.html) (113)
   - [PR #553](https://github.com/Framework-R-D/phlex/pull/553) (partial)
   - Disable check going forward.
-- [ ] [cppcoreguidelines-pro-type-const-cast](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-const-cast.html) (1)
-- [ ] [cppcoreguidelines-pro-type-cstyle-cast](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.html) (62)
+- [x] [cppcoreguidelines-pro-type-const-cast](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-const-cast.html) (1)
+  - [PR #554](https://github.com/Framework-R-D/phlex/pull/554)
+  - Disabled in `form/root_storage/` and `plugins/python/src/` going forward.
+- [x] [cppcoreguidelines-pro-type-reinterpret-cast](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-reinterpret-cast.html) (45)
+  - [PR #554](https://github.com/Framework-R-D/phlex/pull/554)
+  - Disabled in `form/root_storage/` and `plugins/python/src/` going forward.
+- [x] [cppcoreguidelines-pro-type-cstyle-cast](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.html) (62)
+  - [PR #554](https://github.com/Framework-R-D/phlex/pull/554)
+  - Converted to `const_cast` or `reinterpret_cast` as appropriate.
 - [x] [cppcoreguidelines-pro-type-member-init](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.html) (15)
   - [PR #555](https://github.com/Framework-R-D/phlex/pull/554)
-- [ ] [cppcoreguidelines-pro-type-static-cast-downcast](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.html) (1)
+- [x] [cppcoreguidelines-pro-type-static-cast-downcast](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.html) (1)
+  - [PR #554](https://github.com/Framework-R-D/phlex/pull/554)
 - [x] [cppcoreguidelines-pro-type-union-access](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-union-access.html) (1)
   - [PR #557](https://github.com/Framework-R-D/phlex/pull/557)
 - [x] [cppcoreguidelines-pro-type-vararg](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-vararg.html) (29)

--- a/form/root_storage/.clang-tidy
+++ b/form/root_storage/.clang-tidy
@@ -1,0 +1,7 @@
+---
+
+InheritParentConfig: true
+
+Checks: >
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-reinterpret-cast

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -59,7 +59,8 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
   }
 
   if (dictInfo->Property() & EProperty::kIsFundamental) {
-    //Assume this is a fundamental type like int or double
+    // We can avoid a `dynamic_cast` to `TDataType` here after checking EProperty::kIsFundamental
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     auto fundInfo = static_cast<TDataType*>(TDictionary::GetDictionary(type));
     branchBuffer = new char[fundInfo->Size()];
     branchStatus = m_tree->SetBranchAddress(col_name().c_str(),

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -59,9 +59,8 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
   }
 
   if (dictInfo->Property() & EProperty::kIsFundamental) {
-    // We can avoid a `dynamic_cast` to `TDataType` here after checking EProperty::kIsFundamental
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-    auto fundInfo = static_cast<TDataType*>(TDictionary::GetDictionary(type));
+    auto fundInfo = static_cast<TDataType*>(dictInfo); // Already checked to be fundamental
     branchBuffer = new char[fundInfo->Size()];
     branchStatus = m_tree->SetBranchAddress(col_name().c_str(),
                                             reinterpret_cast<void*>(&branchBuffer),

--- a/plugins/python/src/.clang-tidy
+++ b/plugins/python/src/.clang-tidy
@@ -3,4 +3,6 @@
 InheritParentConfig: true
 
 Checks: >
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-vararg

--- a/plugins/python/src/.clang-tidy
+++ b/plugins/python/src/.clang-tidy
@@ -3,6 +3,5 @@
 InheritParentConfig: true
 
 Checks: >
-  -cppcoreguidelines-pro-type-const-cast,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-vararg

--- a/plugins/python/src/configwrap.cpp
+++ b/plugins/python/src/configwrap.cpp
@@ -20,16 +20,16 @@ struct phlex::experimental::py_config_map {
 PyObject* phlex::experimental::wrap_configuration(configuration const& config)
 {
   py_config_map* pyconfig =
-    (py_config_map*)PhlexConfig_Type.tp_new(&PhlexConfig_Type, nullptr, nullptr);
+    reinterpret_cast<py_config_map*>(PhlexConfig_Type.tp_new(&PhlexConfig_Type, nullptr, nullptr));
 
   pyconfig->ph_config = &config;
 
-  return (PyObject*)pyconfig;
+  return reinterpret_cast<PyObject*>(pyconfig);
 }
 
 static py_config_map* pcm_new(PyTypeObject* subtype, PyObject*, PyObject*)
 {
-  py_config_map* pcm = (py_config_map*)subtype->tp_alloc(subtype, 0);
+  py_config_map* pcm = reinterpret_cast<py_config_map*>(subtype->tp_alloc(subtype, 0));
   if (!pcm)
     return nullptr;
 
@@ -41,7 +41,7 @@ static py_config_map* pcm_new(PyTypeObject* subtype, PyObject*, PyObject*)
 static void pcm_dealloc(py_config_map* pcm)
 {
   Py_DECREF(pcm->ph_config_cache);
-  Py_TYPE(pcm)->tp_free((PyObject*)pcm);
+  Py_TYPE(pcm)->tp_free(reinterpret_cast<PyObject*>(pcm));
 }
 
 // Returns the array size as Py_ssize_t, or std::nullopt (and sets a Python
@@ -213,17 +213,18 @@ static PyObject* pcm_subscript(py_config_map* pycmap, PyObject* pykey)
 
 // PyMappingMethods must be non-const; tp_as_mapping in PyTypeObject takes a non-const pointer.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static PyMappingMethods pcm_as_mapping = {nullptr, (binaryfunc)pcm_subscript, nullptr};
+static PyMappingMethods pcm_as_mapping = {
+  nullptr, reinterpret_cast<binaryfunc>(pcm_subscript), nullptr};
 
 // clang-format off
 // PyType_Ready() modifies PyTypeObject in-place; the Python C API requires non-const.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject phlex::experimental::PhlexConfig_Type = {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
-  (char*) "pyphlex.configuration",                   // tp_name
+  const_cast<char*>("pyphlex.configuration"),        // tp_name
   sizeof(py_config_map),                             // tp_basicsize
   0,                                                 // tp_itemsize
-  (destructor)pcm_dealloc,                           // tp_dealloc
+  reinterpret_cast<destructor>(pcm_dealloc),         // tp_dealloc
   0,                                                 // tp_vectorcall_offset / tp_print
   0,                                                 // tp_getattr
   0,                                                 // tp_setattr
@@ -239,7 +240,7 @@ PyTypeObject phlex::experimental::PhlexConfig_Type = {
   0,                                                 // tp_setattro
   0,                                                 // tp_as_buffer
   Py_TPFLAGS_DEFAULT,                                // tp_flags
-  (char*)"phlex configuration object-as-dictionary", // tp_doc
+  const_cast<char*>("phlex configuration object-as-dictionary"), // tp_doc
   0,                                                 // tp_traverse
   0,                                                 // tp_clear
   0,                                                 // tp_richcompare
@@ -256,7 +257,7 @@ PyTypeObject phlex::experimental::PhlexConfig_Type = {
   offsetof(py_config_map, ph_config_cache),          // tp_dictoffset
   0,                                                 // tp_init
   0,                                                 // tp_alloc
-  (newfunc)pcm_new,                                  // tp_new
+  reinterpret_cast<newfunc>(pcm_new),                // tp_new
   0,                                                 // tp_free
   0,                                                 // tp_is_gc
   0,                                                 // tp_bases

--- a/plugins/python/src/configwrap.cpp
+++ b/plugins/python/src/configwrap.cpp
@@ -221,7 +221,7 @@ static PyMappingMethods pcm_as_mapping = {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject phlex::experimental::PhlexConfig_Type = {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
-  const_cast<char*>("pyphlex.configuration"),        // tp_name
+  "pyphlex.configuration",                           // tp_name
   sizeof(py_config_map),                             // tp_basicsize
   0,                                                 // tp_itemsize
   reinterpret_cast<destructor>(pcm_dealloc),         // tp_dealloc
@@ -240,7 +240,7 @@ PyTypeObject phlex::experimental::PhlexConfig_Type = {
   0,                                                 // tp_setattro
   0,                                                 // tp_as_buffer
   Py_TPFLAGS_DEFAULT,                                // tp_flags
-  const_cast<char*>("phlex configuration object-as-dictionary"), // tp_doc
+  "phlex configuration object-as-dictionary",        // tp_doc
   0,                                                 // tp_traverse
   0,                                                 // tp_clear
   0,                                                 // tp_richcompare

--- a/plugins/python/src/dciwrap.cpp
+++ b/plugins/python/src/dciwrap.cpp
@@ -19,7 +19,7 @@ PyObject* phlex::experimental::wrap_dci(data_cell_index const& dci)
   py_data_cell_index* pydci = PyObject_New(py_data_cell_index, &PhlexDataCellIndex_Type);
   pydci->ph_dci = &dci;
 
-  return (PyObject*)pydci;
+  return reinterpret_cast<PyObject*>(pydci);
 }
 
 // simple forwarding methods
@@ -30,16 +30,18 @@ static PyObject* dci_number(py_data_cell_index* pydci)
 
 // PyMethodDef arrays must be non-const; tp_methods in PyTypeObject takes a non-const pointer.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static PyMethodDef dci_methods[] = {
-  {(char*)"number", (PyCFunction)dci_number, METH_NOARGS, (char*)"index number"},
-  {(char*)nullptr, nullptr, 0, nullptr}};
+static PyMethodDef dci_methods[] = {{const_cast<char*>("number"),
+                                     reinterpret_cast<PyCFunction>(dci_number),
+                                     METH_NOARGS,
+                                     const_cast<char*>("index number")},
+                                    {(char*)nullptr, nullptr, 0, nullptr}};
 
 // clang-format off
 // PyType_Ready() modifies PyTypeObject in-place; the Python C API requires non-const.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject phlex::experimental::PhlexDataCellIndex_Type = {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
-  (char*) "pyphlex.data_cell_index",                 // tp_name
+  const_cast<char*>("pyphlex.data_cell_index"),      // tp_name
   sizeof(py_data_cell_index),                        // tp_basicsize
   0,                                                 // tp_itemsize
   0,                                                 // tp_dealloc
@@ -58,7 +60,7 @@ PyTypeObject phlex::experimental::PhlexDataCellIndex_Type = {
   0,                                                 // tp_setattro
   0,                                                 // tp_as_buffer
   Py_TPFLAGS_DEFAULT,                                // tp_flags
-  (char*)"phlex data_cell_index",                    // tp_doc
+  const_cast<char*>("phlex data_cell_index"),        // tp_doc
   0,                                                 // tp_traverse
   0,                                                 // tp_clear
   0,                                                 // tp_richcompare

--- a/plugins/python/src/dciwrap.cpp
+++ b/plugins/python/src/dciwrap.cpp
@@ -30,18 +30,16 @@ static PyObject* dci_number(py_data_cell_index* pydci)
 
 // PyMethodDef arrays must be non-const; tp_methods in PyTypeObject takes a non-const pointer.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static PyMethodDef dci_methods[] = {{const_cast<char*>("number"),
-                                     reinterpret_cast<PyCFunction>(dci_number),
-                                     METH_NOARGS,
-                                     const_cast<char*>("index number")},
-                                    {(char*)nullptr, nullptr, 0, nullptr}};
+static PyMethodDef dci_methods[] = {
+  {"number", reinterpret_cast<PyCFunction>(dci_number), METH_NOARGS, "index number"},
+  {nullptr, nullptr, 0, nullptr}};
 
 // clang-format off
 // PyType_Ready() modifies PyTypeObject in-place; the Python C API requires non-const.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject phlex::experimental::PhlexDataCellIndex_Type = {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
-  const_cast<char*>("pyphlex.data_cell_index"),      // tp_name
+  "pyphlex.data_cell_index",                         // tp_name
   sizeof(py_data_cell_index),                        // tp_basicsize
   0,                                                 // tp_itemsize
   0,                                                 // tp_dealloc
@@ -60,7 +58,7 @@ PyTypeObject phlex::experimental::PhlexDataCellIndex_Type = {
   0,                                                 // tp_setattro
   0,                                                 // tp_as_buffer
   Py_TPFLAGS_DEFAULT,                                // tp_flags
-  const_cast<char*>("phlex data_cell_index"),        // tp_doc
+  "phlex data_cell_index",                           // tp_doc
   0,                                                 // tp_traverse
   0,                                                 // tp_clear
   0,                                                 // tp_richcompare

--- a/plugins/python/src/lifelinewrap.cpp
+++ b/plugins/python/src/lifelinewrap.cpp
@@ -7,7 +7,7 @@ using namespace phlex::experimental;
 
 static py_lifeline_t* ll_new(PyTypeObject* pytype, PyObject*, PyObject*)
 {
-  py_lifeline_t* pyobj = (py_lifeline_t*)pytype->tp_alloc(pytype, 0);
+  py_lifeline_t* pyobj = reinterpret_cast<py_lifeline_t*>(pytype->tp_alloc(pytype, 0));
   if (pyobj) {
     pyobj->m_view = nullptr;
     new (&pyobj->m_source) std::shared_ptr<void>{};
@@ -39,7 +39,7 @@ static void ll_dealloc(py_lifeline_t* pyobj)
   typedef std::shared_ptr<void> generic_shared_t;
   pyobj->m_source.~generic_shared_t();
   // Use tp_free to pair with tp_alloc for GC-tracked Python objects.
-  Py_TYPE(pyobj)->tp_free((PyObject*)pyobj);
+  Py_TYPE(pyobj)->tp_free(reinterpret_cast<PyObject*>(pyobj));
 }
 
 // clang-format off
@@ -47,10 +47,10 @@ static void ll_dealloc(py_lifeline_t* pyobj)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject phlex::experimental::PhlexLifeline_Type = {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
-  (char*) "pyphlex.lifeline",                        // tp_name
+  const_cast<char*>("pyphlex.lifeline"),             // tp_name
   sizeof(py_lifeline_t),                             // tp_basicsize
   0,                                                 // tp_itemsize
-  (destructor)ll_dealloc,                            // tp_dealloc
+  reinterpret_cast<destructor>(ll_dealloc),          // tp_dealloc
   0,                                                 // tp_vectorcall_offset / tp_print
   0,                                                 // tp_getattr
   0,                                                 // tp_setattr
@@ -66,9 +66,9 @@ PyTypeObject phlex::experimental::PhlexLifeline_Type = {
   0,                                                 // tp_setattro
   0,                                                 // tp_as_buffer
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,           // tp_flags
-  (char*)"internal",                                 // tp_doc
-  (traverseproc)ll_traverse,                         // tp_traverse
-  (inquiry)ll_clear,                                 // tp_clear
+  const_cast<char*>("internal"),                     // tp_doc
+  reinterpret_cast<traverseproc>(ll_traverse),       // tp_traverse
+  reinterpret_cast<inquiry>(ll_clear),               // tp_clear
   0,                                                 // tp_richcompare
   0,                                                 // tp_weaklistoffset
   0,                                                 // tp_iter
@@ -83,7 +83,7 @@ PyTypeObject phlex::experimental::PhlexLifeline_Type = {
   0,                                                 // tp_dictoffset
   0,                                                 // tp_init
   0,                                                 // tp_alloc
-  (newfunc)ll_new,                                   // tp_new
+  reinterpret_cast<newfunc>(ll_new),                 // tp_new
   0,                                                 // tp_free
   0,                                                 // tp_is_gc
   0,                                                 // tp_bases

--- a/plugins/python/src/lifelinewrap.cpp
+++ b/plugins/python/src/lifelinewrap.cpp
@@ -47,7 +47,7 @@ static void ll_dealloc(py_lifeline_t* pyobj)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject phlex::experimental::PhlexLifeline_Type = {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
-  const_cast<char*>("pyphlex.lifeline"),             // tp_name
+  "pyphlex.lifeline",                                // tp_name
   sizeof(py_lifeline_t),                             // tp_basicsize
   0,                                                 // tp_itemsize
   reinterpret_cast<destructor>(ll_dealloc),          // tp_dealloc
@@ -66,7 +66,7 @@ PyTypeObject phlex::experimental::PhlexLifeline_Type = {
   0,                                                 // tp_setattro
   0,                                                 // tp_as_buffer
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,           // tp_flags
-  const_cast<char*>("internal"),                     // tp_doc
+  "internal",                                        // tp_doc
   reinterpret_cast<traverseproc>(ll_traverse),       // tp_traverse
   reinterpret_cast<inquiry>(ll_clear),               // tp_clear
   0,                                                 // tp_richcompare

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -503,7 +503,7 @@ namespace {
   static cpptype py_to_##name(intptr_t pyobj)                                                      \
   {                                                                                                \
     PyGILRAII gil;                                                                                 \
-    cpptype i = (cpptype)frompy(reinterpret_cast<PyObject*>(pyobj));                               \
+    cpptype i = static_cast<cpptype>(frompy(reinterpret_cast<PyObject*>(pyobj)));                  \
     std::string msg;                                                                               \
     if (msg_from_py_error(msg, true)) {                                                            \
       Py_DECREF(reinterpret_cast<PyObject*>(pyobj));                                               \
@@ -553,10 +553,10 @@ namespace {
     /* is just a demonstrator; alternatives are still being considered) */                         \
     npy_intp dims[] = {static_cast<npy_intp>(v->size())};                                          \
                                                                                                    \
-    PyObject* np_view = PyArray_SimpleNewFromData(1,                 /* 1-D array */               \
-                                                  dims,              /* dimension sizes */         \
-                                                  nptype,            /* numpy C type */            \
-                                                  (void*)(v->data()) /* raw buffer */              \
+    PyObject* np_view = PyArray_SimpleNewFromData(1,          /* 1-D array */                      \
+                                                  dims,       /* dimension sizes */                \
+                                                  nptype,     /* numpy C type */                   \
+                                                  (v->data()) /* raw buffer */                     \
     );                                                                                             \
                                                                                                    \
     if (!np_view)                                                                                  \
@@ -614,7 +614,7 @@ namespace {
       vec->reserve(total);                                                                         \
       for (Py_ssize_t i = 0; i < total; ++i) {                                                     \
         PyObject* item = PyList_GetItem(reinterpret_cast<PyObject*>(pyobj), i);                    \
-        vec->push_back((cpptype)frompy(item));                                                     \
+        vec->push_back(static_cast<cpptype>(frompy(item)));                                        \
         if (PyErr_Occurred()) {                                                                    \
           PyErr_Clear();                                                                           \
           break;                                                                                   \
@@ -677,18 +677,12 @@ static PyObject* parse_args(PyObject* args,
   // any node. (The observer does not require outputs, but they still need to be
   // retrieved, not ignored, to issue an error message if an output is provided.)
 
-  static char const* kwnames[] = {
-    "callable", "input_family", "output_product_suffixes", "concurrency", "name", nullptr};
+  static char kw0[] = "callable", kw1[] = "input_family", kw2[] = "output_product_suffixes",
+              kw3[] = "concurrency", kw4[] = "name";
+  static char const* kwnames[] = {kw0, kw1, kw2, kw3, kw4, nullptr};
   PyObject *callable = 0, *input = 0, *output = 0, *concurrency = 0, *pyname = 0;
-  if (!PyArg_ParseTupleAndKeywords(args,
-                                   kwds,
-                                   "OO|OOO",
-                                   const_cast<char**>(kwnames),
-                                   &callable,
-                                   &input,
-                                   &output,
-                                   &concurrency,
-                                   &pyname)) {
+  if (!PyArg_ParseTupleAndKeywords(
+        args, kwds, "OO|OOO", kwnames, &callable, &input, &output, &concurrency, &pyname)) {
     // error already set by argument parser
     return nullptr;
   }

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -59,7 +59,7 @@ PyObject* phlex::experimental::wrap_module(phlex_module_t& module_)
   py_phlex_module* pymod = PyObject_New(py_phlex_module, &PhlexModule_Type);
   pymod->ph_module = &module_;
 
-  return (PyObject*)pymod;
+  return reinterpret_cast<PyObject*>(pymod);
 }
 
 // Simple phlex source wrapper
@@ -75,7 +75,7 @@ PyObject* phlex::experimental::wrap_source(phlex_source_t& source_)
   py_phlex_source* pysrc = PyObject_New(py_phlex_source, &PhlexSource_Type);
   pysrc->ph_source = &source_;
 
-  return (PyObject*)pysrc;
+  return reinterpret_cast<PyObject*>(pysrc);
 }
 
 namespace {
@@ -97,9 +97,9 @@ namespace {
 
   static inline PyObject* lifeline_transform(intptr_t arg)
   {
-    PyObject* pyobj = (PyObject*)arg;
+    PyObject* pyobj = reinterpret_cast<PyObject*>(arg);
     if (pyobj && PyObject_TypeCheck(pyobj, &PhlexLifeline_Type)) {
-      return ((py_lifeline_t*)pyobj)->m_view;
+      return reinterpret_cast<py_lifeline_t*>(pyobj)->m_view;
     }
     return pyobj;
   }
@@ -164,7 +164,7 @@ namespace {
         throw std::runtime_error(error_msg.c_str());
       }
 
-      return (intptr_t)result;
+      return reinterpret_cast<intptr_t>(result);
     }
 
     template <typename... Args>
@@ -497,19 +497,19 @@ namespace {
   static intptr_t name##_to_py(cpptype a)                                                          \
   {                                                                                                \
     PyGILRAII gil;                                                                                 \
-    return (intptr_t)topy(a);                                                                      \
+    return reinterpret_cast<intptr_t>(topy(a));                                                    \
   }                                                                                                \
                                                                                                    \
   static cpptype py_to_##name(intptr_t pyobj)                                                      \
   {                                                                                                \
     PyGILRAII gil;                                                                                 \
-    cpptype i = (cpptype)frompy((PyObject*)pyobj);                                                 \
+    cpptype i = (cpptype)frompy(reinterpret_cast<PyObject*>(pyobj));                               \
     std::string msg;                                                                               \
     if (msg_from_py_error(msg, true)) {                                                            \
-      Py_DECREF((PyObject*)pyobj);                                                                 \
+      Py_DECREF(reinterpret_cast<PyObject*>(pyobj));                                               \
       throw std::runtime_error("Python conversion error for type " #name ": " + msg);              \
     }                                                                                              \
-    Py_DECREF((PyObject*)pyobj);                                                                   \
+    Py_DECREF(reinterpret_cast<PyObject*>(pyobj));                                                 \
     return i;                                                                                      \
   }                                                                                                \
                                                                                                    \
@@ -518,7 +518,8 @@ namespace {
     {                                                                                              \
       PyGILRAII gil;                                                                               \
       PyObject* arg0 = wrap_dci(id);                                                               \
-      PyObject* pyres = (PyObject*)call((intptr_t)arg0); /* decrefs arg0 */                        \
+      intptr_t const arg0i = reinterpret_cast<intptr_t>(arg0);                                     \
+      PyObject* pyres = reinterpret_cast<PyObject*>(call(arg0i)); /* decrefs arg0 */               \
       cpptype cres = frompy(pyres);                                                                \
       Py_DECREF(pyres);                                                                            \
       return cres;                                                                                 \
@@ -546,7 +547,7 @@ namespace {
     PyGILRAII gil;                                                                                 \
                                                                                                    \
     if (!v)                                                                                        \
-      return (intptr_t)nullptr;                                                                    \
+      return 0;                                                                                    \
                                                                                                    \
     /* use a numpy view with the shared pointer tied up in a lifeline object (note: this */        \
     /* is just a demonstrator; alternatives are still being considered) */                         \
@@ -559,24 +560,24 @@ namespace {
     );                                                                                             \
                                                                                                    \
     if (!np_view)                                                                                  \
-      return (intptr_t)nullptr;                                                                    \
+      return 0;                                                                                    \
                                                                                                    \
     /* make the data read-only by not making it writable */                                        \
-    PyArray_CLEARFLAGS((PyArrayObject*)np_view, NPY_ARRAY_WRITEABLE);                              \
+    PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(np_view), NPY_ARRAY_WRITEABLE);            \
                                                                                                    \
     /* create a lifeline object to tie this array and the original handle together; note */        \
     /* that the callback code needs to pick the data member out of the lifeline object, */         \
     /* when passing it to the registered Python function */                                        \
-    py_lifeline_t* pyll =                                                                          \
-      (py_lifeline_t*)PhlexLifeline_Type.tp_new(&PhlexLifeline_Type, nullptr, nullptr);            \
+    py_lifeline_t* pyll = reinterpret_cast<py_lifeline_t*>(                                        \
+      PhlexLifeline_Type.tp_new(&PhlexLifeline_Type, nullptr, nullptr));                           \
     if (!pyll) {                                                                                   \
       Py_DECREF(np_view);                                                                          \
-      return (intptr_t)nullptr;                                                                    \
+      return 0;                                                                                    \
     }                                                                                              \
     pyll->m_source = v;                                                                            \
     pyll->m_view = np_view; /* steals reference */                                                 \
                                                                                                    \
-    return (intptr_t)pyll;                                                                         \
+    return reinterpret_cast<intptr_t>(pyll);                                                       \
   }
 
   VECTOR_CONVERTER(vint, std::int32_t, NPY_INT32)
@@ -594,8 +595,8 @@ namespace {
     auto vec = std::make_shared<std::vector<cpptype>>();                                           \
                                                                                                    \
     /* TODO: because of unresolved ownership issues, copy the full array contents */               \
-    if (PyArray_Check((PyObject*)pyobj)) {                                                         \
-      PyArrayObject* arr = (PyArrayObject*)pyobj;                                                  \
+    if (PyArray_Check(reinterpret_cast<PyObject*>(pyobj))) {                                       \
+      PyArrayObject* arr = reinterpret_cast<PyArrayObject*>(pyobj);                                \
                                                                                                    \
       /* TODO: flattening the array here seems to be the only workable solution */                 \
       npy_intp* dims = PyArray_DIMS(arr);                                                          \
@@ -608,11 +609,11 @@ namespace {
       cpptype* raw = static_cast<cpptype*>(PyArray_DATA(arr));                                     \
       vec->reserve(total);                                                                         \
       vec->insert(vec->end(), raw, raw + total);                                                   \
-    } else if (PyList_Check((PyObject*)pyobj)) {                                                   \
-      Py_ssize_t total = PyList_Size((PyObject*)pyobj);                                            \
+    } else if (PyList_Check(reinterpret_cast<PyObject*>(pyobj))) {                                 \
+      Py_ssize_t total = PyList_Size(reinterpret_cast<PyObject*>(pyobj));                          \
       vec->reserve(total);                                                                         \
       for (Py_ssize_t i = 0; i < total; ++i) {                                                     \
-        PyObject* item = PyList_GetItem((PyObject*)pyobj, i);                                      \
+        PyObject* item = PyList_GetItem(reinterpret_cast<PyObject*>(pyobj), i);                    \
         vec->push_back((cpptype)frompy(item));                                                     \
         if (PyErr_Occurred()) {                                                                    \
           PyErr_Clear();                                                                           \
@@ -626,7 +627,7 @@ namespace {
       }                                                                                            \
     }                                                                                              \
                                                                                                    \
-    Py_DECREF((PyObject*)pyobj);                                                                   \
+    Py_DECREF(reinterpret_cast<PyObject*>(pyobj));                                                 \
     return vec;                                                                                    \
   }                                                                                                \
                                                                                                    \
@@ -635,8 +636,8 @@ namespace {
     {                                                                                              \
       PyGILRAII gil;                                                                               \
       PyObject* arg0 = wrap_dci(id);                                                               \
-      intptr_t pyres = call((intptr_t)arg0); /* decrefs arg0 */                                    \
-      auto cres = py_to_##name(pyres);       /* decrefs pyres */                                   \
+      intptr_t pyres = call(reinterpret_cast<intptr_t>(arg0)); /* decrefs arg0 */                  \
+      auto cres = py_to_##name(pyres);                         /* decrefs pyres */                 \
       return cres;                                                                                 \
     }                                                                                              \
   };
@@ -679,8 +680,15 @@ static PyObject* parse_args(PyObject* args,
   static char const* kwnames[] = {
     "callable", "input_family", "output_product_suffixes", "concurrency", "name", nullptr};
   PyObject *callable = 0, *input = 0, *output = 0, *concurrency = 0, *pyname = 0;
-  if (!PyArg_ParseTupleAndKeywords(
-        args, kwds, "OO|OOO", (char**)kwnames, &callable, &input, &output, &concurrency, &pyname)) {
+  if (!PyArg_ParseTupleAndKeywords(args,
+                                   kwds,
+                                   "OO|OOO",
+                                   const_cast<char**>(kwnames),
+                                   &callable,
+                                   &input,
+                                   &output,
+                                   &concurrency,
+                                   &pyname)) {
     // error already set by argument parser
     return nullptr;
   }
@@ -1081,14 +1089,14 @@ static PyObject* md_observe(py_phlex_module* mod, PyObject* args, PyObject* kwds
 
 // PyMethodDef arrays must be non-const; tp_methods in PyTypeObject takes a non-const pointer.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static PyMethodDef md_methods[] = {{(char*)"transform",
-                                    (PyCFunction)md_transform,
+static PyMethodDef md_methods[] = {{const_cast<char*>("transform"),
+                                    reinterpret_cast<PyCFunction>(md_transform),
                                     METH_VARARGS | METH_KEYWORDS,
-                                    (char*)"register a Python transform"},
-                                   {(char*)"observe",
-                                    (PyCFunction)md_observe,
+                                    const_cast<char*>("register a Python transform")},
+                                   {const_cast<char*>("observe"),
+                                    reinterpret_cast<PyCFunction>(md_observe),
                                     METH_VARARGS | METH_KEYWORDS,
-                                    (char*)"register a Python observer"},
+                                    const_cast<char*>("register a Python observer")},
                                    {(char*)nullptr, nullptr, 0, nullptr}};
 
 // clang-format off
@@ -1096,7 +1104,7 @@ static PyMethodDef md_methods[] = {{(char*)"transform",
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject phlex::experimental::PhlexModule_Type = {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
-  (char*)"pyphlex.module",       // tp_name
+  const_cast<char*>("pyphlex.module"),       // tp_name
   sizeof(py_phlex_module),       // tp_basicsize
   0,                             // tp_itemsize
   0,                             // tp_dealloc
@@ -1115,7 +1123,7 @@ PyTypeObject phlex::experimental::PhlexModule_Type = {
   0,                             // tp_setattro
   0,                             // tp_as_buffer
   Py_TPFLAGS_DEFAULT,            // tp_flags
-  (char*)"phlex module wrapper", // tp_doc
+  const_cast<char*>("phlex module wrapper"), // tp_doc
   0,                             // tp_traverse
   0,                             // tp_clear
   0,                             // tp_richcompare
@@ -1173,7 +1181,7 @@ static PyObject* sc_provide(py_phlex_source* src, PyObject* args, PyObject* kwds
   static char const* kwnames[] = {"callable", "output_product", "name", nullptr};
   PyObject *callable = 0, *output = 0, *pyname = 0;
   if (!PyArg_ParseTupleAndKeywords(
-        args, kwds, "OO|O", (char**)kwnames, &callable, &output, &pyname)) {
+        args, kwds, "OO|O", const_cast<char**>(kwnames), &callable, &output, &pyname)) {
     // error already set by argument parser
     return nullptr;
   }
@@ -1299,10 +1307,10 @@ static PyObject* sc_provide(py_phlex_source* src, PyObject* args, PyObject* kwds
 
 // PyMethodDef arrays must be non-const; tp_methods in PyTypeObject takes a non-const pointer.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static PyMethodDef sc_methods[] = {{(char*)"provide",
-                                    (PyCFunction)sc_provide,
+static PyMethodDef sc_methods[] = {{const_cast<char*>("provide"),
+                                    reinterpret_cast<PyCFunction>(sc_provide),
                                     METH_VARARGS | METH_KEYWORDS,
-                                    (char*)"register a Python provider"},
+                                    const_cast<char*>("register a Python provider")},
                                    {(char*)nullptr, nullptr, 0, nullptr}};
 
 // clang-format off
@@ -1310,7 +1318,7 @@ static PyMethodDef sc_methods[] = {{(char*)"provide",
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject phlex::experimental::PhlexSource_Type = {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
-  (char*)"pyphlex.source",       // tp_name
+  const_cast<char*>("pyphlex.source"),       // tp_name
   sizeof(py_phlex_source),       // tp_basicsize
   0,                             // tp_itemsize
   0,                             // tp_dealloc
@@ -1329,7 +1337,7 @@ PyTypeObject phlex::experimental::PhlexSource_Type = {
   0,                             // tp_setattro
   0,                             // tp_as_buffer
   Py_TPFLAGS_DEFAULT,            // tp_flags
-  (char*)"phlex source wrapper", // tp_doc
+  const_cast<char*>("phlex source wrapper"), // tp_doc
   0,                             // tp_traverse
   0,                             // tp_clear
   0,                             // tp_richcompare

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -1083,22 +1083,22 @@ static PyObject* md_observe(py_phlex_module* mod, PyObject* args, PyObject* kwds
 
 // PyMethodDef arrays must be non-const; tp_methods in PyTypeObject takes a non-const pointer.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static PyMethodDef md_methods[] = {{const_cast<char*>("transform"),
+static PyMethodDef md_methods[] = {{"transform",
                                     reinterpret_cast<PyCFunction>(md_transform),
                                     METH_VARARGS | METH_KEYWORDS,
-                                    const_cast<char*>("register a Python transform")},
-                                   {const_cast<char*>("observe"),
+                                    "register a Python transform"},
+                                   {"observe",
                                     reinterpret_cast<PyCFunction>(md_observe),
                                     METH_VARARGS | METH_KEYWORDS,
-                                    const_cast<char*>("register a Python observer")},
-                                   {(char*)nullptr, nullptr, 0, nullptr}};
+                                    "register a Python observer"},
+                                   {nullptr, nullptr, 0, nullptr}};
 
 // clang-format off
 // PyType_Ready() modifies PyTypeObject in-place; the Python C API requires non-const.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject phlex::experimental::PhlexModule_Type = {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
-  const_cast<char*>("pyphlex.module"),       // tp_name
+  "pyphlex.module",              // tp_name
   sizeof(py_phlex_module),       // tp_basicsize
   0,                             // tp_itemsize
   0,                             // tp_dealloc
@@ -1117,7 +1117,7 @@ PyTypeObject phlex::experimental::PhlexModule_Type = {
   0,                             // tp_setattro
   0,                             // tp_as_buffer
   Py_TPFLAGS_DEFAULT,            // tp_flags
-  const_cast<char*>("phlex module wrapper"), // tp_doc
+  "phlex module wrapper",        // tp_doc
   0,                             // tp_traverse
   0,                             // tp_clear
   0,                             // tp_richcompare
@@ -1172,10 +1172,10 @@ static PyObject* sc_provide(py_phlex_source* src, PyObject* args, PyObject* kwds
   // Register a python algorithm by adding the necessary intermediate converter
   // nodes going from C++ to PyObject* and back.
 
-  static char const* kwnames[] = {"callable", "output_product", "name", nullptr};
+  static char kw0[] = "callable", kw1[] = "output_product", kw2[] = "name";
+  static char const* kwnames[] = {kw0, kw1, kw2, nullptr};
   PyObject *callable = 0, *output = 0, *pyname = 0;
-  if (!PyArg_ParseTupleAndKeywords(
-        args, kwds, "OO|O", const_cast<char**>(kwnames), &callable, &output, &pyname)) {
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O", kwnames, &callable, &output, &pyname)) {
     // error already set by argument parser
     return nullptr;
   }
@@ -1301,18 +1301,18 @@ static PyObject* sc_provide(py_phlex_source* src, PyObject* args, PyObject* kwds
 
 // PyMethodDef arrays must be non-const; tp_methods in PyTypeObject takes a non-const pointer.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static PyMethodDef sc_methods[] = {{const_cast<char*>("provide"),
+static PyMethodDef sc_methods[] = {{"provide",
                                     reinterpret_cast<PyCFunction>(sc_provide),
                                     METH_VARARGS | METH_KEYWORDS,
-                                    const_cast<char*>("register a Python provider")},
-                                   {(char*)nullptr, nullptr, 0, nullptr}};
+                                    "register a Python provider"},
+                                   {nullptr, nullptr, 0, nullptr}};
 
 // clang-format off
 // PyType_Ready() modifies PyTypeObject in-place; the Python C API requires non-const.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyTypeObject phlex::experimental::PhlexSource_Type = {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
-  const_cast<char*>("pyphlex.source"),       // tp_name
+  "pyphlex.source",              // tp_name
   sizeof(py_phlex_source),       // tp_basicsize
   0,                             // tp_itemsize
   0,                             // tp_dealloc
@@ -1331,7 +1331,7 @@ PyTypeObject phlex::experimental::PhlexSource_Type = {
   0,                             // tp_setattro
   0,                             // tp_as_buffer
   Py_TPFLAGS_DEFAULT,            // tp_flags
-  const_cast<char*>("phlex source wrapper"), // tp_doc
+  "phlex source wrapper",        // tp_doc
   0,                             // tp_traverse
   0,                             // tp_clear
   0,                             // tp_richcompare


### PR DESCRIPTION
- **Address review comment**
- **Ignore some `clang-tidy` checks by directory**
- **Annotate known/verified instance of `static_cast` to derived**
