### PR TITLE
Optimize FORM storage init by replacing double find with insert(...).first

### DIFF
--- a/form/storage/storage_reader.cpp
+++ b/form/storage/storage_reader.cpp
@@ -24,21 +24,21 @@ int StorageReader::getIndex(Token const& token,
     auto key = std::make_pair(token.fileName(), token.containerName());
     auto cont = m_read_containers.find(key);
     if (cont == m_read_containers.end()) {
-      auto [file, inserted] = m_files.try_emplace(
-        token.fileName(), createFile(token.technology(), token.fileName(), 'i'));
-      if (inserted) {
+      auto file = m_files.find(token.fileName());
+      if (file == m_files.end()) {
+        file =
+          m_files.insert({token.fileName(), createFile(token.technology(), token.fileName(), 'i')})
+            .first;
         for (auto const& [key, value] : settings.getFileTable(token.technology(), token.fileName()))
           file->second->setAttribute(key, value);
       }
-      auto [cont_it, cont_inserted] = m_read_containers.try_emplace(
-        key, createReadContainer(token.technology(), token.containerName()));
-      if (cont_inserted) {
-        for (auto const& [key, value] :
-             settings.getContainerTable(token.technology(), token.containerName()))
-          cont_it->second->setAttribute(key, value);
-        cont_it->second->setFile(file->second);
-      }
-      cont = cont_it;
+      cont = m_read_containers
+               .insert({key, createReadContainer(token.technology(), token.containerName())})
+               .first;
+      for (auto const& [key, value] :
+           settings.getContainerTable(token.technology(), token.containerName()))
+        cont->second->setAttribute(key, value);
+      cont->second->setFile(file->second);
     }
     auto const& type = typeid(std::string);
     int entry = 1;
@@ -61,21 +61,21 @@ void StorageReader::readContainer(Token const& token,
   auto key = std::make_pair(token.fileName(), token.containerName());
   auto cont = m_read_containers.find(key);
   if (cont == m_read_containers.end()) {
-    auto [file, inserted] =
-      m_files.try_emplace(token.fileName(), createFile(token.technology(), token.fileName(), 'i'));
-    if (inserted) {
+    auto file = m_files.find(token.fileName());
+    if (file == m_files.end()) {
+      file =
+        m_files.insert({token.fileName(), createFile(token.technology(), token.fileName(), 'i')})
+          .first;
       for (auto const& [key, value] : settings.getFileTable(token.technology(), token.fileName()))
         file->second->setAttribute(key, value);
     }
-    auto [cont_it, cont_inserted] = m_read_containers.try_emplace(
-      key, createReadContainer(token.technology(), token.containerName()));
-    if (cont_inserted) {
-      cont_it->second->setFile(file->second);
-      for (auto const& [key, value] :
-           settings.getContainerTable(token.technology(), token.containerName()))
-        cont_it->second->setAttribute(key, value);
-    }
-    cont = cont_it;
+    cont = m_read_containers
+             .insert({key, createReadContainer(token.technology(), token.containerName())})
+             .first;
+    cont->second->setFile(file->second);
+    for (auto const& [key, value] :
+         settings.getContainerTable(token.technology(), token.containerName()))
+      cont->second->setAttribute(key, value);
   }
   cont->second->read(token.id(), data, type);
   return;

--- a/form/storage/storage_reader.cpp
+++ b/form/storage/storage_reader.cpp
@@ -25,13 +25,13 @@ int StorageReader::getIndex(Token const& token,
     auto cont = m_read_containers.find(key);
     if (cont == m_read_containers.end()) {
       auto [file, inserted] = m_files.try_emplace(
-          token.fileName(), createFile(token.technology(), token.fileName(), 'i'));
+        token.fileName(), createFile(token.technology(), token.fileName(), 'i'));
       if (inserted) {
         for (auto const& [key, value] : settings.getFileTable(token.technology(), token.fileName()))
           file->second->setAttribute(key, value);
       }
       auto [cont_it, cont_inserted] = m_read_containers.try_emplace(
-          key, createReadContainer(token.technology(), token.containerName()));
+        key, createReadContainer(token.technology(), token.containerName()));
       if (cont_inserted) {
         for (auto const& [key, value] :
              settings.getContainerTable(token.technology(), token.containerName()))
@@ -61,14 +61,14 @@ void StorageReader::readContainer(Token const& token,
   auto key = std::make_pair(token.fileName(), token.containerName());
   auto cont = m_read_containers.find(key);
   if (cont == m_read_containers.end()) {
-    auto [file, inserted] = m_files.try_emplace(
-        token.fileName(), createFile(token.technology(), token.fileName(), 'i'));
+    auto [file, inserted] =
+      m_files.try_emplace(token.fileName(), createFile(token.technology(), token.fileName(), 'i'));
     if (inserted) {
       for (auto const& [key, value] : settings.getFileTable(token.technology(), token.fileName()))
         file->second->setAttribute(key, value);
     }
     auto [cont_it, cont_inserted] = m_read_containers.try_emplace(
-        key, createReadContainer(token.technology(), token.containerName()));
+      key, createReadContainer(token.technology(), token.containerName()));
     if (cont_inserted) {
       cont_it->second->setFile(file->second);
       for (auto const& [key, value] :

--- a/form/storage/storage_reader.cpp
+++ b/form/storage/storage_reader.cpp
@@ -24,20 +24,21 @@ int StorageReader::getIndex(Token const& token,
     auto key = std::make_pair(token.fileName(), token.containerName());
     auto cont = m_read_containers.find(key);
     if (cont == m_read_containers.end()) {
-      auto file = m_files.find(token.fileName());
-      if (file == m_files.end()) {
-        m_files.insert({token.fileName(), createFile(token.technology(), token.fileName(), 'i')});
-        file = m_files.find(token.fileName());
+      auto [file, inserted] = m_files.try_emplace(
+          token.fileName(), createFile(token.technology(), token.fileName(), 'i'));
+      if (inserted) {
         for (auto const& [key, value] : settings.getFileTable(token.technology(), token.fileName()))
           file->second->setAttribute(key, value);
       }
-      m_read_containers.insert(
-        {key, createReadContainer(token.technology(), token.containerName())});
-      cont = m_read_containers.find(key);
-      for (auto const& [key, value] :
-           settings.getContainerTable(token.technology(), token.containerName()))
-        cont->second->setAttribute(key, value);
-      cont->second->setFile(file->second);
+      auto [cont_it, cont_inserted] = m_read_containers.try_emplace(
+          key, createReadContainer(token.technology(), token.containerName()));
+      if (cont_inserted) {
+        for (auto const& [key, value] :
+             settings.getContainerTable(token.technology(), token.containerName()))
+          cont_it->second->setAttribute(key, value);
+        cont_it->second->setFile(file->second);
+      }
+      cont = cont_it;
     }
     auto const& type = typeid(std::string);
     int entry = 1;
@@ -60,19 +61,21 @@ void StorageReader::readContainer(Token const& token,
   auto key = std::make_pair(token.fileName(), token.containerName());
   auto cont = m_read_containers.find(key);
   if (cont == m_read_containers.end()) {
-    auto file = m_files.find(token.fileName());
-    if (file == m_files.end()) {
-      m_files.insert({token.fileName(), createFile(token.technology(), token.fileName(), 'i')});
-      file = m_files.find(token.fileName());
+    auto [file, inserted] = m_files.try_emplace(
+        token.fileName(), createFile(token.technology(), token.fileName(), 'i'));
+    if (inserted) {
       for (auto const& [key, value] : settings.getFileTable(token.technology(), token.fileName()))
         file->second->setAttribute(key, value);
     }
-    m_read_containers.insert({key, createReadContainer(token.technology(), token.containerName())});
-    cont = m_read_containers.find(key);
-    cont->second->setFile(file->second);
-    for (auto const& [key, value] :
-         settings.getContainerTable(token.technology(), token.containerName()))
-      cont->second->setAttribute(key, value);
+    auto [cont_it, cont_inserted] = m_read_containers.try_emplace(
+        key, createReadContainer(token.technology(), token.containerName()));
+    if (cont_inserted) {
+      cont_it->second->setFile(file->second);
+      for (auto const& [key, value] :
+           settings.getContainerTable(token.technology(), token.containerName()))
+        cont_it->second->setAttribute(key, value);
+    }
+    cont = cont_it;
   }
   cont->second->read(token.id(), data, type);
   return;

--- a/form/storage/storage_writer.cpp
+++ b/form/storage/storage_writer.cpp
@@ -27,9 +27,12 @@ void StorageWriter::createContainers(
     auto cont = m_write_containers.find(key);
     if (cont == m_write_containers.end()) {
       // Ensure the file exists
-      auto [file, inserted] = m_files.try_emplace(
-        plcmnt->fileName(), createFile(plcmnt->technology(), plcmnt->fileName(), 'o'));
-      if (inserted) {
+      auto file = m_files.find(plcmnt->fileName());
+      if (file == m_files.end()) {
+        file =
+          m_files
+            .insert({plcmnt->fileName(), createFile(plcmnt->technology(), plcmnt->fileName(), 'o')})
+            .first;
         for (auto const& [key, value] :
              settings.getFileTable(plcmnt->technology(), plcmnt->fileName()))
           file->second->setAttribute(key, value);

--- a/form/storage/storage_writer.cpp
+++ b/form/storage/storage_writer.cpp
@@ -27,11 +27,10 @@ void StorageWriter::createContainers(
     auto cont = m_write_containers.find(key);
     if (cont == m_write_containers.end()) {
       // Ensure the file exists
-      auto file = m_files.find(plcmnt->fileName());
-      if (file == m_files.end()) {
-        m_files.insert(
-          {plcmnt->fileName(), createFile(plcmnt->technology(), plcmnt->fileName(), 'o')});
-        file = m_files.find(plcmnt->fileName());
+      auto [file, inserted] = m_files.try_emplace(
+          plcmnt->fileName(),
+          createFile(plcmnt->technology(), plcmnt->fileName(), 'o'));
+      if (inserted) {
         for (auto const& [key, value] :
              settings.getFileTable(plcmnt->technology(), plcmnt->fileName()))
           file->second->setAttribute(key, value);

--- a/form/storage/storage_writer.cpp
+++ b/form/storage/storage_writer.cpp
@@ -28,8 +28,7 @@ void StorageWriter::createContainers(
     if (cont == m_write_containers.end()) {
       // Ensure the file exists
       auto [file, inserted] = m_files.try_emplace(
-          plcmnt->fileName(),
-          createFile(plcmnt->technology(), plcmnt->fileName(), 'o'));
+        plcmnt->fileName(), createFile(plcmnt->technology(), plcmnt->fileName(), 'o'));
       if (inserted) {
         for (auto const& [key, value] :
              settings.getFileTable(plcmnt->technology(), plcmnt->fileName()))


### PR DESCRIPTION
## Summary

Replace double `find()` lookups with single-lookup using `insert(...).first` in FORM storage initialization.

**Changes**
- Before: `find()` → `insert()` → `find()` again (two lookups)
- After: `find()` → `insert(...).first` (single lookup)

**Why not `try_emplace`?**
An earlier version attempted `try_emplace` but caused test failures due to unconditional constructor calls that broke lazy initialization semantics. The `insert(...).first` pattern is safe and equally efficient.

**Files changed:** `storage_writer.cpp`, `storage_reader.cpp`