### PR TITLE
Some cleanups per @beojan, etc.

### DIFF
--- a/form/form_module.cpp
+++ b/form/form_module.cpp
@@ -64,7 +64,7 @@ namespace {
       auto segment_id = store.index()->to_string();
 
       std::cout << "\n=== FormOutputModule::save_data_products ===\n";
-      std::cout << "Creator: " << creator.full() << "\n";
+      std::cout << "Creator: " << creator.to_string() << "\n";
       std::cout << "Segment ID: " << segment_id << "\n";
       std::cout << "Number of products: " << store.size() << "\n";
 
@@ -82,7 +82,7 @@ namespace {
         // product_ptr: pointer to the actual product data
         assert(product_ptr && "store should not contain null product_ptr");
 
-        std::cout << "  Product: " << product_spec.full() << "\n";
+        std::cout << "  Product: " << product_spec.to_string() << "\n";
 
         // Create FORM product with metadata
         products.emplace_back(product_spec.suffix().trans_get_string(), // label, from map key
@@ -96,7 +96,7 @@ namespace {
       // Write all products to FORM
       // Pass segment_id once for entire collection (not duplicated in each product)
       // No need to check if products is empty - already checked store.empty() above
-      m_form_interface->write(creator.full(), segment_id, products);
+      m_form_interface->write(creator.to_string(), segment_id, products);
       std::cout << "Wrote " << products.size() << " products to FORM\n";
     }
 

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -91,7 +91,7 @@ namespace phlex::experimental {
                         return {};
                       }},
       join_{make_join_or_none<num_inputs>(
-        g, name().full(), layers())}, // FIXME: This should change to include result product!
+        g, name().to_string(), layers())}, // FIXME: This should change to include result product!
       fold_{g,
             concurrency,
             [this, ft = alg.release_algorithm()](messages_t<num_inputs> const& messages, auto&) {

--- a/phlex/core/declared_observer.hpp
+++ b/phlex/core/declared_observer.hpp
@@ -62,7 +62,7 @@ namespace phlex::experimental {
                   AlgorithmBits alg,
                   product_queries input_products) :
       declared_observer{std::move(algo_name), std::move(predicates), std::move(input_products)},
-      join_{make_join_or_none<num_inputs>(g, name().full(), layers())},
+      join_{make_join_or_none<num_inputs>(g, name().to_string(), layers())},
       observer_{g,
                 concurrency,
                 [this, ft = alg.release_algorithm()](

--- a/phlex/core/declared_predicate.hpp
+++ b/phlex/core/declared_predicate.hpp
@@ -66,7 +66,7 @@ namespace phlex::experimental {
                    AlgorithmBits alg,
                    product_queries input_products) :
       declared_predicate{std::move(algo_name), std::move(predicates), std::move(input_products)},
-      join_{make_join_or_none<num_inputs>(g, name().full(), layers())},
+      join_{make_join_or_none<num_inputs>(g, name().to_string(), layers())},
       predicate_{g,
                  concurrency,
                  [this, ft = alg.release_algorithm()](

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -77,7 +77,7 @@ namespace phlex::experimental {
       declared_transform{std::move(algo_name), std::move(predicates), std::move(input_products)},
       output_{
         to_product_specifications(name(), std::move(output), make_output_type_ids<function_t>())},
-      join_{make_join_or_none<num_inputs>(g, name().full(), layers())},
+      join_{make_join_or_none<num_inputs>(g, name().to_string(), layers())},
       transform_{
         g,
         concurrency,

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -103,7 +103,7 @@ namespace phlex::experimental {
       output_{to_product_specifications(name(),
                                         std::move(output_product_suffixes),
                                         make_type_ids<skip_first_type<return_type<Unfold>>>())},
-      join_{make_join_or_none<num_inputs>(g, name().full(), layers())},
+      join_{make_join_or_none<num_inputs>(g, name().to_string(), layers())},
       unfold_{g,
               concurrency,
               [this, p = std::move(predicate), ufold = std::move(unfold)](

--- a/phlex/core/edge_creation_policy.cpp
+++ b/phlex/core/edge_creation_policy.cpp
@@ -32,27 +32,28 @@ namespace phlex::experimental {
           spdlog::debug("Matched ({}) from {} but types don't match (`{}` vs `{}`). Excluding "
                         "from candidate list.",
                         query.to_string(),
-                        producer.node.full(),
+                        producer.node.to_string(),
                         query.type,
                         producer.type);
         } else {
           if (query.type.exact_compare(producer.type)) {
             spdlog::debug("Matched ({}) from {} and types match. Keeping in candidate list.",
                           query.to_string(),
-                          producer.node.full());
+                          producer.node.to_string());
           } else {
             spdlog::warn("Matched ({}) from {} and types match, but not exactly (produce {} and "
                          "consume {}). Keeping in candidate list!",
                          query.to_string(),
-                         producer.node.full(),
+                         producer.node.to_string(),
                          query.type.exact_name(),
                          producer.type.exact_name());
           }
-          candidates.emplace(producer.node.full(), &producer);
+          candidates.emplace(producer.node.to_string(), &producer);
         }
       } else {
-        spdlog::debug(
-          "Creator name mismatch between ({}) and {}", query.to_string(), producer.node.full());
+        spdlog::debug("Creator name mismatch between ({}) and {}",
+                      query.to_string(),
+                      producer.node.to_string());
       }
     }
 

--- a/phlex/core/edge_maker.cpp
+++ b/phlex/core/edge_maker.cpp
@@ -23,11 +23,12 @@ namespace phlex::experimental {
           auto& provider = *p;
           if (port.input_product.match(
                 provider.output_product(), provider.layer(), provider.stage())) {
-            if (!result.contains(provider.name().full())) {
-              result.try_emplace(provider.name().full(), port.input_product, provider.input_port());
+            if (!result.contains(provider.name().to_string())) {
+              result.try_emplace(
+                provider.name().to_string(), port.input_product, provider.input_port());
             }
             spdlog::debug("Connecting provider {} to node {} (product: {})",
-                          provider.name().full(),
+                          provider.name().to_string(),
                           node_name,
                           port.input_product.to_string());
             make_edge(provider.output_port(), *(port.port));

--- a/phlex/core/input_arguments.hpp
+++ b/phlex/core/input_arguments.hpp
@@ -29,21 +29,21 @@ namespace phlex::experimental {
       auto products =
         all_products |
         views::filter([this](product_specification const& spec) { return query.match(spec); }) |
-        views::transform([](product_specification const& spec) { return std::cref(spec); }) |
         std::ranges::to<std::vector>();
       if (products.empty()) {
         throw std::runtime_error(fmt::format(
           "No products found matching the query {}\n Store (id {} from {}) contains:\n    - {}",
           query,
           store->index()->to_string(),
-          store->source().full(),
-          fmt::join(all_products | views::transform(&product_specification::full), "\n    - ")));
+          store->source().to_string(),
+          fmt::join(all_products | views::transform(&product_specification::to_string),
+                    "\n    - ")));
       }
       if (products.size() > 1) {
         throw std::runtime_error(fmt::format(
           "Multiple products found matching the query {}:\n    - {}",
           query,
-          fmt::join(products | views::transform(&product_specification::full), "\n    - ")));
+          fmt::join(products | views::transform(&product_specification::to_string), "\n    - ")));
       }
       return store->get_handle<handle_arg_t>(products[0]);
     }

--- a/phlex/core/provider_node.cpp
+++ b/phlex/core/provider_node.cpp
@@ -27,6 +27,9 @@ namespace phlex::experimental {
                 auto new_product = std::invoke(ft, *index);
                 ++calls_;
 
+                // The constructor argument 1uz specifies how many slots to reserve in the
+                // underlying product container.  For providers, only one data product is
+                // produced per input index.
                 products new_products{1uz};
                 new_products.add(output_, std::move(new_product));
                 auto store = std::make_shared<product_store>(index, name_, std::move(new_products));
@@ -34,8 +37,10 @@ namespace phlex::experimental {
                 return {.store = std::move(store), .id = msg_id};
               }}
   {
-    spdlog::debug(
-      "Created provider node {} making output {} ϵ {}", name().full(), output_.full(), layer_);
+    spdlog::debug("Created provider node {} making output {} ϵ {}",
+                  name().to_string(),
+                  output_.to_string(),
+                  layer_);
   }
 
   algorithm_name const& provider_node::name() const noexcept { return name_; }

--- a/phlex/core/provider_node.hpp
+++ b/phlex/core/provider_node.hpp
@@ -21,7 +21,7 @@ namespace phlex::experimental {
   public:
     using provider_function = std::function<product_ptr(data_cell_index const&)>;
 
-    provider_node(algorithm_name name,
+    provider_node(algorithm_name algo_name,
                   std::size_t concurrency,
                   tbb::flow::graph& g,
                   provider_function provider_func,

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -112,7 +112,7 @@ namespace phlex::experimental {
     {
       assert(creator_);
       auto ptr = creator_(release_predicates(), std::move(output_product_suffixes));
-      auto name = ptr->name().full();
+      auto name = ptr->name().to_string();
       auto [_, inserted] = nodes_->try_emplace(name, std::move(ptr));
       if (not inserted) {
         detail::add_to_error_messages(*errors_, name);

--- a/phlex/model/algorithm_name.cpp
+++ b/phlex/model/algorithm_name.cpp
@@ -43,7 +43,7 @@ namespace phlex::experimental {
   {
   }
 
-  std::string algorithm_name::full() const
+  std::string algorithm_name::to_string() const
   {
     if (!plugin_.empty()) {
       return fmt::format("{}:{}", plugin_, algorithm_);

--- a/phlex/model/algorithm_name.hpp
+++ b/phlex/model/algorithm_name.hpp
@@ -23,7 +23,7 @@ namespace phlex::experimental {
                    identifier algorithm,
                    specified_fields fields = specified_fields::both);
 
-    std::string full() const;
+    std::string to_string() const;
     identifier const& plugin() const noexcept { return plugin_; }
     identifier const& algorithm() const noexcept { return algorithm_; }
 

--- a/phlex/model/product_specification.cpp
+++ b/phlex/model/product_specification.cpp
@@ -19,19 +19,19 @@ namespace phlex::experimental {
   }
   product_specification::product_specification(std::string_view name) { *this = create(name); }
 
-  product_specification::product_specification(algorithm_name qualifier,
+  product_specification::product_specification(algorithm_name creator,
                                                identifier suffix,
                                                type_id type) :
-    qualifier_{std::move(qualifier)}, suffix_{std::move(suffix)}, type_id_{std::move(type)}
+    creator_{std::move(creator)}, suffix_{std::move(suffix)}, type_id_{std::move(type)}
   {
   }
 
-  std::string product_specification::full() const
+  std::string product_specification::to_string() const
   {
-    if (qualifier_.plugin().empty() && qualifier_.algorithm().empty()) {
+    if (creator_.plugin().empty() && creator_.algorithm().empty()) {
       return fmt::format("{}", suffix_);
     }
-    return fmt::format("{}/{}", qualifier_.full(), suffix_);
+    return fmt::format("{}/{}", creator_.to_string(), suffix_);
   }
 
   product_specification product_specification::create(char const* c)

--- a/phlex/model/product_specification.hpp
+++ b/phlex/model/product_specification.hpp
@@ -22,12 +22,12 @@ namespace phlex::experimental {
     product_specification(std::string const& name);
     product_specification(std::string_view name);
     // NOLINTEND(google-explicit-constructor)
-    product_specification(algorithm_name qualifier, identifier suffix, type_id type);
+    product_specification(algorithm_name creator, identifier suffix, type_id type);
 
-    std::string full() const;
-    algorithm_name const& qualifier() const noexcept { return qualifier_; }
-    identifier const& plugin() const noexcept { return qualifier_.plugin(); }
-    identifier const& algorithm() const noexcept { return qualifier_.algorithm(); }
+    std::string to_string() const;
+    algorithm_name const& creator() const noexcept { return creator_; }
+    identifier const& plugin() const noexcept { return creator_.plugin(); }
+    identifier const& algorithm() const noexcept { return creator_.algorithm(); }
     identifier const& suffix() const noexcept { return suffix_; }
     type_id type() const noexcept { return type_id_; }
 
@@ -41,7 +41,7 @@ namespace phlex::experimental {
     friend struct std::hash<product_specification>;
 
   private:
-    algorithm_name qualifier_;
+    algorithm_name creator_;
     identifier suffix_; // Default suffix is empty string
     type_id type_id_{};
   };
@@ -58,8 +58,8 @@ template <>
 struct std::hash<phlex::experimental::product_specification> {
   std::size_t operator()(phlex::experimental::product_specification const& spec) const noexcept
   {
-    std::size_t hash = spec.qualifier_.plugin().hash();
-    boost::hash_combine(hash, spec.qualifier_.algorithm().hash());
+    std::size_t hash = spec.creator_.plugin().hash();
+    boost::hash_combine(hash, spec.creator_.algorithm().hash());
     boost::hash_combine(hash, spec.suffix_.hash());
     boost::hash_combine(hash, spec.type_id_);
     return hash;

--- a/phlex/model/products.cpp
+++ b/phlex/model/products.cpp
@@ -21,7 +21,8 @@ namespace phlex::experimental {
   {
     auto it = std::ranges::find(products_, spec, [](auto const& p) { return p.first; });
     if (it == products_.end()) {
-      throw std::runtime_error(fmt::format("No product exists with the name '{}'.", spec.full()));
+      throw std::runtime_error(
+        fmt::format("No product exists with the specification '{}'.", spec.to_string()));
     }
     return it->second.get();
   }
@@ -32,7 +33,7 @@ namespace phlex::experimental {
   {
     std::string const msg =
       fmt::format("Cannot get product '{}' with type '{}' -- must specify type '{}'.",
-                  spec.full(),
+                  spec.to_string(),
                   boost::core::demangle(requested_type),
                   boost::core::demangle(available_type));
     throw std::runtime_error(msg);

--- a/test/core_misc_test.cpp
+++ b/test/core_misc_test.cpp
@@ -17,23 +17,23 @@ TEST_CASE("algorithm_name tests", "[model]")
   SECTION("Default constructor")
   {
     algorithm_name an;
-    CHECK(an.full() == "");
+    CHECK(an.to_string() == "");
   }
   SECTION("Create from string with colon")
   {
     auto an = algorithm_name::create("plugin:algo");
-    CHECK(an.full() == "plugin:algo");
+    CHECK(an.to_string() == "plugin:algo");
   }
   SECTION("Create from string without colon")
   {
     auto an = algorithm_name::create("algo");
     // For 'either' cases, the word is stored as plugin_ and algorithm_
-    CHECK(an.full() == "algo:algo");
+    CHECK(an.to_string() == "algo:algo");
   }
   SECTION("Create from char pointer")
   {
     auto an = algorithm_name::create("ptr:algo");
-    CHECK(an.full() == "ptr:algo");
+    CHECK(an.to_string() == "ptr:algo");
   }
   SECTION("Create error - trailing colon")
   {
@@ -66,7 +66,7 @@ TEST_CASE("consumer tests", "[core]")
   algorithm_name an = algorithm_name::create("p:a");
   consumer c(an, {"pred1"});
 
-  CHECK(c.name().full() == "p:a");
+  CHECK(c.name().to_string() == "p:a");
   CHECK(c.plugin() == "p"_idq);
   CHECK(c.algorithm() == "a"_idq);
   CHECK(c.when().size() == 1);

--- a/test/output_products.cpp
+++ b/test/output_products.cpp
@@ -25,7 +25,7 @@ namespace {
     void record(experimental::product_store const& store)
     {
       for (auto const& spec : store | std::views::keys) {
-        products_->insert(spec.full());
+        products_->insert(spec.to_string());
       }
     }
 

--- a/test/product_store.cpp
+++ b/test/product_store.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Product store insertion", "[data model]")
       "Cannot get product 'number' with type 'double' -- must specify type 'int'."));
 
   auto const matcher =
-    Catch::Matchers::ContainsSubstring("No product exists with the name 'wrong_key'.");
+    Catch::Matchers::ContainsSubstring("No product exists with the specification 'wrong_key'.");
   CHECK_THROWS_WITH(store->get_handle<int>("wrong_key"), matcher);
 
   CHECK(store->get_product<int>("number") == number);

--- a/test/products_for_output.hpp
+++ b/test/products_for_output.hpp
@@ -14,9 +14,9 @@ namespace phlex::experimental::test {
     {
       std::ostringstream oss;
       oss << "Saving data for store id: " << store.index()
-          << " from source: " << store.source().full();
+          << " from source: " << store.source().to_string();
       for (auto const& [spec, _] : store) {
-        oss << "\n -> Product spec: " << spec.full();
+        oss << "\n -> Product spec: " << spec.to_string();
       }
       spdlog::debug(oss.str());
     }


### PR DESCRIPTION
This PR implements a few cleanups:

- Renames the `full()` member functions to `to_string()`
- Removes an unnecessary `std::views::transform(...)`
- Explains a `1uz` constructor argument in `provider_node`
- Adjusts an exception message to use the name `specification` instead of `name`