### PR TITLE
`clang-tidy`: resolve `google-explicit-constructor`

### DIFF
--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -92,6 +92,7 @@
   - [PR #556](https://github.com/Framework-R-D/phlex/pull/556)
 - [ ] [google-explicit-constructor](https://clang.llvm.org/extra/clang-tidy/checks/google/explicit-constructor.html) (38)
   - _a.k.a._ [misc-explicit-constructor](https://clang.llvm.org/extra/clang-tidy/checks/misc/explicit-constructor.html) (`clang-tidy` >= 23.0.0)
+  - [PR #581](https://github.com/Framework-R-D/phlex/pull/581)
 - [ ] [modernize-avoid-c-arrays](https://clang.llvm.org/extra/clang-tidy/checks/modernize/avoid-c-arrays.html) (17)
 - [ ] [modernize-avoid-c-style-cast](https://clang.llvm.org/extra/clang-tidy/checks/modernize/avoid-c-style-cast.html) (82)
 - [ ] [modernize-concat-nested-namespaces](https://clang.llvm.org/extra/clang-tidy/checks/modernize/concat-nested-namespaces.html) (1)

--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -90,6 +90,8 @@
   - [PR #560](https://github.com/Framework-R-D/phlex/pull/560)
 - [x] [cppcoreguidelines-use-default-member-init](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/use-default-member-init.html) (5)
   - [PR #556](https://github.com/Framework-R-D/phlex/pull/556)
+- [ ] [google-explicit-constructor](https://clang.llvm.org/extra/clang-tidy/checks/google/explicit-constructor.html) (38)
+  - _a.k.a._ [misc-explicit-constructor](https://clang.llvm.org/extra/clang-tidy/checks/misc/explicit-constructor.html) (`clang-tidy` >= 23.0.0)
 - [ ] [modernize-avoid-c-arrays](https://clang.llvm.org/extra/clang-tidy/checks/modernize/avoid-c-arrays.html) (17)
 - [ ] [modernize-avoid-c-style-cast](https://clang.llvm.org/extra/clang-tidy/checks/modernize/avoid-c-style-cast.html) (82)
 - [ ] [modernize-concat-nested-namespaces](https://clang.llvm.org/extra/clang-tidy/checks/modernize/concat-nested-namespaces.html) (1)

--- a/docs/dev/clang-tidy-fixes-2026-04.md
+++ b/docs/dev/clang-tidy-fixes-2026-04.md
@@ -90,7 +90,7 @@
   - [PR #560](https://github.com/Framework-R-D/phlex/pull/560)
 - [x] [cppcoreguidelines-use-default-member-init](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/use-default-member-init.html) (5)
   - [PR #556](https://github.com/Framework-R-D/phlex/pull/556)
-- [ ] [google-explicit-constructor](https://clang.llvm.org/extra/clang-tidy/checks/google/explicit-constructor.html) (38)
+- [x] [google-explicit-constructor](https://clang.llvm.org/extra/clang-tidy/checks/google/explicit-constructor.html) (38)
   - _a.k.a._ [misc-explicit-constructor](https://clang.llvm.org/extra/clang-tidy/checks/misc/explicit-constructor.html) (`clang-tidy` >= 23.0.0)
   - [PR #581](https://github.com/Framework-R-D/phlex/pull/581)
 - [ ] [modernize-avoid-c-arrays](https://clang.llvm.org/extra/clang-tidy/checks/modernize/avoid-c-arrays.html) (17)

--- a/form/root_storage/demangle_name.cpp
+++ b/form/root_storage/demangle_name.cpp
@@ -7,9 +7,12 @@
 namespace {
   class char_string_holder {
   public:
+    // Implicit conversion from char* to allow direct return of
+    // the result of TClassEdit::DemangleTypeIdName.
+    // NOLINTBEGIN(google-explicit-constructor)
     char_string_holder(char* cstr) : m_cstr(cstr, std::free) {}
     operator char const*() const { return m_cstr.get(); }
-
+    // NOLINTEND(google-explicit-constructor)
   private:
     std::unique_ptr<char, decltype(&std::free)> m_cstr;
   };

--- a/form/root_storage/demangle_name.cpp
+++ b/form/root_storage/demangle_name.cpp
@@ -7,12 +7,10 @@
 namespace {
   class char_string_holder {
   public:
+    explicit char_string_holder(char* cstr) : m_cstr(cstr, std::free) {}
     // Implicit conversion from char* to allow direct return of
     // the result of TClassEdit::DemangleTypeIdName.
-    // NOLINTBEGIN(google-explicit-constructor)
-    char_string_holder(char* cstr) : m_cstr(cstr, std::free) {}
-    operator char const*() const { return m_cstr.get(); }
-    // NOLINTEND(google-explicit-constructor)
+    operator char const*() const { return m_cstr.get(); } // NOLINT(google-explicit-constructor)
   private:
     std::unique_ptr<char, decltype(&std::free)> m_cstr;
   };

--- a/form/root_storage/root_tbranch_read_container.hpp
+++ b/form/root_storage/root_tbranch_read_container.hpp
@@ -16,7 +16,7 @@ namespace form::detail::experimental {
 
   class ROOT_TBranch_Read_ContainerImp : public Storage_Read_Container {
   public:
-    ROOT_TBranch_Read_ContainerImp(std::string const& name);
+    explicit ROOT_TBranch_Read_ContainerImp(std::string const& name);
     ~ROOT_TBranch_Read_ContainerImp() override = default;
 
     void setFile(std::shared_ptr<IStorage_File> file) override;

--- a/form/root_storage/root_tbranch_write_container.hpp
+++ b/form/root_storage/root_tbranch_write_container.hpp
@@ -16,7 +16,7 @@ namespace form::detail::experimental {
 
   class ROOT_TBranch_Write_ContainerImp : public Storage_Associative_Write_Container {
   public:
-    ROOT_TBranch_Write_ContainerImp(std::string const& name);
+    explicit ROOT_TBranch_Write_ContainerImp(std::string const& name);
     ~ROOT_TBranch_Write_ContainerImp() override = default;
 
     void setAttribute(std::string const& key, std::string const& value) override;

--- a/form/root_storage/root_ttree_write_container.hpp
+++ b/form/root_storage/root_ttree_write_container.hpp
@@ -15,7 +15,7 @@ namespace form::detail::experimental {
 
   class ROOT_TTree_Write_ContainerImp : public Storage_Write_Association {
   public:
-    ROOT_TTree_Write_ContainerImp(std::string const& name);
+    explicit ROOT_TTree_Write_ContainerImp(std::string const& name);
 
     ROOT_TTree_Write_ContainerImp(ROOT_TTree_Write_ContainerImp const&) = delete;
     ROOT_TTree_Write_ContainerImp& operator=(ROOT_TTree_Write_ContainerImp const&) = delete;

--- a/form/storage/storage_associative_write_container.hpp
+++ b/form/storage/storage_associative_write_container.hpp
@@ -11,7 +11,7 @@ namespace form::detail::experimental {
 
   class Storage_Associative_Write_Container : public Storage_Write_Container {
   public:
-    Storage_Associative_Write_Container(std::string const& name);
+    explicit Storage_Associative_Write_Container(std::string const& name);
     ~Storage_Associative_Write_Container() override;
 
     std::string const& top_name();

--- a/form/storage/storage_read_container.hpp
+++ b/form/storage/storage_read_container.hpp
@@ -12,7 +12,7 @@ namespace form::detail::experimental {
 
   class Storage_Read_Container : public IStorage_Read_Container {
   public:
-    Storage_Read_Container(std::string const& name);
+    explicit Storage_Read_Container(std::string const& name);
     ~Storage_Read_Container() override = default;
 
     std::string const& name() override;

--- a/form/storage/storage_write_association.hpp
+++ b/form/storage/storage_write_association.hpp
@@ -11,7 +11,7 @@ namespace form::detail::experimental {
 
   class Storage_Write_Association : public Storage_Write_Container {
   public:
-    Storage_Write_Association(std::string const& name);
+    explicit Storage_Write_Association(std::string const& name);
     ~Storage_Write_Association() override = default;
 
     void setAttribute(std::string const& key, std::string const& value) override;

--- a/form/storage/storage_write_container.hpp
+++ b/form/storage/storage_write_container.hpp
@@ -12,7 +12,7 @@ namespace form::detail::experimental {
 
   class Storage_Write_Container : public IStorage_Write_Container {
   public:
-    Storage_Write_Container(std::string const& name);
+    explicit Storage_Write_Container(std::string const& name);
     ~Storage_Write_Container() override = default;
 
     std::string const& name() override;

--- a/phlex/core/edge_creation_policy.hpp
+++ b/phlex/core/edge_creation_policy.hpp
@@ -20,7 +20,7 @@ namespace phlex::experimental {
   class PHLEX_CORE_EXPORT edge_creation_policy {
   public:
     template <typename... Args>
-    edge_creation_policy(Args&... producers);
+    explicit edge_creation_policy(Args&... producers);
 
     struct named_output_port {
       algorithm_name node;

--- a/phlex/core/edge_maker.hpp
+++ b/phlex/core/edge_maker.hpp
@@ -30,7 +30,7 @@ namespace phlex::experimental {
   class PHLEX_CORE_EXPORT edge_maker {
   public:
     template <typename... Args>
-    edge_maker(Args&... args);
+    explicit edge_maker(Args&... args);
 
     template <typename... Args>
     void operator()(tbb::flow::graph& g,

--- a/phlex/core/product_query.hpp
+++ b/phlex/core/product_query.hpp
@@ -30,6 +30,7 @@ namespace phlex {
       }
       template <typename U>
         requires std::constructible_from<T, U>
+      // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
       required_creator_name(U&& rhs) : // NOLINT(cppcoreguidelines-missing-std-forward)
         content_(std::forward_like<T>(rhs))
       {
@@ -38,6 +39,7 @@ namespace phlex {
         }
       }
 
+      // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
       operator T const&() const noexcept { return content_; }
 
     private:
@@ -54,6 +56,7 @@ namespace phlex {
       }
       template <typename U>
         requires std::constructible_from<T, U>
+      // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
       required_layer_name(U&& rhs) : // NOLINT(cppcoreguidelines-missing-std-forward)
         content_(std::forward_like<T>(rhs))
       {
@@ -62,6 +65,7 @@ namespace phlex {
         }
       }
 
+      // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
       operator T const&() const noexcept { return content_; }
 
     private:

--- a/phlex/metaprogramming/detail/ctor_reflect_types.hpp
+++ b/phlex/metaprogramming/detail/ctor_reflect_types.hpp
@@ -68,7 +68,7 @@ namespace refl {
     static auto ins(int) -> char;
 
     template <typename U, int = sizeof(fn_def<T, U, N, sizeof(ins<U, N>(0)) == sizeof(char)>)>
-    operator U();
+    operator U(); // NOLINT(google-explicit-constructor) - Implicit conversion is intentional
   };
 
   // Here we detect the data type field number. The byproduct is instantiations.  Uses

--- a/phlex/metaprogramming/type_deduction.hpp
+++ b/phlex/metaprogramming/type_deduction.hpp
@@ -54,8 +54,6 @@ namespace phlex::experimental {
     static_assert(std::tuple_size<input_parameters>{} >= sizeof...(Args));
     static constexpr bool value =
       mp11::mp_starts_with<input_parameters, std::tuple<Args...>>::value;
-    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
-    constexpr operator bool() noexcept { return value; }
   };
 
   // ===================================================================

--- a/phlex/metaprogramming/type_deduction.hpp
+++ b/phlex/metaprogramming/type_deduction.hpp
@@ -54,6 +54,7 @@ namespace phlex::experimental {
     static_assert(std::tuple_size<input_parameters>{} >= sizeof...(Args));
     static constexpr bool value =
       mp11::mp_starts_with<input_parameters, std::tuple<Args...>>::value;
+    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
     constexpr operator bool() noexcept { return value; }
   };
 

--- a/phlex/model/algorithm_name.hpp
+++ b/phlex/model/algorithm_name.hpp
@@ -12,9 +12,11 @@ namespace phlex::experimental {
   public:
     algorithm_name();
 
+    // NOLINTBEGIN(google-explicit-constructor) - Implicit conversion is intentional
     algorithm_name(char const* spec);
     algorithm_name(std::string const& spec);
     algorithm_name(std::string_view spec);
+    // NOLINTEND(google-explicit-constructor)
     algorithm_name(identifier plugin,
                    identifier algorithm,
                    specified_fields fields = specified_fields::both);

--- a/phlex/model/fixed_hierarchy.hpp
+++ b/phlex/model/fixed_hierarchy.hpp
@@ -45,8 +45,11 @@ namespace phlex {
   class PHLEX_MODEL_EXPORT fixed_hierarchy {
   public:
     fixed_hierarchy() = default;
-    // Using an std::initializer_list removes one set of braces that the user must provide
-    fixed_hierarchy(std::initializer_list<std::vector<std::string>> layer_paths);
+    // Using an std::initializer_list removes one set of braces that the
+    // user must provide; leaving it explicit preserves clarity of
+    // expression for callers.
+    // NOLINTNEXTLINE(performance-google-explicit-constructor)
+    explicit fixed_hierarchy(std::initializer_list<std::vector<std::string>> layer_paths);
     explicit fixed_hierarchy(std::vector<std::vector<std::string>> layer_paths);
 
     void validate(data_cell_index_ptr const& index) const;

--- a/phlex/model/fixed_hierarchy.hpp
+++ b/phlex/model/fixed_hierarchy.hpp
@@ -46,7 +46,7 @@ namespace phlex {
   public:
     fixed_hierarchy() = default;
     // Using an std::initializer_list removes one set of braces that the user must provide
-    explicit fixed_hierarchy(std::initializer_list<std::vector<std::string>> layer_paths);
+    fixed_hierarchy(std::initializer_list<std::vector<std::string>> layer_paths);
     explicit fixed_hierarchy(std::vector<std::vector<std::string>> layer_paths);
 
     void validate(data_cell_index_ptr const& index) const;

--- a/phlex/model/handle.hpp
+++ b/phlex/model/handle.hpp
@@ -82,9 +82,10 @@ namespace phlex {
 
     const_pointer operator->() const noexcept { return product_; }
     [[nodiscard]] const_reference operator*() const noexcept { return *operator->(); }
+    // NOLINTBEGIN(google-explicit-constructor) - Implicit conversion is intentional
     operator const_reference() const noexcept { return operator*(); }
     operator const_pointer() const noexcept { return operator->(); }
-
+    // NOLINTEND(google-explicit-constructor)
     auto const& data_cell_index() const noexcept { return *id_; }
 
     // Product specification information

--- a/phlex/model/identifier.hpp
+++ b/phlex/model/identifier.hpp
@@ -35,8 +35,7 @@ namespace phlex::experimental {
 
     // This is here to allow the node API which heretofore stored names as strings to be easily transitioned
     // over to identifiers
-    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
-    identifier(std::string&& str);
+    explicit identifier(std::string&& str);
 
     // char const* calls string_view
     // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional

--- a/phlex/model/identifier.hpp
+++ b/phlex/model/identifier.hpp
@@ -35,9 +35,11 @@ namespace phlex::experimental {
 
     // This is here to allow the node API which heretofore stored names as strings to be easily transitioned
     // over to identifiers
-    explicit identifier(std::string&& str);
+    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
+    identifier(std::string&& str);
 
     // char const* calls string_view
+    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
     identifier(char const* lit) : identifier(std::string_view(lit)) {}
 
     identifier& operator=(identifier const& rhs) = default;

--- a/phlex/model/product_specification.hpp
+++ b/phlex/model/product_specification.hpp
@@ -17,9 +17,11 @@ namespace phlex::experimental {
   class PHLEX_MODEL_EXPORT product_specification {
   public:
     product_specification();
+    // NOLINTBEGIN(google-explicit-constructor) - Implicit conversion is intentional
     product_specification(char const* name);
     product_specification(std::string const& name);
     product_specification(std::string_view name);
+    // NOLINTEND(google-explicit-constructor)
     product_specification(algorithm_name qualifier, identifier suffix, type_id type);
 
     std::string full() const;

--- a/phlex/utilities/async_driver.hpp
+++ b/phlex/utilities/async_driver.hpp
@@ -18,10 +18,10 @@ namespace phlex::experimental {
 
   public:
     template <typename FT>
-    async_driver(FT ft) : driver_{std::move(ft)}
+    explicit async_driver(FT ft) : driver_{std::move(ft)}
     {
     }
-    async_driver(void (*ft)(async_driver<RT>&)) : driver_{ft} {}
+    explicit async_driver(void (*ft)(async_driver<RT>&)) : driver_{ft} {}
 
     std::optional<RT> operator()()
     {

--- a/phlex/utilities/string_literal.hpp
+++ b/phlex/utilities/string_literal.hpp
@@ -8,8 +8,10 @@
 namespace phlex::experimental {
   template <std::size_t N>
   struct string_literal {
+    // NOLINTBEGIN(google-explicit-constructor) - Implicit conversion is intentional
     constexpr string_literal(char const (&str)[N]) { std::copy_n(str, N, value); }
     constexpr operator std::string_view() const { return value; }
+    // NOLINTEND(google-explicit-constructor)
     char value[N]{};
   };
 

--- a/phlex/utilities/string_literal.hpp
+++ b/phlex/utilities/string_literal.hpp
@@ -8,10 +8,10 @@
 namespace phlex::experimental {
   template <std::size_t N>
   struct string_literal {
-    // NOLINTBEGIN(google-explicit-constructor) - Implicit conversion is intentional
+    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
     constexpr string_literal(char const (&str)[N]) { std::copy_n(str, N, value); }
+    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
     constexpr operator std::string_view() const { return value; }
-    // NOLINTEND(google-explicit-constructor)
     char value[N]{};
   };
 

--- a/phlex/utilities/string_literal.hpp
+++ b/phlex/utilities/string_literal.hpp
@@ -8,10 +8,10 @@
 namespace phlex::experimental {
   template <std::size_t N>
   struct string_literal {
-    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
+    // NOLINTBEGIN(google-explicit-constructor) - Implicit conversion is intentional
     constexpr string_literal(char const (&str)[N]) { std::copy_n(str, N, value); }
-    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
     constexpr operator std::string_view() const { return value; }
+    // NOLINTEND(google-explicit-constructor)
     char value[N]{};
   };
 

--- a/phlex/utilities/thread_counter.hpp
+++ b/phlex/utilities/thread_counter.hpp
@@ -10,7 +10,7 @@ namespace phlex::experimental {
   public:
     using counter_type = std::atomic<unsigned int>;
     using value_type = counter_type::value_type;
-    thread_counter(counter_type& counter, value_type const max_value = 1) :
+    explicit thread_counter(counter_type& counter, value_type const max_value = 1) :
       counter_{counter}, max_{max_value}
     {
       auto const count = ++counter_;

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -109,12 +109,14 @@ namespace {
   struct py_callback {
     PyObject* m_callable; // owned
 
+    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
     py_callback(PyObject* callable) : m_callable(callable)
     {
       // callable is always non-null here (validated before py_callback construction)
       PyGILRAII gil;
       Py_INCREF(m_callable);
     }
+    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
     py_callback(py_callback const& pc) : m_callable(pc.m_callable)
     {
       // Must hold GIL when manipulating reference counts
@@ -132,6 +134,7 @@ namespace {
       }
       return *this;
     }
+    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
     ~py_callback()
     {
       // TODO: cleanup deferred to Phlex shutdown hook

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -109,14 +109,12 @@ namespace {
   struct py_callback {
     PyObject* m_callable; // owned
 
-    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
-    py_callback(PyObject* callable) : m_callable(callable)
+    explicit py_callback(PyObject* callable) : m_callable(callable)
     {
       // callable is always non-null here (validated before py_callback construction)
       PyGILRAII gil;
       Py_INCREF(m_callable);
     }
-    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
     py_callback(py_callback const& pc) : m_callable(pc.m_callable)
     {
       // Must hold GIL when manipulating reference counts
@@ -205,14 +203,17 @@ namespace {
   // use explicit instatiations to ensure that the function signature can
   // be derived by the graph builder
   struct py_callback_1 : public py_callback<1> {
+    using py_callback<1>::py_callback;
     intptr_t operator()(intptr_t arg0) { return call(arg0); }
   };
 
   struct py_callback_2 : public py_callback<2> {
+    using py_callback<2>::py_callback;
     intptr_t operator()(intptr_t arg0, intptr_t arg1) { return call(arg0, arg1); }
   };
 
   struct py_callback_3 : public py_callback<3> {
+    using py_callback<3>::py_callback;
     intptr_t operator()(intptr_t arg0, intptr_t arg1, intptr_t arg2)
     {
       return call(arg0, arg1, arg2);
@@ -220,14 +221,17 @@ namespace {
   };
 
   struct py_callback_1v : public py_callback<1> {
+    using py_callback<1>::py_callback;
     void operator()(intptr_t arg0) { callv(arg0); }
   };
 
   struct py_callback_2v : public py_callback<2> {
+    using py_callback<2>::py_callback;
     void operator()(intptr_t arg0, intptr_t arg1) { callv(arg0, arg1); }
   };
 
   struct py_callback_3v : public py_callback<3> {
+    using py_callback<3>::py_callback;
     void operator()(intptr_t arg0, intptr_t arg1, intptr_t arg2) { callv(arg0, arg1, arg2); }
   };
 
@@ -516,6 +520,7 @@ namespace {
   }                                                                                                \
                                                                                                    \
   struct provider_cb_##name : public py_callback<1> {                                              \
+    using py_callback<1>::py_callback;                                                             \
     cpptype operator()(data_cell_index const& id)                                                  \
     {                                                                                              \
       PyGILRAII gil;                                                                               \
@@ -634,6 +639,7 @@ namespace {
   }                                                                                                \
                                                                                                    \
   struct provider_cb_##name : public py_callback<1> {                                              \
+    using py_callback<1>::py_callback;                                                             \
     std::shared_ptr<std::vector<cpptype>> operator()(data_cell_index const& id)                    \
     {                                                                                              \
       PyGILRAII gil;                                                                               \

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -134,7 +134,6 @@ namespace {
       }
       return *this;
     }
-    // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
     ~py_callback()
     {
       // TODO: cleanup deferred to Phlex shutdown hook

--- a/test/filter.cpp
+++ b/test/filter.cpp
@@ -30,7 +30,7 @@ namespace {
 
   // Hacky!
   struct sum_numbers {
-    sum_numbers(unsigned int const n) : total{n} {}
+    explicit sum_numbers(unsigned int const n) : total{n} {}
     ~sum_numbers() { CHECK(sum == total); }
     sum_numbers(sum_numbers const&) = delete;
     sum_numbers& operator=(sum_numbers const&) = delete;
@@ -63,7 +63,7 @@ namespace {
 
   // Hacky!
   struct check_multiple_numbers {
-    check_multiple_numbers(int const n) : total{n}
+    explicit check_multiple_numbers(int const n) : total{n}
     {
       spdlog::debug("construct check_multiple_numbers with n = {}", n);
     }

--- a/test/form/toy_tracker.hpp
+++ b/test/form/toy_tracker.hpp
@@ -8,7 +8,7 @@ class TrackStart;
 
 class ToyTracker {
 public:
-  ToyTracker(int maxTracks);
+  explicit ToyTracker(int maxTracks);
   ~ToyTracker() = default;
 
   std::vector<TrackStart> operator()();


### PR DESCRIPTION
Address 38 instances of the `google-explicit-constructor` clang-tidy check
(also known as `misc-explicit-constructor` in clang-tidy >= 23.0.0) by:

- Adding `explicit` keyword to single-argument constructors that should not
  allow implicit conversion
- Adding `NOLINT` comments with rationale for constructors where implicit
  conversion is intentional (e.g., wrapper types, conversion operators)
- Removing `explicit` from `fixed_hierarchy(std::initializer_list<...>)` to
  reduce required braces in user code, as documented in the comment

Updated `docs/dev/clang-tidy-fixes-2026-04.md` to track this work item.
