### PR TITLE
Exclude `scripts/` path from `unittests` code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -27,6 +27,8 @@ coverage:
 flags:
   unittests:
     # Coverage from the main C++ and Python test suite.
+    paths:
+      - "!scripts/"
     carryforward: true
   scripts:
     # Coverage for scripts/ utility modules.  No status thresholds are set


### PR DESCRIPTION
Looking at [this code coverage example](https://app.codecov.io/gh/Framework-R-D/phlex?flags%5B0%5D=unittests), the scripts directory for this repository was included with the unittests flag. This was not intended. This PR fixes the problem.