### PR TITLE
Update CI container and Spack configuration for improved build reliability

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,6 +46,7 @@
             "description": "Standard build with C++ module scanning disabled for clang-tidy compatibility.",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_COMPILER": "clang++",
                 "CMAKE_CXX_SCAN_FOR_MODULES": "OFF"
             }
         }

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -190,6 +190,22 @@ spack buildcache keys -it
 SPACK_CONFIGURE_MIRRORS
 
 ########################################################################
+# Ensure intel-tbb@2023.0.0 has a checksum in the Spack recipe
+
+RUN <<'ENSURE_INTEL_TBB_CHECKSUM'
+set -euo pipefail
+
+# intel-tbb@2023.0.0 may not be present in the spack-packages recipe that
+# was cloned above.  If spack versions -n lists it as "new" (not checksummed), fetch the archive
+# and add its checksum to the package file so that Spack can install it.
+. /spack/share/spack/setup-env.sh
+
+if spack versions -n intel-tbb | grep -Fwq '2023.0.0'; then
+  EDITOR=true spack checksum -ab intel-tbb 2023.0.0
+fi
+ENSURE_INTEL_TBB_CHECKSUM
+
+########################################################################
 # Use Spack to install the GCC we want to use
 
 RUN <<'SPACK_INSTALL_GCC'
@@ -366,21 +382,6 @@ spack --timestamp install --fail-fast -j $(nproc) -p 1 \
 
 spack clean -dfs
 SPACK_INSTALL_PHLEX_DEPENDENCIES
-
-########################################################################
-# Work around intel-oneapi-tbb's non-standard CMake config layout
-
-RUN <<'FIX_TBB_CMAKE_PATH'
-set -euo pipefail
-
-# intel-oneapi-tbb installs its CMake config files under
-# <prefix>/tbb/latest/lib/cmake/tbb/ rather than the standard
-# <prefix>/lib/cmake/tbb/.  CMake's find_package(TBB) searches
-# <prefix>/lib/<name>/ as a fallback, so a symlink at lib/tbb pointing
-# into the actual cmake directory is sufficient.
-VIEW="${PHLEX_SPACK_ENV}/.spack-env/view"
-ln -sfT "../tbb/latest/lib/cmake/tbb" "${VIEW}/lib/tbb"
-FIX_TBB_CMAKE_PATH
 
 ########################################################################
 # Publish buildcache artifacts if a cache volume is mounted

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -368,6 +368,21 @@ spack clean -dfs
 SPACK_INSTALL_PHLEX_DEPENDENCIES
 
 ########################################################################
+# Work around intel-oneapi-tbb's non-standard CMake config layout
+
+RUN <<'FIX_TBB_CMAKE_PATH'
+set -euo pipefail
+
+# intel-oneapi-tbb installs its CMake config files under
+# <prefix>/tbb/latest/lib/cmake/tbb/ rather than the standard
+# <prefix>/lib/cmake/tbb/.  CMake's find_package(TBB) searches
+# <prefix>/lib/<name>/ as a fallback, so a symlink at lib/tbb pointing
+# into the actual cmake directory is sufficient.
+VIEW="${PHLEX_SPACK_ENV}/.spack-env/view"
+ln -sfT "../tbb/latest/lib/cmake/tbb" "${VIEW}/lib/tbb"
+FIX_TBB_CMAKE_PATH
+
+########################################################################
 # Publish buildcache artifacts if a cache volume is mounted
 
 RUN <<'WRITE_BUILDCACHE'

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,12 +5,12 @@
 # Podman instructions for building tagged images with this file:
 #
 #   $ podman build --format docker \
-#       [-v <local-spack-cache>:/build-cache] \
-#       [-v ~/.gnupg:/run/gpg] \
+#       [-v <local-spack-cache>:/build-cache:Z] \
+#       [-v ~/.gnupg:/run/gpg:Z] \
 #       --target ci   --tag phlex-ci:<tag>  .
 #   $ podman build --format docker \
-#       [-v <local-spack-cache>:/build-cache] \
-#       [-v ~/.gnupg:/run/gpg] \
+#       [-v <local-spack-cache>:/build-cache:Z] \
+#       [-v ~/.gnupg:/run/gpg:Z] \
 #       --target dev  --tag phlex-dev:<tag> .
 #   $ podman login ghcr.io --username <username> -p <token>
 #   $ podman push phlex-ci:<tag>  ghcr.io/framework-r-d/phlex-ci:<tag>
@@ -71,6 +71,7 @@ apt-get upgrade -y --no-install-recommends
 apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
