### PR TITLE
FORM Missing Branch Error Message

### DIFF
--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -40,7 +40,8 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
     m_tree = m_tfile->Get<TTree>(top_name().c_str());
   }
   if (m_tree == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::read no tree found with name " + top_name());
+    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::read no tree found with name " +
+                             top_name());
   }
   if (m_branch == nullptr) {
     m_branch = m_tree->GetBranch(col_name().c_str());

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -40,7 +40,7 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
     m_tree = m_tfile->Get<TTree>(top_name().c_str());
   }
   if (m_tree == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::read no tree found");
+    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::read no tree found with name " + top_name());
   }
   if (m_branch == nullptr) {
     m_branch = m_tree->GetBranch(col_name().c_str());


### PR DESCRIPTION
When FORM can't find the branch for a container, it throws an exception with an error message.  That error message didn't include the name of the branch that can't be found.  This PR adds the branch name to that error message.