### PR TITLE
Avoid maybe-uninitialized GCC warnings

### DIFF
--- a/phlex/metaprogramming/delegate.hpp
+++ b/phlex/metaprogramming/delegate.hpp
@@ -24,13 +24,15 @@ namespace phlex::experimental {
   template <typename R, typename T, typename... Args>
   auto delegate(std::shared_ptr<T> obj, R (T::*f)(Args...))
   {
-    return std::function{[t = obj, f](Args... args) mutable -> R { return ((*t).*f)(args...); }};
+    return std::function{
+      [t = std::move(obj), f](Args... args) mutable -> R { return ((*t).*f)(args...); }};
   }
 
   template <typename R, typename T, typename... Args>
   auto delegate(std::shared_ptr<T> obj, R (T::*f)(Args...) const)
   {
-    return std::function{[t = obj, f](Args... args) mutable -> R { return ((*t).*f)(args...); }};
+    return std::function{
+      [t = std::move(obj), f](Args... args) mutable -> R { return ((*t).*f)(args...); }};
   }
 
   template <typename Bound, typename Algorithm>


### PR DESCRIPTION
This PR makes the following change in the `delegate(...)` metaprogramming function templates:

```diff
- return std::function{[t = obj, f](Args... args) mutable -> R { return ((*t).*f)(args...); }};
+ return std::function{[t = std::move(obj), f](Args... args) mutable -> R { return ((*t).*f)(args...); }};
```

More modern versions of GCC (e.g., 15.2) warn that the `t = obj` capture-by-value construct may induce and uninitialized initialization of `std::shared_ptr<T>`.  Although this warning is spurious, it can be silenced by moving `obj` instead of copying it, which is more efficient anyway.