### PR TITLE
Accommodate oneTBB 2023.0.0 resource-limiting interface

### DIFF
--- a/test/tbb-preview/CMakeLists.txt
+++ b/test/tbb-preview/CMakeLists.txt
@@ -1,9 +1,10 @@
 include(CheckCXXSourceCompiles)
 
-# Check if flow::resource_provider<int> is available in TBB
+# Check if flow::resource_limiter is available in TBB (preview feature)
 set(CMAKE_REQUIRED_LIBRARIES_SAVE ${CMAKE_REQUIRED_LIBRARIES})
 set(CMAKE_REQUIRED_INCLUDES_SAVE ${CMAKE_REQUIRED_INCLUDES})
 set(CMAKE_REQUIRED_FLAGS_SAVE "${CMAKE_REQUIRED_FLAGS}")
+set(CMAKE_TRY_COMPILE_VERBOSE_SAVE ${CMAKE_TRY_COMPILE_VERBOSE})
 
 get_target_property(_TBB_INCLUDES TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
 get_target_property(_TBB_LOCATION TBB::tbb LOCATION)
@@ -15,23 +16,26 @@ if(_TBB_LOCATION)
 endif()
 set(CMAKE_REQUIRED_FLAGS "-std=c++${CMAKE_CXX_STANDARD}")
 
+set(CMAKE_TRY_COMPILE_VERBOSE ON)
+
 check_cxx_source_compiles(
   "
-  #define TBB_PREVIEW_FLOW_GRAPH_RESOURCE_LIMITED_NODE 1
+  #define TBB_PREVIEW_FLOW_GRAPH_RESOURCE_LIMITING 1
   #include <oneapi/tbb/flow_graph.h>
 
-  using type = oneapi::tbb::flow::resource_provider<int>;
+  using type = oneapi::tbb::flow::resource_limiter<int>;
 
   int main() {}
 "
-  HAVE_TBB_RESOURCE_PROVIDER
+  HAVE_TBB_RESOURCE_LIMITING
 )
 
 set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_SAVE})
 set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_SAVE})
 set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS_SAVE}")
+set(CMAKE_TRY_COMPILE_VERBOSE ${CMAKE_TRY_COMPILE_VERBOSE_SAVE})
 
-if(HAVE_TBB_RESOURCE_PROVIDER)
+if(HAVE_TBB_RESOURCE_LIMITING)
   cet_test(
     resource_limiting
     USE_CATCH2_MAIN
@@ -42,13 +46,7 @@ if(HAVE_TBB_RESOURCE_PROVIDER)
     TBB::tbb
     spdlog::spdlog
   )
-  target_compile_definitions(
-    resource_limiting
-    PRIVATE TBB_PREVIEW_FLOW_GRAPH_RESOURCE_LIMITED_NODE=1
-  )
+  target_compile_definitions(resource_limiting PRIVATE TBB_PREVIEW_FLOW_GRAPH_RESOURCE_LIMITING=1)
 else()
-  message(
-    STATUS
-    "Skipping resource_limiting test: flow::resource_provider<int> not available in TBB"
-  )
+  message(STATUS "Skipping resource_limiting test: flow::resource_limiter not available in TBB")
 endif()

--- a/test/tbb-preview/resource_limiting_test.cpp
+++ b/test/tbb-preview/resource_limiting_test.cpp
@@ -64,8 +64,8 @@ TEST_CASE("Serialize functions based on resource", "[multithreading]")
 
   ROOT const root_resource{};
 
-  flow::resource_provider<ROOT const*> root_resource_provider{&root_resource};
-  flow::resource_provider<GENIE> genie_resource{GENIE{}};
+  flow::resource_limiter<ROOT const*> root_resource_provider{&root_resource};
+  flow::resource_limiter<GENIE> genie_resource{GENIE{}};
 
   flow::resource_limited_node<unsigned int, std::tuple<unsigned int>> node1{
     g,
@@ -134,7 +134,7 @@ TEST_CASE("Serialize functions in diamond graph", "[multithreading]")
                          return 0u;
                        }};
 
-  flow::resource_provider<ROOT> root_resource{ROOT{}};
+  flow::resource_limiter<ROOT> root_resource{ROOT{}};
 
   std::atomic<unsigned int> root_counter{};
 
@@ -193,12 +193,12 @@ TEST_CASE("Test based on oneTBB PR 1677 (RFC)", "[multithreading]")
   std::atomic<unsigned int> genie_counter{};
   std::atomic<unsigned int> db_counter{};
 
-  flow::resource_provider<ROOT> root_limiter{ROOT{}};
-  flow::resource_provider<GENIE> genie_limiter{GENIE{}};
+  flow::resource_limiter<ROOT> root_limiter{ROOT{}};
+  flow::resource_limiter<GENIE> genie_limiter{GENIE{}};
 
   DB const db1{1};
   DB const db13{13};
-  flow::resource_provider<DB const*> db_limiter{&db1, &db13};
+  flow::resource_limiter<DB const*> db_limiter{&db1, &db13};
 
   auto fill_histo = [&root_counter](unsigned int const i, auto& outputs, ROOT) {
     thread_counter c{root_counter};


### PR DESCRIPTION
The `resource_provider` template was replaced with `resource_limiter` in oneTBB 2023.0.0.  There was also a change in the macro name required to use the resource-limiting preview.