+    cmake \
     curl \
     file \
     git \
@@ -78,11 +79,16 @@ apt-get install -y --no-install-recommends \
     locales-all \
     libcurl4-openssl-dev \
     libssl-dev \
+    libxslt1-dev \
+    libxml2-dev \
     lsb-release \
     ninja-build \
+    pkg-config \
     software-properties-common \
     sudo \
-    unzip
+    unzip \
+    zlib1g-dev
+
 apt autoremove -y
 apt-get clean
 rm -rf /var/lib/apt/lists/*
@@ -115,6 +121,7 @@ PREP_SPACK_GROUP
 ########################################################################
 # Configure Spack: add repos, compilers, externals, and cache locations
 
+COPY packages.yaml /tmp/packages.yaml
 RUN <<'SPACK_CONFIGURE_DEFAULTS'
 set -euo pipefail
 
@@ -130,10 +137,23 @@ find "$SPACK_REPO_ROOT" -type d -exec chmod g+s {} +
 
 . /spack/share/spack/setup-env.sh
 
-spack --timestamp repo add --scope site $SPACK_REPO_ROOT/phlex-spack-recipes/spack_repo/phlex
-spack --timestamp repo add --scope site $SPACK_REPO_ROOT/fnal_art/spack_repo/fnal_art
-spack --timestamp repo add --scope site $SPACK_REPO_ROOT/spack-packages/repos/spack_repo/builtin
-spack --timestamp compiler find
+# Install settings from our copied packages.yaml
+spack config --scope site add -f /tmp/packages.yaml
+rm -f /tmp/packages.yaml
+
+# Recipe repos
+spack repo add --scope site $SPACK_REPO_ROOT/phlex-spack-recipes/spack_repo/phlex
+spack repo add --scope site $SPACK_REPO_ROOT/fnal_art/spack_repo/fnal_art
+spack repo add --scope site $SPACK_REPO_ROOT/spack-packages/repos/spack_repo/builtin
+
+# Other config settings
+spack config --scope defaults add config:build_stage:/opt/spack-stage
+spack config --scope defaults add config:source_cache:/opt/spack-cache/downloads
+spack config --scope defaults add config:misc_cache:/opt/spack-cache/misc
+spack config --scope defaults add config:install_tree:padded_length:255
+
+# Find compilers (destination packages.yaml for Spack >=1.0)
+spack --timestamp compiler find --scope site
 
 # Discover externals
 #
@@ -141,11 +161,6 @@ spack --timestamp compiler find
 #   not necessarily include the Python.h header file.  We therefore need
 #   Spack to build Python.
 spack --timestamp external find --exclude python
-
-spack config --scope defaults add config:build_stage:/opt/spack-stage
-spack config --scope defaults add config:source_cache:/opt/spack-cache/downloads
-spack config --scope defaults add config:misc_cache:/opt/spack-cache/misc
-spack config --scope defaults add "config:install_tree:padded_length:255"
 SPACK_CONFIGURE_DEFAULTS
 
 ENV GNUPGHOME=/run/gpg
@@ -168,7 +183,7 @@ set -euo pipefail
 spack mirror add --type binary phlex-ci-scisoft https://scisoft.fnal.gov/scisoft/spack-packages/phlex-dev
 
 if [ -d "/build-cache" ]; then
-  spack --timestamp mirror add --type binary --unsigned phlex-dev-local /build-cache
+  spack mirror add --type binary --unsigned phlex-dev-local /build-cache
 fi
 
 spack buildcache keys -it
@@ -188,7 +203,8 @@ spack --timestamp install --fail-fast -j "$(nproc)" -p 1 \
       gcc@15.2 target=x86_64_v3 \
       +binutils+bootstrap+graphite~nvptx+piclibs+profiled+strip \
       build_type=Release \
-      languages=c,c++,fortran,lto
+      languages=c,c++,fortran,lto \
+      %c,cxx=gcc@13.3.0 # % must be LAST (along with ^ dependencies)
 
 if [ -d "/build-cache" ]; then
   key_id=${GPG_KEY_ID:-$({ gpg --list-secret-keys --with-colons | grep -Ee '^sec' | cut -d: -f 5 | head -n1; } 2>/dev/null || true)}
@@ -197,7 +213,7 @@ if [ -d "/build-cache" ]; then
   else
     key_args=(-u)
   fi
-  spack --timestamp buildcache create ${key_args[*]:+"${key_args[@]}"} -j $(nproc) --update-index \
+  spack --timestamp buildcache create --allow-missing ${key_args[*]:+"${key_args[@]}"} -j $(nproc) --update-index \
         /build-cache $(spack find --no-groups -LI | \
         sed -Ene 's&^\[\+\] +([^[:space:]]+).*$&/\1&p')
 fi
@@ -221,6 +237,7 @@ set -euo pipefail
 mkdir -p "$(dirname "$PHLEX_SPACK_ENV")"
 rm -rf "$PHLEX_SPACK_ENV"
 spack --timestamp env create -d "$PHLEX_SPACK_ENV" /tmp/spack.yaml
+rm -f /tmp/spack.yaml
 spack --timestamp env activate -d "$PHLEX_SPACK_ENV"
 spack --timestamp concretize
 chgrp -R spack "$PHLEX_SPACK_ENV"
@@ -241,7 +258,7 @@ set -euo pipefail
 
 spack --timestamp install --fail-fast -j $(nproc) -p 1 \
   --no-add --only-concrete --no-check-signature \
-  cmake lcov ninja py-gcovr
+  cmake lcov ninja py-gcovr py-pytest-cov py-pyyaml
 
 if [ -d "/build-cache" ]; then
   key_id=${GPG_KEY_ID:-$({ gpg --list-secret-keys --with-colons | grep -Ee '^sec' | cut -d: -f 5 | head -n1; } 2>/dev/null || true)}
@@ -250,13 +267,34 @@ if [ -d "/build-cache" ]; then
   else
     key_args=(-u)
   fi
-  spack --timestamp buildcache create ${key_args[*]:+"${key_args[@]}"} -j $(nproc) --update-index \
+  spack --timestamp buildcache create --allow-missing ${key_args[*]:+"${key_args[@]}"} -j $(nproc) --update-index \
         /build-cache $(spack find --no-groups -LI | \
         sed -Ene 's&^\[\+\] +([^[:space:]]+).*$&/\1&p')
 fi
 
 spack clean -dfs
 INSTALL_TOOLING_CORE
+
+########################################################################
+# Verify Python was built with SSL support
+
+RUN <<'VERIFY_PYTHON_SSL'
+set -euo pipefail
+
+# Confirm that the Spack-built Python provides a working ssl module,
+# which requires that Python was compiled against the expected SSL library.
+. /entrypoint.sh
+
+python -c "
+import ssl
+ctx = ssl.create_default_context()
+print('Python SSL OK:', ssl.OPENSSL_VERSION)
+" || {
+  echo "ERROR: Spack Python does not provide a working ssl module." >&2
+  echo "Check that Python was built with OpenSSL support (openssl~shared is a common culprit)." >&2
+  exit 1
+}
+VERIFY_PYTHON_SSL
 
 ########################################################################
 # Install LLVM toolchain separately for caching efficiency
@@ -277,7 +315,7 @@ if [ -d "/build-cache" ]; then
   else
     key_args=(-u)
   fi
-  spack --timestamp buildcache create ${key_args[*]:+"${key_args[@]}"} -j $(nproc) --update-index \
+  spack --timestamp buildcache create --allow-missing ${key_args[*]:+"${key_args[@]}"} -j $(nproc) --update-index \
         /build-cache $(spack find --no-groups -LI | \
         sed -Ene 's&^\[\+\] +([^[:space:]]+).*$&/\1&p')
 fi
@@ -305,7 +343,7 @@ if [ -d "/build-cache" ]; then
   else
     key_args=(-u)
   fi
-  spack --timestamp buildcache create ${key_args[*]:+"${key_args[@]}"} -j $(nproc) --update-index \
+  spack --timestamp buildcache create --allow-missing ${key_args[*]:+"${key_args[@]}"} -j $(nproc) --update-index \
         /build-cache $(spack find --no-groups -LI | \
         sed -Ene 's&^\[\+\] +([^[:space:]]+).*$&/\1&p')
 fi
@@ -330,27 +368,6 @@ spack clean -dfs
 SPACK_INSTALL_PHLEX_DEPENDENCIES
 
 ########################################################################
-# Verify Python was built with SSL support
-
-RUN <<'VERIFY_PYTHON_SSL'
-set -euo pipefail
-
-# Confirm that the Spack-built Python provides a working ssl module,
-# which requires that Python was compiled against the expected SSL library.
-. /entrypoint.sh
-
-python -c "
-import ssl
-ctx = ssl.create_default_context()
-print('Python SSL OK:', ssl.OPENSSL_VERSION)
-" || {
-  echo "ERROR: Spack Python does not provide a working ssl module." >&2
-  echo "Check that Python was built with OpenSSL support (openssl~shared is a common culprit)." >&2
-  exit 1
-}
-VERIFY_PYTHON_SSL
-
-########################################################################
 # Publish buildcache artifacts if a cache volume is mounted
 
 RUN <<'WRITE_BUILDCACHE'
@@ -369,7 +386,7 @@ if [ -d "/build-cache" ]; then
   else
     key_args=(-u)
   fi
-  spack --timestamp buildcache create ${key_args[*]:+"${key_args[@]}"} -j $(nproc) --update-index \
+  spack --timestamp buildcache create --allow-missing ${key_args[*]:+"${key_args[@]}"} -j $(nproc) --update-index \
         /build-cache $(spack find --no-groups -LI | \
         sed -Ene 's&^\[\+\] +([^[:space:]]+).*$&/\1&p')
 fi
@@ -438,6 +455,25 @@ USER root
 
 FROM base AS dev
 ENV SPACK_GROUP=spack
+
+########################################################################
+# Install useful developer command-line tools with apt-get
+
+RUN <<'INSTALL_DEV_ESSENTIALS'
+set -euo pipefail
+
+# Install locale support required by tooling and Spack
+apt-get update
+apt-get upgrade -y --no-install-recommends
+apt-get install -y --no-install-recommends \
+  ack \
+  bubblewrap \
+  less \
+  ripgrep
+apt autoremove -y
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+INSTALL_DEV_ESSENTIALS
 
 ########################################################################
 # Install developer tooling (gersemi, prek, ruff)

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -9,3 +9,7 @@ export SPACK_DISABLE_LOCAL_CONFIG=true
 . /spack/share/spack/setup-env.sh
 spack env activate -d "$PHLEX_SPACK_ENV"
 PATH=$(spack -E location -i gcc@15 %c,cxx=gcc@13)/bin:$PATH
+# spack env activate sets CC/CXX to clang/clang++ because LLVM is an explicit
+# spec that provides compiler virtuals.  Override so that builds which do not
+# name a compiler explicitly (e.g. the CMake "default" preset) use GCC 15.
+export CC=gcc CXX=g++

--- a/ci/packages.yaml
+++ b/ci/packages.yaml
@@ -1,0 +1,39 @@
+# Spack site-level packages configuration.
+#
+# This file is installed to the Spack site configuration directory
+# (/etc/spack/packages.yaml) during the container build so that all
+# environments and ad-hoc installs inherit these settings without
+# needing to repeat them in every spack.yaml.
+#
+# Design notes:
+#   - All packages default to target x86_64_v3 and compiler gcc@13.
+#     This covers root's own dependencies (e.g. zlib, python, xrootd)
+#     which do not need to share the gcc@15 ABI of root itself.
+#   - root and its dependents (phlex) require gcc@15; those overrides
+#     live in each environment's spack.yaml, not here.
+#   - System zlib is declared external so Spack does not build its own
+#     zlib / zlib-ng, eliminating duplicate virtual-provider builds.
+
+packages:
+  all:
+    target:
+      - x86_64_v3
+    providers:
+      "zlib-api:": [zlib]
+
+  c:
+    prefer: ["gcc@13"]
+  cxx:
+    prefer: ["gcc@13"]
+  fortran:
+    prefer: ["gcc@13"]
+
+  # Use the system zlib rather than building zlib / zlib-ng from source.
+  # The external entry must match the Ubuntu 24.04 package layout.
+  zlib:
+    externals:
+      - spec: zlib@1.3
+        prefix: /usr
+    buildable: false
+  zlib-ng:
+    buildable: false

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -42,6 +42,10 @@ spack:
         - "~qtgui"
         - "@4:"
 
+    llvm:
+      require:
+        - "%c,cxx=gcc@15"
+
     phlex:
       require:
         - "+form"

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -6,8 +6,7 @@
 
 spack:
   specs:
-    - >-
-      phlex ^intel-oneapi-tbb@2023.0.0:
+    - phlex
     - catch2
     - cmake
     - lcov
@@ -34,9 +33,6 @@ spack:
         - type: buildcache
 
   packages:
-    all:
-      providers:
-        "tbb:": [intel-oneapi-tbb]
     cmake:
       require:
         - "~qtgui"
@@ -51,7 +47,7 @@ spack:
         - "+form"
         - "cxxstd=23"
         - "%cxx=gcc@15"
-        - "^tbb@2023.0.0:"
+        - "^intel-tbb@2023.0.0:"
 
     py-cython:
       require:

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -6,7 +6,8 @@
 
 spack:
   specs:
-    - phlex
+    - >-
+      phlex ^intel-oneapi-tbb@2023.0.0:
     - catch2
     - cmake
     - lcov
@@ -33,21 +34,20 @@ spack:
         - type: buildcache
 
   packages:
+    all:
+      providers:
+        "tbb:": [intel-oneapi-tbb]
     cmake:
       require:
         - "~qtgui"
         - "@4:"
-
-    # Should include Phlex-requested feature
-    intel-oneapi-tbb:
-      require:
-        - "@2023.0.0:"
 
     phlex:
       require:
         - "+form"
         - "cxxstd=23"
         - "%cxx=gcc@15"
+        - "^tbb@2023.0.0:"
 
     py-cython:
       require:

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -15,9 +15,14 @@ spack:
     - py-pytest-cov # Needed for Python coverage reports
     - py-pyyaml # Needed by run-clang-tidy --export-fixes to merge per-TU fix files
     - |
-      llvm@22.1.1 +zstd +llvm_dylib +link_llvm_dylib ~lldb targets=x86
+      llvm@22.1.3 +zstd +llvm_dylib +link_llvm_dylib ~lldb targets=x86
 
-  view: true
+  view:
+    default:
+      root: .spack-env/view
+      link: all
+      projections:
+        zstd: "{name}-{version}/{compiler.name}-{compiler.version}/{hash}"
 
   concretizer:
     unify: true
@@ -28,36 +33,50 @@ spack:
         - type: buildcache
 
   packages:
-    all:
-      target:
-        - x86_64_v3
-
     cmake:
       require:
-        - "%c,cxx=gcc@13"
         - "~qtgui"
         - "@4:"
+
+    # Should include Phlex-requested feature
+    intel-oneapi-tbb:
+      require:
+        - "@2023.0.0:"
 
     phlex:
       require:
         - "+form"
         - "cxxstd=23"
-        - "%gcc@15"
+        - "%cxx=gcc@15"
 
-    # GCC 15 uses C23 as the default C language, and the versions of
-    # libunwind and unuran available in Spack (as of 8/12/2025) do not
-    # yet support C23.
-    libunwind:
+    py-cython:
       require:
-        - "cflags='-std=c17'"
+        - "build_system=python_pip"
 
-    unuran:
+    py-gcovr:
       require:
-        - "cflags='-std=c17'"
+        - "build_system=python_pip"
 
+    py-pytest-cov:
+      require:
+        - "build_system=python_pip"
+
+    py-pyyaml:
+      require:
+        - "build_system=python_pip"
+
+    # Temporary version pin for C-API `char const *` consistency
+    python:
+      require:
+        - "@3.12"
+
+    # root and its dependents (phlex) must be built with gcc@15 so
+    # they share a single ABI.  root's own dependencies (e.g. zlib,
+    # python, xrootd) inherit the gcc@13 site default instead.
     # ROOT should be built with the same version of the C++ standard
     # as will be used by Phlex (C++23 for now).
     root:
       require:
         - "~x" # No graphics libraries required
         - "cxxstd=23"
+        - "%c,cxx=gcc@15"


### PR DESCRIPTION
Reorganize Spack configuration into a dedicated site-level packages.yaml file
to centralize compiler and dependency settings across all environments. This
eliminates duplication and ensures consistent behavior in both CI and ad-hoc
installs.

Key changes:

- **New packages.yaml**: Defines site-level defaults (gcc@13 compiler, x86_64_v3
  target, system zlib external) that all environments inherit
- **Dockerfile improvements**:
  - Add missing build dependencies (cmake, libxml2-dev, libxslt1-dev, pkg-config,
    zlib1g-dev) required by ROOT and other packages
  - Update Podman volume mount syntax to include SELinux context (`:Z` flag)
  - Move Python SSL verification earlier in build to catch issues sooner
  - Simplify Spack configuration by loading packages.yaml instead of repeating
    settings in each environment
  - Add `--allow-missing` flag to buildcache create commands for robustness
  - Install developer essentials (ack, bubblewrap, less, ripgrep) in dev image
- **spack.yaml updates**:
  - Bump LLVM from 22.1.1 to 22.1.3
  - Consolidate package requirements (cmake, tbb, phlex, python,
    root) with explicit build_system and version constraints
  - Remove redundant compiler specifications now inherited from packages.yaml
  - Add py-pytest-cov and py-pyyaml to tooling installation
  - Tweak view to allow for different `zstd` build for GCC.

These changes improve build reproducibility, reduce configuration maintenance
burden, and ensure all Spack environments use consistent compiler and
dependency settings.
