### PR TITLE
FORM TTree Write Fundamental Types

### DIFF
--- a/form/root_storage/root_tbranch_write_container.cpp
+++ b/form/root_storage/root_tbranch_write_container.cpp
@@ -57,20 +57,19 @@ void ROOT_TBranch_Write_ContainerImp::setupWrite(std::type_info const& type)
 {
   //Type name conversion based on https://root.cern.ch/doc/master/classTTree.html#ac1fa9466ce018d4aa739b357f981c615
   //An empty leaf list (i.e. for a type not in this map) defaults to Float_t; this is intentional.
-  static std::map<Int_t, std::string> typeNameToLeafList = {
-    {kChar_t, "/B"},
-    {kUChar_t, "/b"},
-    {kInt_t, "/I"},
-    {kUInt_t, "/i"},
-    {kFloat_t, "/F"},
-    {kDouble_t, "/D"},
-    {kShort_t, "/S"},
-    {kUShort_t, "/s"},
-    {kLong_t, "/G"},
-    {kULong_t, "/g"},
-    {kLong64_t, "/L"},
-    {kULong64_t, "/l"},
-    {kBool_t, "/O"}};
+  static std::map<Int_t, std::string> typeNameToLeafList = {{kChar_t, "/B"},
+                                                            {kUChar_t, "/b"},
+                                                            {kInt_t, "/I"},
+                                                            {kUInt_t, "/i"},
+                                                            {kFloat_t, "/F"},
+                                                            {kDouble_t, "/D"},
+                                                            {kShort_t, "/S"},
+                                                            {kUShort_t, "/s"},
+                                                            {kLong_t, "/G"},
+                                                            {kULong_t, "/g"},
+                                                            {kLong64_t, "/L"},
+                                                            {kULong64_t, "/l"},
+                                                            {kBool_t, "/O"}};
 
   if (m_tree == nullptr) {
     throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::setupWrite no tree found");
@@ -83,10 +82,11 @@ void ROOT_TBranch_Write_ContainerImp::setupWrite(std::type_info const& type)
                                DemangleName(type));
     }
     if (dictInfo->Property() & EProperty::kIsFundamental) {
-      m_branch = m_tree->Branch(col_name().c_str(),
-                                static_cast<void*>(nullptr), // Overload selection
-                                (col_name() + typeNameToLeafList[static_cast<TDataType*>(dictInfo)->GetType()]).c_str(),
-                                4096);
+      m_branch = m_tree->Branch(
+        col_name().c_str(),
+        static_cast<void*>(nullptr), // Overload selection
+        (col_name() + typeNameToLeafList[static_cast<TDataType*>(dictInfo)->GetType()]).c_str(),
+        4096);
     } else {
       m_branch = m_tree->Branch(col_name().c_str(), dictInfo->GetName(), nullptr);
     }

