### PR TITLE
Fix clang-tidy PR comments for fork PRs via workflow_run

### DIFF
--- a/.github/workflows/clang-tidy-check.yaml
+++ b/.github/workflows/clang-tidy-check.yaml
@@ -196,6 +196,17 @@ jobs:
 
           echo "✅ No new clang-tidy issues on modified lines"
 
+      - name: Save PR metadata
+        if: always() && github.event_name == 'pull_request'
+        shell: bash
+        env:
+          BUILD_PATH: ${{ needs.setup.outputs.build_path }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          BUILD_DIR="$GITHUB_WORKSPACE/$BUILD_PATH"
+          mkdir -p "$BUILD_DIR"
+          printf '%s\n' "$PR_NUMBER" > "$BUILD_DIR/pr_number.txt"
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -205,12 +216,16 @@ jobs:
             ${{ needs.setup.outputs.build_path }}/clang-tidy-fixes.yaml
             ${{ needs.setup.outputs.build_path }}/clang-tidy.log
             ${{ needs.setup.outputs.build_path }}/clang-tidy-new-issues.txt
+            ${{ needs.setup.outputs.build_path }}/pr_number.txt
           retention-days: 7
           if-no-files-found: ignore
 
   report:
     needs: [setup, clang-tidy-check]
-    if: always() && needs.setup.result == 'success'
+    # pull_request events from forks have read-only GITHUB_TOKEN; the separate
+    # clang-tidy-report.yaml workflow (triggered via workflow_run) handles
+    # posting PR comments for pull_request events with the necessary write access.
+    if: always() && needs.setup.result == 'success' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/clang-tidy-report.yaml
+++ b/.github/workflows/clang-tidy-report.yaml
@@ -29,6 +29,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       - name: Download clang-tidy artifacts
+        id: download
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: clang-tidy-*
@@ -41,11 +42,20 @@ jobs:
       - name: Locate artifacts and PR number
         id: locate
         shell: bash
+        env:
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
         run: |
+          if [ "$DOWNLOAD_OUTCOME" = "failure" ]; then
+            echo "::error::Artifact download failed — check token permissions or artifact expiry"
+            exit 1
+          fi
+
           pr_number_file=$(find artifacts -name "pr_number.txt" 2>/dev/null | head -1)
           if [ -n "$pr_number_file" ]; then
             pr_number=$(cat "$pr_number_file")
             echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::pr_number.txt not found in downloaded artifacts; skipping PR comment"
           fi
 
           fixes_file=$(find artifacts -name "clang-tidy-fixes.yaml" 2>/dev/null | head -1)

--- a/.github/workflows/clang-tidy-report.yaml
+++ b/.github/workflows/clang-tidy-report.yaml
@@ -1,0 +1,65 @@
+name: Clang-Tidy Report
+"run-name": "Post clang-tidy results for ${{ github.event.workflow_run.head_branch }}"
+
+# This workflow runs after the Clang-Tidy Check workflow completes and is
+# responsible for posting clang-tidy results as PR comments.
+#
+# The Clang-Tidy Check workflow runs on pull_request events, which — for PRs
+# from fork repositories — grants only read-only access to the GITHUB_TOKEN.
+# Posting PR comments requires write access, so this separate workflow_run-
+# triggered workflow is used instead: workflow_run events run in the base
+# repository's context and can be granted pull-requests: write.
+
+"on":
+  workflow_run:
+    workflows: ["Clang-Tidy Check"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    # Only run for pull_request events; issue_comment and workflow_dispatch
+    # triggers are handled by the report job inside clang-tidy-check.yaml.
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download clang-tidy artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: clang-tidy-*
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: artifacts
+        continue-on-error: true
+
+      - name: Locate artifacts and PR number
+        id: locate
+        shell: bash
+        run: |
+          pr_number_file=$(find artifacts -name "pr_number.txt" 2>/dev/null | head -1)
+          if [ -n "$pr_number_file" ]; then
+            pr_number=$(cat "$pr_number_file")
+            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          fi
+
+          fixes_file=$(find artifacts -name "clang-tidy-fixes.yaml" 2>/dev/null | head -1)
+          issues_file=$(find artifacts -name "clang-tidy-new-issues.txt" 2>/dev/null | head -1)
+          if [ -n "$fixes_file" ]; then
+            echo "build_path=$(dirname "$fixes_file")" >> "$GITHUB_OUTPUT"
+          elif [ -n "$issues_file" ]; then
+            echo "build_path=$(dirname "$issues_file")" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post clang-tidy results
+        if: steps.locate.outputs.pr_number != '' && steps.locate.outputs.build_path != ''
+        uses: Framework-R-D/phlex/.github/actions/post-clang-tidy-results@main
+        with:
+          build-path: ${{ steps.locate.outputs.build_path }}
+          pr-number: ${{ steps.locate.outputs.pr_number }}
+          post-summary: "true"


### PR DESCRIPTION
For pull_request events from fork repositories, GITHUB_TOKEN is
hard-capped at read-only by GitHub's security model, regardless of the
permissions: pull-requests: write declared in the workflow. This caused
the report job's comment-posting steps to fail silently, so no
clang-tidy results were ever posted on fork PRs.

Fixes #600. Supersedes #608.

The fix uses the workflow_run pattern (already established in
codeql-comment.yaml): a separate workflow triggered after Clang-Tidy
Check completes runs in the base repository's context and can be
granted write access.

Changes:
- clang-tidy-check.yaml: save the PR number to pr_number.txt in the
  artifact (with if: always() so it is captured even when clang-tidy
  reports issues); add pr_number.txt to the uploaded artifact paths;
  exclude pull_request events from the existing report job (they are
  now handled by the new workflow).
- clang-tidy-report.yaml (new): triggered by workflow_run on
  Clang-Tidy Check completion, filtered to pull_request events only;
  downloads the clang-tidy artifact from the triggering run using
  run-id, extracts the PR number, and calls post-clang-tidy-results
  to post inline comments and a summary.
