### PR TITLE
Accommodate `product_specification` API change 

### DIFF
--- a/phlex/core/product_selector.cpp
+++ b/phlex/core/product_selector.cpp
@@ -28,7 +28,7 @@ namespace phlex {
   // Check if a product_specification satisfies this query
   bool product_selector::match(experimental::product_specification const& spec) const
   {
-    if (!creator_match(spec.qualifier())) {
+    if (!creator_match(spec.creator())) {
       return false;
     }
     if (type != spec.type()) {


### PR DESCRIPTION
I merged #615, which introduced a inconsistency wrt. `main`.  This PR fixes that.