### PR TITLE
fix(devcontainer): drop --format=docker from buildOptions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,12 @@
 FROM ghcr.io/framework-r-d/phlex-dev:latest
 
-# Validate Python site-packages symlink
-RUN <<'VALIDATE_PYTHON_SYMLINK'
+# Validate Python site-packages symlink.
+# Invoke bash explicitly: the script uses bash features (pipefail, arrays,
+# shopt). Do NOT rely on the base image's SHELL being inherited -- the OCI
+# image config has no Shell field, so podman/buildah builds run RUN under
+# /bin/sh and these heredocs would fail. `RUN bash <<...` works on both
+# docker (BuildKit) and podman/buildah regardless of image format.
+RUN bash <<'VALIDATE_PYTHON_SYMLINK'
 set -euo pipefail
 shopt -s nullglob
 
@@ -58,7 +63,7 @@ VALIDATE_PYTHON_SYMLINK
 
 # Install podman client and socat inside the container to support nested
 # container communication and provide a 'docker' command alias.
-RUN <<'INSTALL_PODMAN_CLIENT'
+RUN bash <<'INSTALL_PODMAN_CLIENT'
 set -euo pipefail
 apt-get update
 apt-get install -y --no-install-recommends podman socat

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,7 @@
 {
     "name": "Phlex CI Dev Container",
     "build": {
-        "dockerfile": "Dockerfile",
-        "options": [
-            "--format=docker"
-        ]
+        "dockerfile": "Dockerfile"
     },
     "workspaceFolder": "/workspaces/phlex",
     "remoteUser": "root",


### PR DESCRIPTION
## Summary

- Removes the `--format=docker` flag from `buildOptions` in `.devcontainer/devcontainer.json`
- This flag is not supported by Buildx in its default configuration and causes container builds to fail

## Test plan

- [ ] Open the repository in VS Code with the Dev Containers extension
- [ ] Rebuild the devcontainer and confirm it builds without errors