--- a/form/root_storage/root_tbranch_write_container.cpp
+++ b/form/root_storage/root_tbranch_write_container.cpp
@@ -85,7 +85,7 @@ void ROOT_TBranch_Write_ContainerImp::setupWrite(std::type_info const& type)
       m_branch = m_tree->Branch(
         col_name().c_str(),
         static_cast<void*>(nullptr), // Overload selection
-        (col_name() + typeNameToLeafList[static_cast<TDataType*>(dictInfo)->GetType()]).c_str(),
+        (col_name() + type_name_to_leaf_list[static_cast<TDataType*>(dictInfo)->GetType()]).c_str(),
         4096);
     } else {
       m_branch = m_tree->Branch(col_name().c_str(), dictInfo->GetName(), nullptr);

--- a/form/root_storage/root_tbranch_write_container.cpp
+++ b/form/root_storage/root_tbranch_write_container.cpp
@@ -57,7 +57,7 @@ void ROOT_TBranch_Write_ContainerImp::setupWrite(std::type_info const& type)
 {
   //Type name conversion based on https://root.cern.ch/doc/master/classTTree.html#ac1fa9466ce018d4aa739b357f981c615
   //An empty leaf list (i.e. for a type not in this map) defaults to Float_t; this is intentional.
-  static std::map<Int_t, std::string> typeNameToLeafList = {
+  static std::map<Int_t, std::string> type_name_to_leaf_list = {
     {kChar_t, "/B"},
     {kUChar_t, "/b"},
     {kInt_t, "/I"},

--- a/form/root_storage/root_tbranch_write_container.cpp
+++ b/form/root_storage/root_tbranch_write_container.cpp
@@ -82,10 +82,10 @@ void ROOT_TBranch_Write_ContainerImp::setupWrite(std::type_info const& type)
                                DemangleName(type));
     }
     if (dictInfo->Property() & EProperty::kIsFundamental) {
-      //NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
       m_branch = m_tree->Branch(
         col_name().c_str(),
         static_cast<void*>(nullptr), // Overload selection
+        //NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
         (col_name() + type_name_to_leaf_list[static_cast<TDataType*>(dictInfo)->GetType()]).c_str(),
         4096);
     } else {

--- a/form/root_storage/root_tbranch_write_container.cpp
+++ b/form/root_storage/root_tbranch_write_container.cpp
@@ -82,6 +82,7 @@ void ROOT_TBranch_Write_ContainerImp::setupWrite(std::type_info const& type)
                                DemangleName(type));
     }
     if (dictInfo->Property() & EProperty::kIsFundamental) {
+      //NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
       m_branch = m_tree->Branch(
         col_name().c_str(),
         static_cast<void*>(nullptr), // Overload selection

--- a/form/root_storage/root_tbranch_write_container.cpp
+++ b/form/root_storage/root_tbranch_write_container.cpp
@@ -57,16 +57,20 @@ void ROOT_TBranch_Write_ContainerImp::setupWrite(std::type_info const& type)
 {
   //Type name conversion based on https://root.cern.ch/doc/master/classTTree.html#ac1fa9466ce018d4aa739b357f981c615
   //An empty leaf list (i.e. for a type not in this map) defaults to Float_t; this is intentional.
-  static std::unordered_map<std::string, std::string> typeNameToLeafList = {
-    {"int", "/I"},
-    {"unsigned int", "/i"},
-    {"float", "/F"},
-    {"double", "/D"},
-    {"short int", "/S"},
-    {"unsigned short", "/s"},
-    {"long int", "/L"},
-    {"unsigned long int", "/l"},
-    {"bool", "/O"}};
+  static std::map<Int_t, std::string> typeNameToLeafList = {
+    {kChar_t, "/B"},
+    {kUChar_t, "/b"},
+    {kInt_t, "/I"},
+    {kUInt_t, "/i"},
+    {kFloat_t, "/F"},
+    {kDouble_t, "/D"},
+    {kShort_t, "/S"},
+    {kUShort_t, "/s"},
+    {kLong_t, "/G"},
+    {kULong_t, "/g"},
+    {kLong64_t, "/L"},
+    {kULong64_t, "/l"},
+    {kBool_t, "/O"}};
 
   if (m_tree == nullptr) {
     throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::setupWrite no tree found");
@@ -81,7 +85,7 @@ void ROOT_TBranch_Write_ContainerImp::setupWrite(std::type_info const& type)
     if (dictInfo->Property() & EProperty::kIsFundamental) {
       m_branch = m_tree->Branch(col_name().c_str(),
                                 static_cast<void*>(nullptr), // Overload selection
-                                (col_name() + typeNameToLeafList[dictInfo->GetName()]).c_str(),
+                                (col_name() + typeNameToLeafList[static_cast<TDataType*>(dictInfo)->GetType()]).c_str(),
                                 4096);
     } else {
       m_branch = m_tree->Branch(col_name().c_str(), dictInfo->GetName(), nullptr);


### PR DESCRIPTION
FORM's TTree backend can't write some of the fundamental types that ROOT supports right now because it doesn't have leaflist entries for e.g. `long long`.  This PR makes FORM as capable with fundamental types as TTree itself and makes the leaflist map more robust.  Part of a chain of PRs that will lead to RNTuple-friendly tests.