### PR TITLE
Introduce `phlex::index_generator` to support driver coroutines

### DIFF
--- a/.amazonq/rules/memory-bank/structure.md
+++ b/.amazonq/rules/memory-bank/structure.md
@@ -44,7 +44,7 @@ The main framework implementation containing the execution engine and core abstr
 - **`utilities/`**: General utilities
   - `resource_usage.cpp/hpp`: Resource monitoring
   - `hashing.cpp/hpp`: Hash functions
-  - `async_driver.hpp`: Asynchronous execution
+  - `resumable_driver.hpp`: Resumable driver execution
   - `max_allowed_parallelism.hpp`: Parallelism control
   - `thread_counter.hpp`: Thread tracking
   - `simple_ptr_map.hpp`, `sized_tuple.hpp`, `sleep_for.hpp`, `string_literal.hpp`: Various utilities

--- a/phlex/configuration.cpp
+++ b/phlex/configuration.cpp
@@ -9,7 +9,7 @@
 #include <string_view>
 
 namespace phlex::detail {
-  std::optional<phlex::experimental::identifier> value_if_exists(
+  std::optional<experimental::identifier> value_if_exists(
     boost::json::object const& obj, // will be used later for new product_selector
     std::string_view parameter)
   {
@@ -17,7 +17,7 @@ namespace phlex::detail {
       return std::nullopt;
     }
     auto const& val = obj.at(parameter);
-    return boost::json::value_to<phlex::experimental::identifier>(val);
+    return boost::json::value_to<experimental::identifier>(val);
   }
 }
 

--- a/phlex/configuration.hpp
+++ b/phlex/configuration.hpp
@@ -24,8 +24,8 @@ namespace phlex {
     }
 
     // Used later for product_selector
-    PHLEX_CONFIGURATION_INTERNAL_EXPORT std::optional<phlex::experimental::identifier>
-    value_if_exists(boost::json::object const& obj, std::string_view parameter);
+    PHLEX_CONFIGURATION_INTERNAL_EXPORT std::optional<experimental::identifier> value_if_exists(
+      boost::json::object const& obj, std::string_view parameter);
 
     // helper for unpacking json array
     template <typename T, std::size_t... I>

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -41,7 +41,7 @@ namespace phlex::experimental {
                     tbb::flow::unlimited,
                     [this](ready_flushes_then_emit const& input) -> data_cell_index_ptr {
                       auto&& [ready_flushes, index_to_emit] = input;
-                      return index_router_.route(index_to_emit, ready_flushes);
+                      return index_router_.route(index_to_emit, std::move(ready_flushes));
                     }},
     hierarchy_node_{graph_,
                     tbb::flow::unlimited,

--- a/phlex/driver.hpp
+++ b/phlex/driver.hpp
@@ -53,7 +53,7 @@ namespace phlex::experimental {
                          is_driver_like_with_cursor auto driver_function) const
     {
       auto h = hierarchy;
-      return {[f = std::move(driver_function), h = std::move(h)](framework_driver& d) {
+      return {[f = std::move(driver_function), h = std::move(h)](framework_driver& d) mutable {
                 f(h.yield_job(d));
               },
               std::move(hierarchy)};
@@ -68,7 +68,7 @@ namespace phlex::experimental {
                          is_driver_like_with_yielder auto driver_function) const
     {
       auto h = hierarchy;
-      return {[f = std::move(driver_function), h = std::move(h)](framework_driver& d) {
+      return {[f = std::move(driver_function), h = std::move(h)](framework_driver& d) mutable {
                 f(h.yielder(d));
               },
               std::move(hierarchy)};

--- a/phlex/driver.hpp
+++ b/phlex/driver.hpp
@@ -36,7 +36,10 @@ namespace phlex::experimental {
 
 namespace phlex::experimental {
   template <typename F>
-  concept is_driver_like = std::invocable<F, data_cell_cursor const&>;
+  concept is_driver_like_with_cursor = std::invocable<F, data_cell_cursor>;
+
+  template <typename F>
+  concept is_driver_like_with_yielder = std::invocable<F, data_cell_yielder>;
 
   /// @brief Proxy for constructing a driver bundle from a user-supplied driver function.
   ///
@@ -49,11 +52,27 @@ namespace phlex::experimental {
     /// @param hierarchy  The data hierarchy the driver will traverse.
     /// @param driver_function  A callable receiving a @c data_cell_cursor const& that
     ///                         emits data cells to the framework.
-    driver_bundle driver(fixed_hierarchy hierarchy, is_driver_like auto driver_function) const
+    driver_bundle driver(fixed_hierarchy hierarchy,
+                         is_driver_like_with_cursor auto driver_function) const
     {
       auto h = hierarchy;
       return {[f = std::move(driver_function), h = std::move(h)](framework_driver& d) mutable {
                 f(h.yield_job(d));
+              },
+              std::move(hierarchy)};
+    }
+
+    /// @brief Creates a driver_bundle from a hierarchy and a user-supplied driver function.
+    ///
+    /// @param hierarchy  The data hierarchy the driver will traverse.
+    /// @param driver_function  A callable receiving a @c data_cell_yielder const& that
+    ///                         emits data cells to the framework.
+    driver_bundle driver(fixed_hierarchy hierarchy,
+                         is_driver_like_with_yielder auto driver_function) const
+    {
+      auto h = hierarchy;
+      return {[f = std::move(driver_function), h = std::move(h)](framework_driver& d) mutable {
+                f(h.yielder(d));
               },
               std::move(hierarchy)};
     }

--- a/phlex/driver.hpp
+++ b/phlex/driver.hpp
@@ -7,7 +7,7 @@
 #include "phlex/model/data_cell_index.hpp"
 #include "phlex/model/fixed_hierarchy.hpp"
 #include "phlex/model/product_store.hpp"
-#include "phlex/utilities/async_driver.hpp"
+#include "phlex/utilities/resumable_driver.hpp"
 
 #include <concepts>
 #include <functional>
@@ -17,11 +17,8 @@ namespace phlex::experimental {
   class driver_proxy;
   struct driver_bundle;
 
-  using framework_driver = experimental::async_driver<data_cell_index_ptr>;
-
   namespace detail {
     using next_index_t = std::function<void(framework_driver&)>;
-    using driver_creator_t = driver_bundle(driver_proxy const&, configuration const&);
     // Shim type for the extern "C" entry-point: out-parameter avoids returning a C++ type
     // across a C-linkage boundary.
     using driver_shim_t = void(driver_proxy const&, configuration const&, driver_bundle*);
@@ -56,7 +53,7 @@ namespace phlex::experimental {
                          is_driver_like_with_cursor auto driver_function) const
     {
       auto h = hierarchy;
-      return {[f = std::move(driver_function), h = std::move(h)](framework_driver& d) mutable {
+      return {[f = std::move(driver_function), h = std::move(h)](framework_driver& d) {
                 f(h.yield_job(d));
               },
               std::move(hierarchy)};
@@ -71,7 +68,7 @@ namespace phlex::experimental {
                          is_driver_like_with_yielder auto driver_function) const
     {
       auto h = hierarchy;
-      return {[f = std::move(driver_function), h = std::move(h)](framework_driver& d) mutable {
+      return {[f = std::move(driver_function), h = std::move(h)](framework_driver& d) {
                 f(h.yielder(d));
               },
               std::move(hierarchy)};

--- a/phlex/model/CMakeLists.txt
+++ b/phlex/model/CMakeLists.txt
@@ -28,6 +28,7 @@ cet_make_library(
 install(
   FILES
     algorithm_name.hpp
+    index_generator.hpp
     fixed_hierarchy.hpp
     flush_messages.hpp
     fwd.hpp

--- a/phlex/model/data_cell_index.cpp
+++ b/phlex/model/data_cell_index.cpp
@@ -44,9 +44,9 @@ namespace phlex {
     parent_{std::move(parent)},
     number_{i},
     layer_name_{std::move(layer_name)},
-    layer_hash_{phlex::experimental::hash(parent_->layer_hash_, layer_name_.hash())},
+    layer_hash_{experimental::hash(parent_->layer_hash_, layer_name_.hash())},
     depth_{parent_->depth_ + 1},
-    hash_{phlex::experimental::hash(parent_->hash_, number_, layer_hash_)}
+    hash_{experimental::hash(parent_->hash_, number_, layer_hash_)}
   {
     // FIXME: Should it be an error to create an ID with an empty name?
   }

--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -78,6 +78,20 @@ namespace phlex {
   std::string data_cell_cursor::layer_path() const { return index_->layer_path(); }
 
   // ================================================================================
+  // data_cell_yielder implementation
+  data_cell_yielder::data_cell_yielder(fixed_hierarchy const& h,
+                                       experimental::async_driver<data_cell_index_ptr>& d) :
+    hierarchy_{h}, driver_{d}
+  {
+  }
+
+  void data_cell_yielder::operator()(data_cell_index_ptr const& index) const
+  {
+    hierarchy_.validate(index);
+    driver_.yield(index);
+  }
+
+  // ================================================================================
   // fixed_hierarchy implementation
   fixed_hierarchy::fixed_hierarchy(std::initializer_list<std::vector<std::string>> layer_paths) :
     fixed_hierarchy(std::vector<std::vector<std::string>>(layer_paths))
@@ -109,4 +123,9 @@ namespace phlex {
     return data_cell_cursor{job, *this, d};
   }
 
+  data_cell_yielder fixed_hierarchy::yielder(
+    experimental::async_driver<data_cell_index_ptr>& d) const
+  {
+    return data_cell_yielder{*this, d};
+  }
 }

--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -2,8 +2,8 @@
 
 #include "phlex/model/data_cell_index.hpp"
 #include "phlex/model/identifier.hpp"
-#include "phlex/utilities/async_driver.hpp"
 #include "phlex/utilities/hashing.hpp"
+#include "phlex/utilities/resumable_driver.hpp"
 
 #include "fmt/format.h"
 
@@ -61,7 +61,7 @@ namespace phlex {
   // data_cell_cursor implementation
   data_cell_cursor::data_cell_cursor(data_cell_index_ptr index,
                                      fixed_hierarchy const& h,
-                                     experimental::async_driver<data_cell_index_ptr>& d) :
+                                     experimental::framework_driver& d) :
     index_{std::move(index)}, hierarchy_{h}, driver_{d}
   {
   }
@@ -80,7 +80,7 @@ namespace phlex {
   // ================================================================================
   // data_cell_yielder implementation
   data_cell_yielder::data_cell_yielder(fixed_hierarchy const& h,
-                                       experimental::async_driver<data_cell_index_ptr>& d) :
+                                       experimental::framework_driver& d) :
     hierarchy_{h}, driver_{d}
   {
   }
@@ -115,16 +115,14 @@ namespace phlex {
       fmt::format("Layer {} is not part of the fixed hierarchy.", index->layer_path()));
   }
 
-  data_cell_cursor fixed_hierarchy::yield_job(
-    experimental::async_driver<data_cell_index_ptr>& d) const
+  data_cell_cursor fixed_hierarchy::yield_job(experimental::framework_driver& d) const
   {
     auto job = data_cell_index::job();
     d.yield(job);
     return data_cell_cursor{job, *this, d};
   }
 
-  data_cell_yielder fixed_hierarchy::yielder(
-    experimental::async_driver<data_cell_index_ptr>& d) const
+  data_cell_yielder fixed_hierarchy::yielder(experimental::framework_driver& d) const
   {
     return data_cell_yielder{*this, d};
   }

--- a/phlex/model/fixed_hierarchy.hpp
+++ b/phlex/model/fixed_hierarchy.hpp
@@ -42,6 +42,20 @@ namespace phlex {
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
 
+  class PHLEX_MODEL_EXPORT data_cell_yielder {
+  public:
+    void operator()(data_cell_index_ptr const& index) const;
+
+  private:
+    friend class fixed_hierarchy;
+    data_cell_yielder(fixed_hierarchy const& h, experimental::async_driver<data_cell_index_ptr>& d);
+
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+    fixed_hierarchy const& hierarchy_;
+    experimental::async_driver<data_cell_index_ptr>& driver_;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
+  };
+
   class PHLEX_MODEL_EXPORT fixed_hierarchy {
   public:
     fixed_hierarchy() = default;
@@ -61,6 +75,8 @@ namespace phlex {
     // data_cell_cursor for the job.  Must only be called from a function registered
     // via driver_proxy::drive().
     data_cell_cursor yield_job(experimental::async_driver<data_cell_index_ptr>& d) const;
+
+    data_cell_yielder yielder(experimental::async_driver<data_cell_index_ptr>& d) const;
 
   private:
     std::vector<std::vector<std::string>> layer_paths_;

--- a/phlex/model/fixed_hierarchy.hpp
+++ b/phlex/model/fixed_hierarchy.hpp
@@ -12,8 +12,13 @@
 
 namespace phlex {
 
-  class fixed_hierarchy;
-
+  /// @brief Cursor-like object for traversing the data-cell hierarchy.
+  ///
+  /// Represents a position in the hierarchy and provides `yield_child()` to emit
+  /// child data cells and advance the cursor. Used by driver functions that require
+  /// hierarchical traversal of the data-cell tree.
+  ///
+  /// @see data_cell_yielder for a callable alternative that accepts indices directly
   class PHLEX_MODEL_EXPORT data_cell_cursor {
   public:
     // Validates that the child layer is part of the fixed hierarchy and yields the child
@@ -37,6 +42,14 @@ namespace phlex {
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
 
+  /// @brief Callable object that yields data cells to the framework driver.
+  ///
+  /// Bound to a @c fixed_hierarchy and @c framework_driver, this callable accepts
+  /// a @c data_cell_index_ptr and validates it against the hierarchy before yielding
+  /// it to the driver. Used by driver functions that need to emit multiple data cells
+  /// without manually managing the job-level cursor.
+  ///
+  /// @see data_cell_cursor for a cursor-based alternative
   class PHLEX_MODEL_EXPORT data_cell_yielder {
   public:
     void operator()(data_cell_index_ptr const& index) const;
@@ -67,12 +80,10 @@ namespace phlex {
     void validate(data_cell_index_ptr const& index) const;
 
     // Yields the job-level data-cell index to the provided driver and returns a
-    // data_cell_cursor for the job.  Must only be called from a function registered
-    // via driver_proxy::drive().
+    // data_cell_cursor for the job.
     data_cell_cursor yield_job(experimental::framework_driver& d) const;
 
-    // Returns a callable data-cell yielder bound to the provided driver for use when
-    // yielding additional data-cell indexes from registered framework functions.
+    // Returns a callable data-cell yielder bound to the provided driver.
     data_cell_yielder yielder(experimental::framework_driver& d) const;
 
   private:

--- a/phlex/model/fixed_hierarchy.hpp
+++ b/phlex/model/fixed_hierarchy.hpp
@@ -10,11 +10,6 @@
 #include <string>
 #include <vector>
 
-namespace phlex::experimental {
-  template <typename RT>
-  class async_driver;
-}
-
 namespace phlex {
 
   class fixed_hierarchy;
@@ -31,14 +26,14 @@ namespace phlex {
     friend class fixed_hierarchy;
     data_cell_cursor(data_cell_index_ptr index,
                      fixed_hierarchy const& h,
-                     experimental::async_driver<data_cell_index_ptr>& d);
+                     experimental::framework_driver& d);
 
     data_cell_index_ptr index_;
     // Non-owning references to the enclosing hierarchy and driver; data_cell_cursor is a
     // short-lived view and does not manage their lifetimes.
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     fixed_hierarchy const& hierarchy_;
-    experimental::async_driver<data_cell_index_ptr>& driver_;
+    experimental::framework_driver& driver_;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
 
@@ -48,11 +43,11 @@ namespace phlex {
 
   private:
     friend class fixed_hierarchy;
-    data_cell_yielder(fixed_hierarchy const& h, experimental::async_driver<data_cell_index_ptr>& d);
+    data_cell_yielder(fixed_hierarchy const& h, experimental::framework_driver& d);
 
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     fixed_hierarchy const& hierarchy_;
-    experimental::async_driver<data_cell_index_ptr>& driver_;
+    experimental::framework_driver& driver_;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
 
@@ -74,9 +69,11 @@ namespace phlex {
     // Yields the job-level data-cell index to the provided driver and returns a
     // data_cell_cursor for the job.  Must only be called from a function registered
     // via driver_proxy::drive().
-    data_cell_cursor yield_job(experimental::async_driver<data_cell_index_ptr>& d) const;
+    data_cell_cursor yield_job(experimental::framework_driver& d) const;
 
-    data_cell_yielder yielder(experimental::async_driver<data_cell_index_ptr>& d) const;
+    // Returns a callable data-cell yielder bound to the provided driver for use when
+    // yielding additional data-cell indexes from registered framework functions.
+    data_cell_yielder yielder(experimental::framework_driver& d) const;
 
   private:
     std::vector<std::vector<std::string>> layer_paths_;

--- a/phlex/model/fwd.hpp
+++ b/phlex/model/fwd.hpp
@@ -3,6 +3,14 @@
 
 #include <memory>
 
+namespace phlex {
+  class data_cell_index;
+  using data_cell_index_ptr = std::shared_ptr<data_cell_index const>;
+
+  template <typename T>
+  class handle;
+}
+
 namespace phlex::experimental {
   class data_layer_hierarchy;
   class data_cell_counts;
@@ -12,14 +20,11 @@ namespace phlex::experimental {
   using data_cell_counts_ptr = std::shared_ptr<data_cell_counts>;
   using product_store_const_ptr = std::shared_ptr<product_store const>;
   using product_store_ptr = std::shared_ptr<product_store>;
-}
 
-namespace phlex {
-  class data_cell_index;
-  using data_cell_index_ptr = std::shared_ptr<data_cell_index const>;
+  template <typename RT>
+  class resumable_driver;
 
-  template <typename T>
-  class handle;
+  using framework_driver = resumable_driver<data_cell_index_ptr>;
 }
 
 #endif // PHLEX_MODEL_FWD_HPP

--- a/phlex/model/fwd.hpp
+++ b/phlex/model/fwd.hpp
@@ -9,6 +9,8 @@ namespace phlex {
 
   template <typename T>
   class handle;
+
+  class fixed_hierarchy;
 }
 
 namespace phlex::experimental {

--- a/phlex/model/index_generator.hpp
+++ b/phlex/model/index_generator.hpp
@@ -1,6 +1,18 @@
 #ifndef PHLEX_MODEL_INDEX_GENERATOR_HPP
 #define PHLEX_MODEL_INDEX_GENERATOR_HPP
 
+/// @file
+/// @brief Provides a generator-like iterator for data_cell_index_ptr values.
+///
+/// This file exists to support generator-like behavior for compilers that do not necessarily
+/// support std::generator (for example, Apple clang). It is intended to be removed once the
+/// compilers we develop with support std::generator.
+///
+/// Phlex uses index_generator for sources that need to produce a sequence of data-cell index
+/// pointers, typically for iterating over hierarchical data structures (e.g., run → subrun →
+/// trigger record). The generator pattern allows sources to yield indices lazily as they traverse
+/// the hierarchy.
+
 #include "phlex/model/fwd.hpp"
 
 #if defined(__has_include)

--- a/phlex/model/index_generator.hpp
+++ b/phlex/model/index_generator.hpp
@@ -1,0 +1,144 @@
+#ifndef PHLEX_MODEL_INDEX_GENERATOR_HPP
+#define PHLEX_MODEL_INDEX_GENERATOR_HPP
+
+#include "phlex/model/fwd.hpp"
+
+#if defined(__has_include)
+#if __has_include(<generator>)
+#include <generator>
+#include <version>
+#endif
+#endif
+
+#if !defined(__cpp_lib_generator)
+#include <coroutine>
+#include <exception>
+#include <iterator>
+#include <memory>
+#include <utility>
+#endif
+
+namespace phlex {
+#if defined(__cpp_lib_generator)
+  using index_generator = std::generator<data_cell_index_ptr>;
+#else
+  class index_generator {
+  public:
+    struct promise_type;
+    using handle_type = std::coroutine_handle<promise_type>;
+
+    struct promise_type {
+      data_cell_index_ptr current_{};
+      std::exception_ptr exception_{};
+
+      index_generator get_return_object()
+      {
+        return index_generator{handle_type::from_promise(*this)};
+      }
+      static std::suspend_always initial_suspend() noexcept { return {}; }
+      static std::suspend_always final_suspend() noexcept { return {}; }
+      std::suspend_always yield_value(data_cell_index_ptr value) noexcept
+      {
+        current_ = std::move(value);
+        return {};
+      }
+      void return_void() noexcept {}
+      void unhandled_exception() noexcept { exception_ = std::current_exception(); }
+    };
+
+    class iterator {
+    public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type = data_cell_index_ptr;
+      using difference_type = std::ptrdiff_t;
+
+      iterator() noexcept = default;
+      explicit iterator(handle_type coroutine) noexcept : coroutine_{coroutine} {}
+
+      iterator& operator++()
+      {
+        coroutine_.resume();
+        if (coroutine_.done()) {
+          auto& promise = coroutine_.promise();
+          if (promise.exception_) {
+            std::rethrow_exception(promise.exception_);
+          }
+        }
+        return *this;
+      }
+
+      void operator++(int) { (void)++(*this); }
+
+      value_type const& operator*() const noexcept { return coroutine_.promise().current_; }
+      value_type const* operator->() const noexcept
+      {
+        return std::addressof(coroutine_.promise().current_);
+      }
+
+      bool operator==(std::default_sentinel_t) const noexcept
+      {
+        return !coroutine_ || coroutine_.done();
+      }
+
+    private:
+      handle_type coroutine_{};
+    };
+
+    index_generator() noexcept = default;
+
+    explicit index_generator(handle_type coroutine) noexcept : coroutine_{coroutine} {}
+
+    index_generator(index_generator const&) = delete;
+    index_generator& operator=(index_generator const&) = delete;
+
+    index_generator(index_generator&& other) noexcept :
+      coroutine_{std::exchange(other.coroutine_, {})}
+    {
+    }
+
+    index_generator& operator=(index_generator&& other) noexcept
+    {
+      if (this == &other) {
+        return *this;
+      }
+
+      if (coroutine_) {
+        coroutine_.destroy();
+      }
+      coroutine_ = std::exchange(other.coroutine_, {});
+      return *this;
+    }
+
+    ~index_generator()
+    {
+      if (coroutine_) {
+        coroutine_.destroy();
+      }
+    }
+
+    iterator begin()
+    {
+      if (!coroutine_) {
+        return iterator{};
+      }
+
+      coroutine_.resume();
+      if (coroutine_.done()) {
+        auto& promise = coroutine_.promise();
+        if (promise.exception_) {
+          std::rethrow_exception(promise.exception_);
+        }
+        return iterator{};
+      }
+      return iterator{coroutine_};
+    }
+
+    std::default_sentinel_t end() const noexcept { return {}; }
+
+  private:
+    handle_type coroutine_{};
+  };
+#endif
+}
+
+#endif // PHLEX_MODEL_INDEX_GENERATOR_HPP

--- a/phlex/utilities/CMakeLists.txt
+++ b/phlex/utilities/CMakeLists.txt
@@ -14,7 +14,7 @@ cet_make_library(
 
 install(
   FILES
-    async_driver.hpp
+    resumable_driver.hpp
     hashing.hpp
     max_allowed_parallelism.hpp
     resource_usage.hpp

--- a/phlex/utilities/resumable_driver.hpp
+++ b/phlex/utilities/resumable_driver.hpp
@@ -1,9 +1,9 @@
-#ifndef PHLEX_UTILITIES_ASYNC_DRIVER_HPP
-#define PHLEX_UTILITIES_ASYNC_DRIVER_HPP
+#ifndef PHLEX_UTILITIES_RESUMABLE_DRIVER_HPP
+#define PHLEX_UTILITIES_RESUMABLE_DRIVER_HPP
 
 // ===========================================================================================
-// async_driver mediates between a TBB task thread and a dedicated driver thread that produces
-// items one at a time via yield().
+// resumable_driver mediates between a TBB task thread and a dedicated driver thread that
+// produces items one at a time via yield().
 //
 // The two threads alternate ownership of a single slot using two binary semaphores:
 //
@@ -32,15 +32,15 @@
 namespace phlex::experimental {
 
   template <typename RT>
-  class async_driver {
+  class resumable_driver {
     enum class states : std::uint8_t { off, drive, park };
 
   public:
     template <typename FT>
-    explicit async_driver(FT ft) : driver_{std::move(ft)}
+    explicit resumable_driver(FT ft) : driver_{std::move(ft)}
     {
     }
-    explicit async_driver(void (*ft)(async_driver<RT>&)) : driver_{ft} {}
+    explicit resumable_driver(void (*ft)(resumable_driver<RT>&)) : driver_{ft} {}
 
     std::optional<RT> operator()()
     {
@@ -89,7 +89,7 @@ namespace phlex::experimental {
     }
 
   private:
-    std::function<void(async_driver&)> driver_;
+    std::function<void(resumable_driver&)> driver_;
     std::optional<RT> current_;
     std::atomic<states> gear_ = states::off;
     std::jthread thread_;
@@ -99,4 +99,4 @@ namespace phlex::experimental {
   };
 }
 
-#endif // PHLEX_UTILITIES_ASYNC_DRIVER_HPP
+#endif // PHLEX_UTILITIES_RESUMABLE_DRIVER_HPP

--- a/plugins/generate_layers.cpp
+++ b/plugins/generate_layers.cpp
@@ -36,5 +36,9 @@ PHLEX_REGISTER_DRIVER(d, config)
                     .starting_value = layer_config.get<unsigned int>("starting_number", 0)});
   }
 
-  return d.driver(gen->hierarchy(), [gen](data_cell_cursor const& job) { (*gen)(job); });
+  return d.driver(gen->hierarchy(), [gen](data_cell_yielder const yield) {
+    for (data_cell_index_ptr const& index : gen->indices()) {
+      yield(index);
+    }
+  });
 }

--- a/plugins/layer_generator.cpp
+++ b/plugins/layer_generator.cpp
@@ -123,26 +123,35 @@ namespace phlex::experimental {
     layer_paths_.push_back(full_path);
   }
 
-  void layer_generator::operator()(data_cell_cursor const& job)
+  index_generator layer_generator::indices()
   {
     ++emitted_cells_.at("/job");
-    execute(job);
+    auto job = data_cell_index::job();
+    co_yield job;
+
+    for (auto const& generated_cell : execute(job)) {
+      co_yield generated_cell;
+    }
   }
 
-  void layer_generator::execute(data_cell_cursor const& cell)
+  index_generator layer_generator::execute(data_cell_index_ptr const cell)
   {
-    auto it = parent_to_children_.find(cell.layer_path());
+    auto it = parent_to_children_.find(cell->layer_path());
     assert(it != parent_to_children_.cend());
 
     for (auto const& child : it->second) {
-      auto const full_child_path = cell.layer_path() + "/" + child;
+      auto const full_child_path = cell->layer_path() + "/" + child;
       auto const& [_, total_per_parent, starting_value] = layers_.at(full_child_path);
       bool const has_children = parent_to_children_.contains(full_child_path);
       for (unsigned int i : std::views::iota(starting_value, total_per_parent + starting_value)) {
+        auto child_cell = cell->make_child(child, i);
         ++emitted_cells_.at(full_child_path);
-        auto const child_cell = cell.yield_child(child, i);
+        co_yield child_cell;
+
         if (has_children) {
-          execute(child_cell);
+          for (auto const& generated_cell : execute(child_cell)) {
+            co_yield generated_cell;
+          }
         }
       }
     }

--- a/plugins/layer_generator.cpp
+++ b/plugins/layer_generator.cpp
@@ -1,11 +1,13 @@
 #include "plugins/layer_generator.hpp"
-#include "phlex/model/data_cell_index.hpp"
 
 #include "fmt/format.h"
-#include "spdlog/spdlog.h"
 
 #include <algorithm>
+#include <cassert>
+#include <functional>
 #include <ranges>
+#include <stdexcept>
+#include <utility>
 
 namespace phlex::experimental {
 
@@ -33,12 +35,7 @@ namespace phlex::experimental {
   {
     // Check if the count of all emitted cells is requested
     if (layer_path.empty()) {
-      // For C++23, we can use std::ranges::fold_left
-      std::size_t total{};
-      for (auto const& [_, count] : emitted_cells_) {
-        total += count;
-      }
-      return total;
+      return std::ranges::fold_left(emitted_cells_ | std::views::values, 0uz, std::plus<>{});
     }
 
     if (auto it = emitted_cells_.find(layer_path); it != emitted_cells_.end()) {

--- a/plugins/layer_generator.hpp
+++ b/plugins/layer_generator.hpp
@@ -30,6 +30,7 @@
 
 #include "phlex/driver.hpp"
 #include "phlex/model/data_cell_index.hpp"
+#include "phlex/model/index_generator.hpp"
 
 #include <functional>
 #include <map>
@@ -55,13 +56,13 @@ namespace phlex::experimental {
 
     void add_layer(std::string layer_name, layer_spec lspec);
 
-    void operator()(data_cell_cursor const& job);
+    index_generator indices();
 
     fixed_hierarchy hierarchy() const;
     std::size_t emitted_cell_count(std::string layer_path = {}) const;
 
   private:
-    void execute(data_cell_cursor const& cell);
+    index_generator execute(data_cell_index_ptr const cell);
     std::string parent_path(std::string const& layer_name,
                             std::string const& parent_layer_spec) const;
     void maybe_rebase_layer_paths(std::string const& layer_name,
@@ -79,8 +80,11 @@ namespace phlex::experimental {
   inline driver_bundle driver_for_test(layer_generator& generator)
   {
     driver_proxy const proxy{};
-    return proxy.driver(generator.hierarchy(),
-                        [&generator](data_cell_cursor const& job) { generator(job); });
+    return proxy.driver(generator.hierarchy(), [&generator](data_cell_yielder const yield) {
+      for (data_cell_index_ptr const& index : generator.indices()) {
+        yield(index);
+      }
+    });
   }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,6 +170,9 @@ cet_test(
 cet_test(data_cell_index USE_CATCH2_MAIN SOURCE data_cell_index.cpp LIBRARIES
          phlex::model_internal
 )
+cet_test(index_generator USE_CATCH2_MAIN SOURCE index_generator.cpp LIBRARIES
+         phlex::model_internal
+)
 cet_test(fixed_hierarchy_test USE_CATCH2_MAIN SOURCE fixed_hierarchy_test.cpp LIBRARIES
          phlex::model
 )

--- a/test/framework_graph.cpp
+++ b/test/framework_graph.cpp
@@ -8,17 +8,17 @@
 #include <stdexcept>
 
 using namespace phlex;
+using phlex::experimental::framework_driver;
 
 TEST_CASE("Catch STL exceptions", "[graph]")
 {
-  experimental::framework_graph g{
-    [](experimental::framework_driver&) { throw std::runtime_error("STL error"); }};
+  experimental::framework_graph g{[](framework_driver&) { throw std::runtime_error("STL error"); }};
   CHECK_THROWS_AS(g.execute(), std::exception);
 }
 
 TEST_CASE("Catch other exceptions", "[graph]")
 {
-  experimental::framework_graph g{[](experimental::framework_driver&) { throw 2.5; }};
+  experimental::framework_graph g{[](framework_driver&) { throw 2.5; }};
   CHECK_THROWS_AS(g.execute(), double);
 }
 

--- a/test/index_generator.cpp
+++ b/test/index_generator.cpp
@@ -1,0 +1,31 @@
+#include "phlex/model/index_generator.hpp"
+#include "phlex/model/data_cell_index.hpp"
+
+#include "catch2/catch_test_macros.hpp"
+
+#include <vector>
+
+using namespace phlex;
+
+namespace {
+  index_generator make_indices()
+  {
+    auto job = data_cell_index::job();
+    co_yield job;
+
+    auto run = job->make_child("run", 2);
+    co_yield run;
+
+    co_yield run->make_child("subrun", 7);
+  }
+}
+
+TEST_CASE("index_generator yields data_cell_index_ptr values", "[data model]")
+{
+  std::vector<std::string> seen;
+  for (auto const& index : make_indices()) {
+    seen.push_back(index->to_string());
+  }
+
+  CHECK(seen == std::vector<std::string>{"[]", "[run:2]", "[run:2, subrun:7]"});
+}

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -30,8 +30,6 @@ namespace {
 TEST_CASE("provider_test")
 {
   constexpr auto max_events{3u};
-  // constexpr auto max_events{1'000'000u};
-  spdlog::flush_on(spdlog::level::trace);
 
   experimental::layer_generator gen;
   gen.add_layer("spill", {"job", max_events, 1u});

--- a/test/yielding_driver.cpp
+++ b/test/yielding_driver.cpp
@@ -1,6 +1,6 @@
 #include "phlex/model/data_cell_index.hpp"
 #include "phlex/model/index_generator.hpp"
-#include "phlex/utilities/async_driver.hpp"
+#include "phlex/utilities/resumable_driver.hpp"
 
 #include "catch2/catch_test_macros.hpp"
 
@@ -31,7 +31,7 @@ namespace {
     }
   }
 
-  void cells_to_process(experimental::async_driver<data_cell_index_ptr>& d)
+  void cells_to_process(experimental::resumable_driver<data_cell_index_ptr>& d)
   {
     for (auto const& index : make_indices(2, 2, 3)) {
       d.yield(index);
@@ -39,9 +39,9 @@ namespace {
   }
 }
 
-TEST_CASE("Async driver with TBB flow graph", "[async_driver]")
+TEST_CASE("Resumable driver with TBB flow graph", "[resumable_driver]")
 {
-  experimental::async_driver<data_cell_index_ptr> drive{cells_to_process};
+  experimental::resumable_driver<data_cell_index_ptr> drive{cells_to_process};
   std::vector<std::string> received_indices;
 
   tbb::flow::graph g{};

--- a/test/yielding_driver.cpp
+++ b/test/yielding_driver.cpp
@@ -1,4 +1,5 @@
 #include "phlex/model/data_cell_index.hpp"
+#include "phlex/model/index_generator.hpp"
 #include "phlex/utilities/async_driver.hpp"
 
 #include "catch2/catch_test_macros.hpp"
@@ -10,23 +11,30 @@
 
 using namespace phlex;
 
-void cells_to_process(experimental::async_driver<data_cell_index_ptr>& d)
-{
-  unsigned int const num_runs = 2;
-  unsigned int const num_subruns = 2;
-  unsigned int const num_spills = 3;
-
-  auto job_id = data_cell_index::job();
-  d.yield(job_id);
-  for (unsigned int r : std::views::iota(0u, num_runs)) {
-    auto run_id = job_id->make_child("run", r);
-    d.yield(run_id);
-    for (unsigned int sr : std::views::iota(0u, num_subruns)) {
-      auto subrun_id = run_id->make_child("subrun", sr);
-      d.yield(subrun_id);
-      for (unsigned int spill : std::views::iota(0u, num_spills)) {
-        d.yield(subrun_id->make_child("spill", spill));
+namespace {
+  index_generator make_indices(unsigned int num_runs,
+                               unsigned int num_subruns,
+                               unsigned int num_spills)
+  {
+    auto job_id = data_cell_index::job();
+    co_yield job_id;
+    for (unsigned int r : std::views::iota(0u, num_runs)) {
+      auto run_id = job_id->make_child("run", r);
+      co_yield run_id;
+      for (unsigned int sr : std::views::iota(0u, num_subruns)) {
+        auto subrun_id = run_id->make_child("subrun", sr);
+        co_yield subrun_id;
+        for (unsigned int spill : std::views::iota(0u, num_spills)) {
+          co_yield subrun_id->make_child("spill", spill);
+        }
       }
+    }
+  }
+
+  void cells_to_process(experimental::async_driver<data_cell_index_ptr>& d)
+  {
+    for (auto const& index : make_indices(2, 2, 3)) {
+      d.yield(index);
     }
   }
 }


### PR DESCRIPTION
This is to support the pattern discussed at https://github.com/orgs/Framework-R-D/discussions/505#discussioncomment-17079828, where sources can lazily emit data-cell indices.