### PR TITLE
FORM Testing Loop Over Technologies

### DIFF
--- a/test/form/CMakeLists.txt
+++ b/test/form/CMakeLists.txt
@@ -63,7 +63,10 @@ if(FORM_USE_ROOT_STORAGE)
         TEST_ARGS
         ${TECH}
     )
-    target_include_directories("form_root_schema_write_test_${TECH}" PRIVATE ${PROJECT_SOURCE_DIR}/form)
+    target_include_directories(
+      "form_root_schema_write_test_${TECH}"
+      PRIVATE ${PROJECT_SOURCE_DIR}/form
+    )
 
     cet_test(
        "form_root_schema_read_test_${TECH}"
@@ -82,7 +85,10 @@ if(FORM_USE_ROOT_STORAGE)
        TEST_ARGS
        ${TECH}
     )
-    target_include_directories("form_root_schema_read_test_${TECH}" PRIVATE ${PROJECT_SOURCE_DIR}/form)
+    target_include_directories(
+      "form_root_schema_read_test_${TECH}"
+      PRIVATE ${PROJECT_SOURCE_DIR}/form
+    )
 
     cet_test(
       "check_root_schema_evolution_${TECH}"

--- a/test/form/CMakeLists.txt
+++ b/test/form/CMakeLists.txt
@@ -8,85 +8,100 @@ if(FORM_USE_ROOT_STORAGE)
   target_link_libraries(form_test_utils INTERFACE ROOT::Core)
   target_include_directories(form_test_utils INTERFACE ${PROJECT_SOURCE_DIR})
 
-  cet_test(
-      WriteVector
-      SOURCE
-      writer.cpp
-      toy_tracker.cpp
-      LIBRARIES
-      form
-      form_test_data_products
-      TEST_ARGS
-      "${CMAKE_CURRENT_BINARY_DIR}/toy.root"
-      "${CMAKE_CURRENT_BINARY_DIR}/toy_checksums.txt"
-  )
-  target_include_directories(WriteVector PRIVATE ${PROJECT_SOURCE_DIR}/form)
+  list(APPEND FORM_TEST_TECHNOLOGIES "ROOT_TTREE")
+  #if(FORM_USE_RNTUPLE_STORAGE) #Example of what this loop will be used for
+  #  list(APPEND FORM_TEST_TECHNOLOGIES "ROOT_RNTUPLE")
+  #endif()
 
-  cet_test(
-      ReadVector
-      SOURCE
-      reader.cpp
-      LIBRARIES
-      form
-      form_test_data_products
-      TEST_ARGS
-      "${CMAKE_CURRENT_BINARY_DIR}/toy.root"
-      "${CMAKE_CURRENT_BINARY_DIR}/toy_checksums.txt"
-      TEST_PROPERTIES
-      DEPENDS
-      WriteVector
-  )
-  target_include_directories(ReadVector PRIVATE ${PROJECT_SOURCE_DIR}/form)
+  foreach(TECH IN LISTS FORM_TEST_TECHNOLOGIES)
+    cet_test(
+        "WriteVector_${TECH}"
+        SOURCE
+        writer.cpp
+        toy_tracker.cpp
+        LIBRARIES
+        form
+        form_test_data_products
+        form_test_utils
+        TEST_ARGS
+        "${CMAKE_CURRENT_BINARY_DIR}/toy.root"
+        "${CMAKE_CURRENT_BINARY_DIR}/toy_checksums.txt"
+        ${TECH}
+    )
+    target_include_directories("WriteVector_${TECH}" PRIVATE ${PROJECT_SOURCE_DIR}/form)
 
-  cet_test(
-      form_root_schema_write_test
-      SOURCE
-      form_root_schema_write_test.cpp
-      toy_tracker.cpp
-      LIBRARIES
-      form
-      root_storage
-      form_test_data_products
-      form_test_utils
+    cet_test(
+        "ReadVector_${TECH}"
+        SOURCE
+        reader.cpp
+        LIBRARIES
+        form
+        form_test_data_products
+        form_test_utils
+        TEST_ARGS
+        "${CMAKE_CURRENT_BINARY_DIR}/toy.root"
+        "${CMAKE_CURRENT_BINARY_DIR}/toy_checksums.txt"
+        ${TECH}
+        TEST_PROPERTIES
+        DEPENDS
+        "WriteVector_${TECH}"
+    )
+    target_include_directories("ReadVector_${TECH}" PRIVATE ${PROJECT_SOURCE_DIR}/form)
+
+    cet_test(
+        "form_root_schema_write_test_${TECH}"
+        SOURCE
+        form_root_schema_write_test.cpp
+        toy_tracker.cpp
+        LIBRARIES
+        form
+        root_storage
+        form_test_data_products
+        form_test_utils
+        TEST_WORKDIR
+        form_root_schema_test
+        TEST_ARGS
+        ${TECH}
+    )
+    target_include_directories("form_root_schema_write_test_${TECH}" PRIVATE ${PROJECT_SOURCE_DIR}/form)
+
+    cet_test(
+       "form_root_schema_read_test_${TECH}"
+       SOURCE
+       form_root_schema_read_test.cpp
+       LIBRARIES
+       form
+       root_storage
+       form_test_data_products_schema_evolution
+       form_test_utils
+       DIRTY_WORKDIR
+       TEST_WORKDIR
+       form_root_schema_test
+       REQUIRED_FIXTURES
+       "form_root_schema_write_test_${TECH}"
+       TEST_ARGS
+       ${TECH}
+    )
+    target_include_directories("form_root_schema_read_test_${TECH}" PRIVATE ${PROJECT_SOURCE_DIR}/form)
+
+    cet_test(
+      "check_root_schema_evolution_${TECH}"
+      HANDBUILT
+      TEST_EXEC
+      ${CMAKE_COMMAND}
+      TEST_ARGS
+      -E
+      compare_files
+      form_root_schema_write_log.txt
+      form_root_schema_read_log.txt
+      DIRTY_WORKDIR
       TEST_WORKDIR
       form_root_schema_test
-  )
-  target_include_directories(form_root_schema_write_test PRIVATE ${PROJECT_SOURCE_DIR}/form)
-
-  cet_test(
-     form_root_schema_read_test
-     SOURCE
-     form_root_schema_read_test.cpp
-     LIBRARIES
-     form
-     root_storage
-     form_test_data_products_schema_evolution
-     form_test_utils
-     DIRTY_WORKDIR
-     TEST_WORKDIR
-     form_root_schema_test
-     REQUIRED_FIXTURES
-     form_root_schema_write_test
-  )
-  target_include_directories(form_root_schema_read_test PRIVATE ${PROJECT_SOURCE_DIR}/form)
-
-  cet_test(
-    check_root_schema_evolution
-    HANDBUILT
-    TEST_EXEC
-    ${CMAKE_COMMAND}
-    TEST_ARGS
-    -E
-    compare_files
-    form_root_schema_write_log.txt
-    form_root_schema_read_log.txt
-    DIRTY_WORKDIR
-    TEST_WORKDIR
-    form_root_schema_test
-    REQUIRED_FIXTURES
-    form_root_schema_write_test
-    form_root_schema_read_test
-  )
+      REQUIRED_FIXTURES
+      "form_root_schema_write_test_${TECH}"
+      "form_root_schema_read_test_${TECH}"
+    )
+  endforeach()
 endif()
 
 cet_test(

--- a/test/form/form_root_schema_read_test.cpp
+++ b/test/form/form_root_schema_read_test.cpp
@@ -12,8 +12,6 @@ using namespace form::test;
 int main(int const argc, char const** argv)
 try {
   int const technology = getTechnology((argc > 1) ? argv[1] : "ROOT_TTREE");
-  if (technology < 0)
-    return 1;
 
   auto const& [prods] = read<std::vector<TrackStart>>(technology);
   std::ofstream outFile("form_root_schema_read_log.txt");

--- a/test/form/form_root_schema_read_test.cpp
+++ b/test/form/form_root_schema_read_test.cpp
@@ -11,7 +11,7 @@ using namespace form::test;
 
 int main(int const argc, char const** argv)
 try {
-  int const technology = getTechnology(argc, argv);
+  int const technology = getTechnology((argc > 1) ? argv[1] : "ROOT_TTREE");
   if (technology < 0)
     return 1;
 

--- a/test/form/form_root_schema_write_test.cpp
+++ b/test/form/form_root_schema_write_test.cpp
@@ -12,9 +12,7 @@ using namespace form::test;
 
 int main(int const argc, char const** argv)
 {
-  int const technology = getTechnology(argc, argv);
-  if (technology < 0)
-    return 1;
+  int const technology = getTechnology((argc > 1) ? argv[1] : "ROOT_TTREE");
 
   ToyTracker tracker(4 * 1024);
   std::vector<TrackStart> const prods = tracker();

--- a/test/form/reader.cpp
+++ b/test/form/reader.cpp
@@ -4,6 +4,7 @@
 #include "form/form_reader.hpp"
 #include "form/technology.hpp"
 #include "test_helpers.hpp"
+#include "test_utils.hpp"
 
 #include <cmath>
 #include <format>
@@ -35,6 +36,7 @@ int main(int argc, char** argv)
 
   std::string const filename = (argc > 1) ? argv[1] : "toy.root";
   std::string const checksum_filename = (argc > 2) ? argv[2] : "toy_checksums.txt";
+  int const technology = form::test::getTechnology((argc > 3) ? argv[3] : "ROOT_TTREE");
 
   // Load expected checksums from file
   std::map<std::pair<int, int>, SegChecksum> expected_seg;
@@ -67,10 +69,10 @@ int main(int argc, char** argv)
 
   // TODO: Read configuration from config file instead of hardcoding
   form::experimental::config::ItemConfig config_items;
-  config_items.addItem("trackStart", filename, form::technology::ROOT_TTREE);
-  config_items.addItem("trackNumberHits", filename, form::technology::ROOT_TTREE);
-  config_items.addItem("trackStartPoints", filename, form::technology::ROOT_TTREE);
-  config_items.addItem("trackStartX", filename, form::technology::ROOT_TTREE);
+  config_items.addItem("trackStart", filename, technology);
+  config_items.addItem("trackNumberHits", filename, technology);
+  config_items.addItem("trackStartPoints", filename, technology);
+  config_items.addItem("trackStartX", filename, technology);
 
   form::experimental::config::tech_setting_config tech_config;
 

--- a/test/form/test_utils.hpp
+++ b/test/form/test_utils.hpp
@@ -30,7 +30,8 @@ namespace form::test {
   inline std::string makeTestBranchName()
   {
     auto branchName = std::string(testTreeName) + "/" + getTypeName<PROD>();
-    for(size_t firstSpace = branchName.find_first_of(' '); firstSpace != std::string::npos; firstSpace = branchName.find_first_of(' '))
+    for (size_t firstSpace = branchName.find_first_of(' '); firstSpace != std::string::npos;
+         firstSpace = branchName.find_first_of(' '))
       branchName = branchName.erase(firstSpace, 1);
     return branchName;
   }

--- a/test/form/test_utils.hpp
+++ b/test/form/test_utils.hpp
@@ -29,7 +29,10 @@ namespace form::test {
   template <class PROD>
   inline std::string makeTestBranchName()
   {
-    return std::string(testTreeName) + "/" + getTypeName<PROD>();
+    auto branchName = std::string(testTreeName) + "/" + getTypeName<PROD>();
+    for(size_t firstSpace = branchName.find_first_of(' '); firstSpace != std::string::npos; firstSpace = branchName.find_first_of(' '))
+      branchName = branchName.erase(firstSpace, 1);
+    return branchName;
   }
 
   inline std::vector<std::shared_ptr<IStorage_Write_Container>> doWrite(
@@ -98,21 +101,19 @@ namespace form::test {
     return std::make_tuple(doRead<PRODS>(file, technology)...);
   }
 
-  inline int getTechnology(int const argc, char const** argv)
+  inline int getTechnology(std::string const& tech_string)
   {
-    if (argc > 2 || (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))) {
-      std::cerr << "Expected exactly one argument, but got " << argc - 1 << "\n"
-                << "USAGE: testSchemaWriteOldProduct <technologyInt>\n";
-      return -1;
+    std::unordered_map<std::string_view, int> const tech_lookup = {
+      {"ROOT_TTREE", form::technology::ROOT_TTREE},
+      {"ROOT_RNTUPLE", form::technology::ROOT_RNTUPLE},
+      {"HDF5", form::technology::HDF5}};
+
+    auto const it = tech_lookup.find(tech_string);
+    if (it == tech_lookup.end()) {
+      throw std::runtime_error("Unknown technology: " + tech_string);
     }
 
-    //Default to TTree with TFile
-    int technology = form::technology::ROOT_TTREE;
-
-    if (argc == 2)
-      technology = std::stoi(argv[1]);
-
-    return technology;
+    return it->second;
   }
 
 } // namespace form::test

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -4,8 +4,8 @@
 #include "form/form_writer.hpp"
 #include "form/technology.hpp"
 #include "test_helpers.hpp"
-#include "toy_tracker.hpp"
 #include "test_utils.hpp"
+#include "toy_tracker.hpp"
 
 #include <cstdlib>
 #include <ctime>
@@ -57,8 +57,7 @@ int main(int argc, char** argv)
   form::experimental::config::tech_setting_config tech_config;
   tech_config.container_settings[form::technology::ROOT_TTREE]["trackStart"].emplace_back(
     "auto_flush", "1");
-  tech_config.file_settings[technology]["toy.root"].emplace_back("compression",
-                                                                                   "kZSTD");
+  tech_config.file_settings[technology]["toy.root"].emplace_back("compression", "kZSTD");
   tech_config.container_settings[form::technology::ROOT_RNTUPLE]["Toy_Tracker/trackStartPoints"]
     .emplace_back("force_streamer_field", "true");
 

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -5,6 +5,7 @@
 #include "form/technology.hpp"
 #include "test_helpers.hpp"
 #include "toy_tracker.hpp"
+#include "test_utils.hpp"
 
 #include <cstdlib>
 #include <ctime>
@@ -44,18 +45,19 @@ int main(int argc, char** argv)
 
   std::string const filename = (argc > 1) ? argv[1] : "toy.root";
   std::string const checksum_filename = (argc > 2) ? argv[2] : "toy_checksums.txt";
+  int const technology = form::test::getTechnology((argc > 3) ? argv[3] : "ROOT_TTREE");
 
   // TODO: Read configuration from config file instead of hardcoding
   form::experimental::config::ItemConfig config_items;
-  config_items.addItem("trackStart", filename, form::technology::ROOT_TTREE);
-  config_items.addItem("trackNumberHits", filename, form::technology::ROOT_TTREE);
-  config_items.addItem("trackStartPoints", filename, form::technology::ROOT_TTREE);
-  config_items.addItem("trackStartX", filename, form::technology::ROOT_TTREE);
+  config_items.addItem("trackStart", filename, technology);
+  config_items.addItem("trackNumberHits", filename, technology);
+  config_items.addItem("trackStartPoints", filename, technology);
+  config_items.addItem("trackStartX", filename, technology);
 
   form::experimental::config::tech_setting_config tech_config;
   tech_config.container_settings[form::technology::ROOT_TTREE]["trackStart"].emplace_back(
     "auto_flush", "1");
-  tech_config.file_settings[form::technology::ROOT_TTREE]["toy.root"].emplace_back("compression",
+  tech_config.file_settings[technology]["toy.root"].emplace_back("compression",
                                                                                    "kZSTD");
   tech_config.container_settings[form::technology::ROOT_RNTUPLE]["Toy_Tracker/trackStartPoints"]
     .emplace_back("force_streamer_field", "true");


### PR DESCRIPTION
FORM is soon going to support more than one backend technology.  This PR prepares for automatically testing all FORM backends by looping over technologies when running most FORM tests.  Unifying how tests select a technology to use now helps keep testing infrastructure consistent when I'm working on new FORM backends.

Two tests remain that only test TTree.  They will be updated in a near-future PR where I deal with Catch's command line interface.