### PR TITLE
Optimize some hot paths

### DIFF
--- a/phlex/core/consumer.cpp
+++ b/phlex/core/consumer.cpp
@@ -6,8 +6,8 @@ namespace phlex::experimental {
   {
   }
 
+  algorithm_name const& consumer::name() const noexcept { return name_; }
   std::string consumer::full_name() const { return name_.full(); }
-
   identifier const& consumer::plugin() const noexcept { return name_.plugin(); }
   identifier const& consumer::algorithm() const noexcept { return name_.algorithm(); }
 

--- a/phlex/core/consumer.cpp
+++ b/phlex/core/consumer.cpp
@@ -7,7 +7,6 @@ namespace phlex::experimental {
   }
 
   algorithm_name const& consumer::name() const noexcept { return name_; }
-  std::string consumer::full_name() const { return name_.full(); }
   identifier const& consumer::plugin() const noexcept { return name_.plugin(); }
   identifier const& consumer::algorithm() const noexcept { return name_.algorithm(); }
 

--- a/phlex/core/consumer.hpp
+++ b/phlex/core/consumer.hpp
@@ -13,6 +13,7 @@ namespace phlex::experimental {
   public:
     consumer(algorithm_name name, std::vector<std::string> predicates);
 
+    algorithm_name const& name() const noexcept;
     std::string full_name() const;
     identifier const& plugin() const noexcept;
     identifier const& algorithm() const noexcept;

--- a/phlex/core/consumer.hpp
+++ b/phlex/core/consumer.hpp
@@ -14,7 +14,6 @@ namespace phlex::experimental {
     consumer(algorithm_name name, std::vector<std::string> predicates);
 
     algorithm_name const& name() const noexcept;
-    std::string full_name() const;
     identifier const& plugin() const noexcept;
     identifier const& algorithm() const noexcept;
     std::vector<std::string> const& when() const noexcept;

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -126,7 +126,7 @@ namespace phlex::experimental {
     void emit_and_evict_if_done(data_cell_index_ptr const& fold_index)
     {
       if (auto counter = done_with(fold_index->hash())) {
-        auto parent = std::make_shared<product_store>(fold_index, this->full_name());
+        auto parent = std::make_shared<product_store>(fold_index, this->name());
         commit(parent);
         ++product_count_;
         tbb::flow::output_port<0>(fold_).try_put(

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -65,7 +65,7 @@ namespace phlex::experimental {
     using function_t = typename AlgorithmBits::bound_type;
 
   public:
-    fold_node(algorithm_name name,
+    fold_node(algorithm_name algo_name,
               std::size_t concurrency,
               std::vector<std::string> predicates,
               tbb::flow::graph& g,
@@ -74,10 +74,10 @@ namespace phlex::experimental {
               product_queries input_products,
               std::vector<std::string> output,
               std::string partition) :
-      declared_fold{std::move(name), std::move(predicates), std::move(input_products)},
+      declared_fold{std::move(algo_name), std::move(predicates), std::move(input_products)},
       initializer_{std::move(initializer)},
       output_{
-        to_product_specifications(full_name(), std::move(output), make_type_ids<result_type>())},
+        to_product_specifications(name().full(), std::move(output), make_type_ids<result_type>())},
       partition_{std::move(partition)},
       flush_receiver_{g,
                       tbb::flow::unlimited,
@@ -92,7 +92,7 @@ namespace phlex::experimental {
                         return {};
                       }},
       join_{make_join_or_none<num_inputs>(
-        g, full_name(), layers())}, // FIXME: This should change to include result product!
+        g, name().full(), layers())}, // FIXME: This should change to include result product!
       fold_{g,
             concurrency,
             [this, ft = alg.release_algorithm()](messages_t<num_inputs> const& messages, auto&) {
@@ -126,7 +126,7 @@ namespace phlex::experimental {
     void emit_and_evict_if_done(data_cell_index_ptr const& fold_index)
     {
       if (auto counter = done_with(fold_index->hash())) {
-        auto parent = std::make_shared<product_store>(fold_index, this->name());
+        auto parent = std::make_shared<product_store>(fold_index, name());
         commit(parent);
         ++product_count_;
         tbb::flow::output_port<0>(fold_).try_put(

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -76,8 +76,7 @@ namespace phlex::experimental {
               std::string partition) :
       declared_fold{std::move(algo_name), std::move(predicates), std::move(input_products)},
       initializer_{std::move(initializer)},
-      output_{
-        to_product_specifications(name().full(), std::move(output), make_type_ids<result_type>())},
+      output_{to_product_specifications(name(), std::move(output), make_type_ids<result_type>())},
       partition_{std::move(partition)},
       flush_receiver_{g,
                       tbb::flow::unlimited,

--- a/phlex/core/declared_observer.hpp
+++ b/phlex/core/declared_observer.hpp
@@ -55,14 +55,14 @@ namespace phlex::experimental {
     static constexpr auto number_output_products = 0;
     using node_ptr_type = declared_observer_ptr;
 
-    observer_node(algorithm_name name,
+    observer_node(algorithm_name algo_name,
                   std::size_t concurrency,
                   std::vector<std::string> predicates,
                   tbb::flow::graph& g,
                   AlgorithmBits alg,
                   product_queries input_products) :
-      declared_observer{std::move(name), std::move(predicates), std::move(input_products)},
-      join_{make_join_or_none<num_inputs>(g, full_name(), layers())},
+      declared_observer{std::move(algo_name), std::move(predicates), std::move(input_products)},
+      join_{make_join_or_none<num_inputs>(g, name().full(), layers())},
       observer_{g,
                 concurrency,
                 [this, ft = alg.release_algorithm()](

--- a/phlex/core/declared_predicate.hpp
+++ b/phlex/core/declared_predicate.hpp
@@ -59,14 +59,14 @@ namespace phlex::experimental {
     static constexpr auto number_output_products = 0ull;
     using node_ptr_type = declared_predicate_ptr;
 
-    predicate_node(algorithm_name name,
+    predicate_node(algorithm_name algo_name,
                    std::size_t concurrency,
                    std::vector<std::string> predicates,
                    tbb::flow::graph& g,
                    AlgorithmBits alg,
                    product_queries input_products) :
-      declared_predicate{std::move(name), std::move(predicates), std::move(input_products)},
-      join_{make_join_or_none<num_inputs>(g, full_name(), layers())},
+      declared_predicate{std::move(algo_name), std::move(predicates), std::move(input_products)},
+      join_{make_join_or_none<num_inputs>(g, name().full(), layers())},
       predicate_{g,
                  concurrency,
                  [this, ft = alg.release_algorithm()](

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -89,10 +89,10 @@ namespace phlex::experimental {
           ++calls_;
           ++product_count_[store->index()->layer_hash()];
 
-          products new_products;
+          products new_products{num_outputs};
           new_products.add_all(output_, std::move(result));
-          auto new_store = std::make_shared<product_store>(
-            store->index(), this->full_name(), std::move(new_products));
+          auto new_store =
+            std::make_shared<product_store>(store->index(), this->name(), std::move(new_products));
 
           std::get<0>(output).try_put({.store = std::move(new_store), .id = message_id});
         }}

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -75,8 +75,8 @@ namespace phlex::experimental {
                    product_queries input_products,
                    std::vector<std::string> output) :
       declared_transform{std::move(algo_name), std::move(predicates), std::move(input_products)},
-      output_{to_product_specifications(
-        name().full(), std::move(output), make_output_type_ids<function_t>())},
+      output_{
+        to_product_specifications(name(), std::move(output), make_output_type_ids<function_t>())},
       join_{make_join_or_none<num_inputs>(g, name().full(), layers())},
       transform_{
         g,

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -67,17 +67,17 @@ namespace phlex::experimental {
     using node_ptr_type = declared_transform_ptr;
     static constexpr auto number_output_products = num_outputs;
 
-    transform_node(algorithm_name name,
+    transform_node(algorithm_name algo_name,
                    std::size_t concurrency,
                    std::vector<std::string> predicates,
                    tbb::flow::graph& g,
                    AlgorithmBits alg,
                    product_queries input_products,
                    std::vector<std::string> output) :
-      declared_transform{std::move(name), std::move(predicates), std::move(input_products)},
+      declared_transform{std::move(algo_name), std::move(predicates), std::move(input_products)},
       output_{to_product_specifications(
-        full_name(), std::move(output), make_output_type_ids<function_t>())},
-      join_{make_join_or_none<num_inputs>(g, full_name(), layers())},
+        name().full(), std::move(output), make_output_type_ids<function_t>())},
+      join_{make_join_or_none<num_inputs>(g, name().full(), layers())},
       transform_{
         g,
         concurrency,
@@ -92,7 +92,7 @@ namespace phlex::experimental {
           products new_products{num_outputs};
           new_products.add_all(output_, std::move(result));
           auto new_store =
-            std::make_shared<product_store>(store->index(), this->name(), std::move(new_products));
+            std::make_shared<product_store>(store->index(), name(), std::move(new_products));
 
           std::get<0>(output).try_put({.store = std::move(new_store), .id = message_id});
         }}

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -100,7 +100,7 @@ namespace phlex::experimental {
                       std::move(predicates),
                       std::move(input_products),
                       std::move(child_layer_name)},
-      output_{to_product_specifications(name().full(),
+      output_{to_product_specifications(name(),
                                         std::move(output_product_suffixes),
                                         make_type_ids<skip_first_type<return_type<Unfold>>>())},
       join_{make_join_or_none<num_inputs>(g, name().full(), layers())},
@@ -111,7 +111,7 @@ namespace phlex::experimental {
                 auto const& msg = most_derived(messages);
                 auto const& store = msg.store;
 
-                generator gen{store, name().full(), child_layer()};
+                generator gen{store, name(), child_layer()};
                 call(
                   p, ufold, store->index(), gen, messages, std::make_index_sequence<num_inputs>{});
                 std::get<2>(outputs).try_put({.index = store->index(),

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -167,7 +167,7 @@ namespace phlex::experimental {
       std::size_t counter = 0;
       auto running_value = obj.initial_value();
       while (std::invoke(predicate, obj, running_value)) {
-        products new_products;
+        products new_products{num_outputs};
         auto new_id = unfolded_id->make_child(child_layer(), counter);
         if constexpr (requires { std::invoke(unfold, obj, running_value, *new_id); }) {
           auto [next_value, prods] = std::invoke(unfold, obj, running_value, *new_id);

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -87,7 +87,7 @@ namespace phlex::experimental {
     static constexpr std::size_t num_outputs = number_output_objects<Unfold>;
 
   public:
-    unfold_node(algorithm_name name,
+    unfold_node(algorithm_name algo_name,
                 std::size_t concurrency,
                 std::vector<std::string> predicates,
                 tbb::flow::graph& g,
@@ -96,14 +96,14 @@ namespace phlex::experimental {
                 product_queries input_products,
                 std::vector<std::string> output_product_suffixes,
                 std::string child_layer_name) :
-      declared_unfold{std::move(name),
+      declared_unfold{std::move(algo_name),
                       std::move(predicates),
                       std::move(input_products),
                       std::move(child_layer_name)},
-      output_{to_product_specifications(full_name(),
+      output_{to_product_specifications(name().full(),
                                         std::move(output_product_suffixes),
                                         make_type_ids<skip_first_type<return_type<Unfold>>>())},
-      join_{make_join_or_none<num_inputs>(g, full_name(), layers())},
+      join_{make_join_or_none<num_inputs>(g, name().full(), layers())},
       unfold_{g,
               concurrency,
               [this, p = std::move(predicate), ufold = std::move(unfold)](
@@ -111,7 +111,7 @@ namespace phlex::experimental {
                 auto const& msg = most_derived(messages);
                 auto const& store = msg.store;
 
-                generator gen{store, this->full_name(), child_layer()};
+                generator gen{store, name().full(), child_layer()};
                 call(
                   p, ufold, store->index(), gen, messages, std::make_index_sequence<num_inputs>{});
                 std::get<2>(outputs).try_put({.index = store->index(),

--- a/phlex/core/edge_maker.cpp
+++ b/phlex/core/edge_maker.cpp
@@ -23,11 +23,11 @@ namespace phlex::experimental {
           auto& provider = *p;
           if (port.input_product.match(
                 provider.output_product(), provider.layer(), provider.stage())) {
-            if (!result.contains(provider.full_name())) {
-              result.try_emplace(provider.full_name(), port.input_product, provider.input_port());
+            if (!result.contains(provider.name().full())) {
+              result.try_emplace(provider.name().full(), port.input_product, provider.input_port());
             }
             spdlog::debug("Connecting provider {} to node {} (product: {})",
-                          provider.full_name(),
+                          provider.name().full(),
                           node_name,
                           port.input_product.to_string());
             make_edge(provider.output_port(), *(port.port));

--- a/phlex/core/provider_node.cpp
+++ b/phlex/core/provider_node.cpp
@@ -27,10 +27,9 @@ namespace phlex::experimental {
                 auto new_product = std::invoke(ft, *index);
                 ++calls_;
 
-                products new_products;
+                products new_products{1uz};
                 new_products.add(output_, std::move(new_product));
-                auto store = std::make_shared<product_store>(
-                  index, this->full_name(), std::move(new_products));
+                auto store = std::make_shared<product_store>(index, name_, std::move(new_products));
 
                 return {.store = std::move(store), .id = msg_id};
               }}

--- a/phlex/core/provider_node.cpp
+++ b/phlex/core/provider_node.cpp
@@ -8,14 +8,14 @@
 #include <utility>
 
 namespace phlex::experimental {
-  provider_node::provider_node(algorithm_name name,
+  provider_node::provider_node(algorithm_name algo_name,
                                std::size_t concurrency,
                                tbb::flow::graph& g,
                                provider_function provider_func,
                                product_specification output_spec,
                                identifier output_layer,
                                identifier stage) :
-    name_{std::move(name)},
+    name_{std::move(algo_name)},
     output_{std::move(output_spec)},
     layer_{std::move(output_layer)},
     stage_{std::move(stage)},
@@ -35,10 +35,10 @@ namespace phlex::experimental {
               }}
   {
     spdlog::debug(
-      "Created provider node {} making output {} ϵ {}", this->full_name(), output_.full(), layer_);
+      "Created provider node {} making output {} ϵ {}", name().full(), output_.full(), layer_);
   }
 
-  std::string provider_node::full_name() const { return name_.full(); }
+  algorithm_name const& provider_node::name() const noexcept { return name_; }
 
   product_specification const& provider_node::output_product() const noexcept { return output_; }
 

--- a/phlex/core/provider_node.hpp
+++ b/phlex/core/provider_node.hpp
@@ -14,7 +14,6 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
-#include <string>
 
 namespace phlex::experimental {
 
@@ -30,7 +29,7 @@ namespace phlex::experimental {
                   identifier output_layer,
                   identifier stage);
 
-    std::string full_name() const;
+    algorithm_name const& name() const noexcept;
     product_specification const& output_product() const noexcept;
     identifier const& layer() const noexcept;
     identifier const& stage() const noexcept;

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -112,7 +112,7 @@ namespace phlex::experimental {
     {
       assert(creator_);
       auto ptr = creator_(release_predicates(), std::move(output_product_suffixes));
-      auto name = ptr->full_name();
+      auto name = ptr->name().full();
       auto [_, inserted] = nodes_->try_emplace(name, std::move(ptr));
       if (not inserted) {
         detail::add_to_error_messages(*errors_, name);

--- a/phlex/model/product_specification.cpp
+++ b/phlex/model/product_specification.cpp
@@ -50,7 +50,7 @@ namespace phlex::experimental {
     return {algorithm_name::create(""), identifier(s), type_id{}};
   }
 
-  product_specifications to_product_specifications(std::string_view const algorithm_specification,
+  product_specifications to_product_specifications(algorithm_name const& algo_name,
                                                    std::vector<std::string> output_suffixes,
                                                    std::vector<type_id> output_types)
   {
@@ -68,7 +68,6 @@ namespace phlex::experimental {
     assert(output_suffixes.size() == output_types.size());
 
     // We can use std::views::zip_transform once the AppleClang C++ STL supports it.
-    auto const algo_name = algorithm_name::create(algorithm_specification);
     return std::views::zip(output_suffixes, output_types) |
            std::views::transform([&algo_name](auto const& p) {
              return product_specification{algo_name, identifier(std::get<0>(p)), std::get<1>(p)};

--- a/phlex/model/product_specification.hpp
+++ b/phlex/model/product_specification.hpp
@@ -49,7 +49,7 @@ namespace phlex::experimental {
   using product_specifications = std::vector<product_specification>;
 
   PHLEX_MODEL_EXPORT product_specifications
-  to_product_specifications(std::string_view name,
+  to_product_specifications(algorithm_name const& algo_name,
                             std::vector<std::string> output_suffixes,
                             std::vector<type_id> output_types);
 }

--- a/phlex/model/product_store.cpp
+++ b/phlex/model/product_store.cpp
@@ -24,11 +24,6 @@ namespace phlex::experimental {
   algorithm_name const& product_store::source() const noexcept { return source_; }
   data_cell_index_ptr const& product_store::index() const noexcept { return id_; }
 
-  bool product_store::contains_product(product_specification const& key) const
-  {
-    return products_.contains(key);
-  }
-
   product_store_ptr const& more_derived(product_store_ptr const& a, product_store_ptr const& b)
   {
     if (a->index()->depth() > b->index()->depth()) {

--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -35,8 +35,6 @@ namespace phlex::experimental {
     data_cell_index_ptr const& index() const noexcept;
 
     // Product interface
-    bool contains_product(product_specification const& key) const;
-
     template <typename T>
     T const& get_product(product_specification const& key) const;
 

--- a/phlex/model/products.cpp
+++ b/phlex/model/products.cpp
@@ -5,9 +5,14 @@
 #include <string>
 
 namespace phlex::experimental {
+  products::products(std::size_t number_known_products)
+  {
+    products_.reserve(number_known_products);
+  }
+
   bool products::contains(product_specification const& spec) const
   {
-    return products_.contains(spec);
+    return std::ranges::any_of(products_, [&](auto const& p) { return p.first == spec; });
   }
 
   products::const_iterator products::begin() const noexcept { return products_.begin(); }

--- a/phlex/model/products.cpp
+++ b/phlex/model/products.cpp
@@ -12,11 +12,6 @@ namespace phlex::experimental {
     products_.reserve(number_known_products);
   }
 
-  bool products::contains(product_specification const& spec) const
-  {
-    return std::ranges::any_of(products_, [&](auto const& p) { return p.first == spec; });
-  }
-
   products::const_iterator products::begin() const noexcept { return products_.begin(); }
   products::const_iterator products::end() const noexcept { return products_.end(); }
   products::size_type products::size() const noexcept { return products_.size(); }

--- a/phlex/model/products.cpp
+++ b/phlex/model/products.cpp
@@ -2,6 +2,8 @@
 
 #include "boost/core/demangle.hpp"
 
+#include <algorithm>
+#include <stdexcept>
 #include <string>
 
 namespace phlex::experimental {
@@ -19,6 +21,15 @@ namespace phlex::experimental {
   products::const_iterator products::end() const noexcept { return products_.end(); }
   products::size_type products::size() const noexcept { return products_.size(); }
   bool products::empty() const noexcept { return products_.empty(); }
+
+  product_base const* products::find_product(product_specification const& spec) const
+  {
+    auto it = std::ranges::find(products_, spec, [](auto const& p) { return p.first; });
+    if (it == products_.end()) {
+      throw std::runtime_error(fmt::format("No product exists with the name '{}'.", spec.full()));
+    }
+    return it->second.get();
+  }
 
   void products::throw_mismatched_type(product_specification const& spec,
                                        char const* requested_type,

--- a/phlex/model/products.hpp
+++ b/phlex/model/products.hpp
@@ -5,7 +5,6 @@
 
 #include "phlex/model/product_specification.hpp"
 
-#include <algorithm>
 #include <cassert>
 #include <concepts>
 #include <memory>
@@ -88,12 +87,7 @@ namespace phlex::experimental {
     template <typename T>
     T const& get(product_specification const& spec) const
     {
-      auto it = std::ranges::find(products_, spec, [](auto const& p) { return p.first; });
-      if (it == products_.end()) {
-        throw std::runtime_error(fmt::format("No product exists with the name '{}'.", spec.full()));
-      }
-
-      auto const* available_product = it->second.get();
+      auto const* available_product = find_product(spec);
 
       if (auto const* desired_product = dynamic_cast<product<T> const*>(available_product)) {
         return desired_product->obj;
@@ -109,6 +103,7 @@ namespace phlex::experimental {
     bool empty() const noexcept;
 
   private:
+    product_base const* find_product(product_specification const& spec) const;
     static void throw_mismatched_type [[noreturn]] (product_specification const& spec,
                                                     char const* requested_type,
                                                     char const* available_type);

--- a/phlex/model/products.hpp
+++ b/phlex/model/products.hpp
@@ -96,7 +96,6 @@ namespace phlex::experimental {
       throw_mismatched_type(spec, typeid(T).name(), available_product->type().name());
     }
 
-    bool contains(product_specification const& spec) const;
     const_iterator begin() const noexcept;
     const_iterator end() const noexcept;
     size_type size() const noexcept;

--- a/phlex/model/products.hpp
+++ b/phlex/model/products.hpp
@@ -5,13 +5,14 @@
 
 #include "phlex/model/product_specification.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <concepts>
 #include <memory>
 #include <string>
 #include <typeinfo>
-#include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace phlex::experimental {
 
@@ -53,16 +54,19 @@ namespace phlex::experimental {
   }
 
   class PHLEX_MODEL_EXPORT products {
-    using collection_t = std::unordered_map<product_specification, product_ptr>;
+    using collection_t = std::vector<std::pair<product_specification, product_ptr>>;
 
   public:
     using const_iterator = collection_t::const_iterator;
     using size_type = collection_t::size_type;
 
+    products() = default;
+    explicit products(std::size_t number_known_products);
+
     template <typename T>
     void add(product_specification const& spec, T t)
     {
-      products_.emplace(spec, product_for(std::move(t)));
+      products_.emplace_back(spec, product_for(std::move(t)));
     }
 
     template <typename Ts>
@@ -84,8 +88,8 @@ namespace phlex::experimental {
     template <typename T>
     T const& get(product_specification const& spec) const
     {
-      auto it = products_.find(spec);
-      if (it == cend(products_)) {
+      auto it = std::ranges::find(products_, spec, [](auto const& p) { return p.first; });
+      if (it == products_.end()) {
         throw std::runtime_error(fmt::format("No product exists with the name '{}'.", spec.full()));
       }
 

--- a/test/core_misc_test.cpp
+++ b/test/core_misc_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE("consumer tests", "[core]")
   algorithm_name an = algorithm_name::create("p:a");
   consumer c(an, {"pred1"});
 
-  CHECK(c.full_name() == "p:a");
+  CHECK(c.name().full() == "p:a");
   CHECK(c.plugin() == "p"_idq);
   CHECK(c.algorithm() == "a"_idq);
   CHECK(c.when().size() == 1);

--- a/test/output_products.cpp
+++ b/test/output_products.cpp
@@ -64,6 +64,6 @@ TEST_CASE("Output data products", "[graph]")
   // store from the "provide_number" provider, and once to receive the data store from the
   // "square_number" transform.
   CHECK(g.execution_count("record_numbers") == 2u);
-  CHECK(products_from_nodes == std::set<std::string>{"input:input/number_from_provider",
-                                                     "square_number:square_number/squared_number"});
+  CHECK(products_from_nodes ==
+        std::set<std::string>{"input:input/number_from_provider", "square_number/squared_number"});
 }


### PR DESCRIPTION
These are some optimizations that were suggested by Claude using macOS Instruments' profile data on the `many_events` test.

- Send the `algorithm_name` directly to product_store constructors instead of creating one from a std::string.
- Adjust the underlying container of `products` to be a `std::vector`.