### PR TITLE
Actions use other Phlex actions via pinned hash

### DIFF
--- a/.github/actions/prepare-check-outputs/action.yaml
+++ b/.github/actions/prepare-check-outputs/action.yaml
@@ -44,11 +44,11 @@ runs:
     - name: Get PR Info
       if: github.event_name == 'issue_comment'
       id: get_pr
-      uses: Framework-R-D/phlex/.github/actions/get-pr-info@main
+      uses: Framework-R-D/phlex/.github/actions/get-pr-info@1b6b94e13ce2adbc2ba092d8d0fce6e11b252916 # actions-v0.1.0
 
     - name: Detect act environment
       id: detect_act
-      uses: Framework-R-D/phlex/.github/actions/detect-act-env@main
+      uses: Framework-R-D/phlex/.github/actions/detect-act-env@1b6b94e13ce2adbc2ba092d8d0fce6e11b252916 # actions-v0.1.0
 
     - name: Resolve outputs
       id: resolve

--- a/.github/actions/prepare-fix-outputs/action.yaml
+++ b/.github/actions/prepare-fix-outputs/action.yaml
@@ -26,7 +26,7 @@ runs:
     - name: Get PR Info
       if: github.event_name == 'issue_comment' && (inputs.ref == '' || inputs.repo == '')
       id: get_pr
-      uses: Framework-R-D/phlex/.github/actions/get-pr-info@main
+      uses: Framework-R-D/phlex/.github/actions/get-pr-info@1b6b94e13ce2adbc2ba092d8d0fce6e11b252916 # actions-v0.1.0
 
     - name: Resolve outputs
       id: resolve

--- a/.github/actions/run-change-detection/action.yaml
+++ b/.github/actions/run-change-detection/action.yaml
@@ -59,7 +59,7 @@ runs:
 
     - name: Detect relevant changes
       id: filter
-      uses: Framework-R-D/phlex/.github/actions/detect-relevant-changes@main
+      uses: Framework-R-D/phlex/.github/actions/detect-relevant-changes@1b6b94e13ce2adbc2ba092d8d0fce6e11b252916 # actions-v0.1.0
       with:
         repo-path: ${{ inputs.checkout-path }}
         base-ref: ${{ inputs.base-ref }}

--- a/.github/actions/workflow-setup/action.yaml
+++ b/.github/actions/workflow-setup/action.yaml
@@ -65,7 +65,7 @@ runs:
     - name: Prepare basic outputs (check mode)
       if: inputs.mode == 'check'
       id: prepare_check
-      uses: Framework-R-D/phlex/.github/actions/prepare-check-outputs@main
+      uses: Framework-R-D/phlex/.github/actions/prepare-check-outputs@1b6b94e13ce2adbc2ba092d8d0fce6e11b252916 # actions-v0.1.0
       with:
         ref: ${{ inputs.ref }}
         repo: ${{ inputs.repo }}
@@ -76,7 +76,7 @@ runs:
     - name: Prepare basic outputs (fix mode)
       if: inputs.mode == 'fix'
       id: prepare_fix
-      uses: Framework-R-D/phlex/.github/actions/prepare-fix-outputs@main
+      uses: Framework-R-D/phlex/.github/actions/prepare-fix-outputs@1b6b94e13ce2adbc2ba092d8d0fce6e11b252916 # actions-v0.1.0
       with:
         ref: ${{ inputs.ref }}
         repo: ${{ inputs.repo }}
@@ -125,7 +125,7 @@ runs:
     - name: Run change detection
       id: detect
       if: (inputs.file-type != '' || inputs.include-globs != '') && steps.prepare.outputs.is_act != 'true'
-      uses: Framework-R-D/phlex/.github/actions/run-change-detection@main
+      uses: Framework-R-D/phlex/.github/actions/run-change-detection@1b6b94e13ce2adbc2ba092d8d0fce6e11b252916 # actions-v0.1.0
       with:
         checkout-path: ${{ steps.prepare.outputs.checkout_path }}
         ref: ${{ steps.prepare.outputs.ref }}


### PR DESCRIPTION
This PR is mainly to satisfy CodeQL. It suffers from a minor hysteresis due to the presence of multiple reusable actions in the Phlex repository. Ideally this would be fixed by the usual convention of one action per dedicated repo, but that would occur an extra maintenance burden.