### PR TITLE
Constrain exposed API of graph-proxy objects

### DIFF
--- a/phlex/core/concepts.hpp
+++ b/phlex/core/concepts.hpp
@@ -14,6 +14,9 @@ namespace phlex::experimental {
   concept not_void = !std::same_as<T, void>;
 
   template <typename T>
+  concept is_bound_object = not std::same_as<T, void_tag>;
+
+  template <typename T>
   concept sendable = std::move_constructible<T> || requires(T& t) {
     { send(t) } -> std::move_constructible;
   };

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -149,7 +149,7 @@ namespace phlex::experimental {
     glue<T> make_glue(Args&&... args)
     {
       std::shared_ptr<T> bound_object{nullptr};
-      if constexpr (!std::same_as<T, void_tag> && Construct) {
+      if constexpr (is_bound_object<T> && Construct) {
         bound_object = std::make_shared<T>(std::forward<Args>(args)...);
       }
       return {graph_, nodes_, std::move(bound_object), registration_errors_};

--- a/phlex/core/graph_proxy.hpp
+++ b/phlex/core/graph_proxy.hpp
@@ -29,17 +29,17 @@ namespace phlex::experimental {
   /// Passed to user plugin entry points by the framework. Use the registration
   /// methods to attach user algorithms to the graph. Users never construct
   /// this type directly.
-  template <typename T, bool BoundObject = false>
+  template <typename T>
   class graph_proxy {
   public:
-    template <typename, bool>
+    template <typename>
     friend class graph_proxy;
 
     graph_proxy(configuration const& config,
                 tbb::flow::graph& g,
                 node_catalog& nodes,
                 std::vector<std::string>& errors)
-      requires(std::same_as<T, void_tag> && !BoundObject)
+      requires(not is_bound_object<T>)
       : config_{&config}, graph_{g}, nodes_{nodes}, errors_{errors}
     {
     }
@@ -50,8 +50,8 @@ namespace phlex::experimental {
     /// Returns a new proxy through which member functions of that object may
     /// be registered as algorithm nodes.
     template <typename U, typename... Args>
-    graph_proxy<U, true> make(Args&&... args)
-      requires(not BoundObject)
+    graph_proxy<U> make(Args&&... args)
+      requires(not is_bound_object<T>)
     {
       return bind_to<graph_proxy, U>(std::forward<Args>(args)...);
     }
@@ -114,11 +114,11 @@ namespace phlex::experimental {
     }
 
   protected:
-    template <template <typename, bool> typename Proxy, typename U, typename... Args>
-    Proxy<U, true> bind_to(Args&&... args)
-      requires(not BoundObject)
+    template <template <typename> typename Proxy, typename U, typename... Args>
+    Proxy<U> bind_to(Args&&... args)
+      requires(not is_bound_object<T>)
     {
-      return Proxy<U, true>{
+      return Proxy<U>{
         config_, graph_, nodes_, std::make_shared<U>(std::forward<Args>(args)...), errors_};
     }
 
@@ -127,7 +127,7 @@ namespace phlex::experimental {
                 node_catalog& nodes,
                 std::shared_ptr<T> bound_obj,
                 std::vector<std::string>& errors)
-      requires(not std::same_as<T, void_tag> && BoundObject)
+      requires(is_bound_object<T>)
       : config_{config}, graph_{g}, nodes_{nodes}, bound_obj_{bound_obj}, errors_{errors}
     {
     }
@@ -139,7 +139,7 @@ namespace phlex::experimental {
     }
 
     configuration const* config_;
-    // Non-owning references to framework-owned resources; graph_proxy<T, BoundObject> is a
+    // Non-owning references to framework-owned resources; graph_proxy<T> is a
     // short-lived builder.
     tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     node_catalog& nodes_;     // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)

--- a/phlex/core/graph_proxy.hpp
+++ b/phlex/core/graph_proxy.hpp
@@ -29,17 +29,17 @@ namespace phlex::experimental {
   /// Passed to user plugin entry points by the framework. Use the registration
   /// methods to attach user algorithms to the graph. Users never construct
   /// this type directly.
-  template <typename T>
+  template <typename T, bool BoundObject = false>
   class graph_proxy {
   public:
-    template <typename>
+    template <typename, bool>
     friend class graph_proxy;
 
     graph_proxy(configuration const& config,
                 tbb::flow::graph& g,
                 node_catalog& nodes,
                 std::vector<std::string>& errors)
-      requires(std::same_as<T, void_tag>)
+      requires(std::same_as<T, void_tag> && !BoundObject)
       : config_{&config}, graph_{g}, nodes_{nodes}, errors_{errors}
     {
     }
@@ -50,10 +50,10 @@ namespace phlex::experimental {
     /// Returns a new proxy through which member functions of that object may
     /// be registered as algorithm nodes.
     template <typename U, typename... Args>
-    graph_proxy<U> make(Args&&... args)
+    graph_proxy<U, true> make(Args&&... args)
+      requires(not BoundObject)
     {
-      return graph_proxy<U>{
-        config_, graph_, nodes_, std::make_shared<U>(std::forward<Args>(args)...), errors_};
+      return bind_to<graph_proxy, U>(std::forward<Args>(args)...);
     }
 
     /// @brief Registers a fold algorithm node.
@@ -113,24 +113,34 @@ namespace phlex::experimental {
       return create_glue().output(std::move(name), std::move(f), c);
     }
 
-  private:
+  protected:
+    template <template <typename, bool> typename Proxy, typename U, typename... Args>
+    Proxy<U, true> bind_to(Args&&... args)
+      requires(not BoundObject)
+    {
+      return Proxy<U, true>{
+        config_, graph_, nodes_, std::make_shared<U>(std::forward<Args>(args)...), errors_};
+    }
+
     graph_proxy(configuration const* config,
                 tbb::flow::graph& g,
                 node_catalog& nodes,
                 std::shared_ptr<T> bound_obj,
                 std::vector<std::string>& errors)
-      requires(not std::same_as<T, void_tag>)
+      requires(not std::same_as<T, void_tag> && BoundObject)
       : config_{config}, graph_{g}, nodes_{nodes}, bound_obj_{bound_obj}, errors_{errors}
     {
     }
 
+  private:
     glue<T> create_glue(bool use_bound_object = true)
     {
       return glue{graph_, nodes_, (use_bound_object ? bound_obj_ : nullptr), errors_, config_};
     }
 
     configuration const* config_;
-    // Non-owning references to framework-owned resources; graph_proxy<T> is a short-lived builder.
+    // Non-owning references to framework-owned resources; graph_proxy<T, BoundObject> is a
+    // short-lived builder.
     tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     node_catalog& nodes_;     // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::shared_ptr<T> bound_obj_;

--- a/phlex/metaprogramming/delegate.hpp
+++ b/phlex/metaprogramming/delegate.hpp
@@ -7,8 +7,6 @@
 #include <memory>
 
 namespace phlex::experimental {
-  struct void_tag {};
-
   template <typename FT>
   auto delegate(std::shared_ptr<void_tag>, FT f) // Used for lambda closures
   {

--- a/phlex/metaprogramming/type_deduction.hpp
+++ b/phlex/metaprogramming/type_deduction.hpp
@@ -86,6 +86,13 @@ namespace phlex::experimental {
 
   template <typename... Ts>
   class is_tuple<std::tuple<Ts...>> : public std::true_type {};
+
+  // void_tag is a type used to represent the absence of a bound object in template contexts.
+  //
+  // Used as a sentinel type in graph proxy templates to distinguish between
+  // unbound proxies (no bound algorithm object) and bound proxies (with a
+  // bound algorithm object instance).
+  struct void_tag {};
 }
 
 #endif // PHLEX_METAPROGRAMMING_TYPE_DEDUCTION_HPP

--- a/phlex/module.hpp
+++ b/phlex/module.hpp
@@ -6,25 +6,31 @@
 #include "phlex/core/graph_proxy.hpp"
 #include "phlex/detail/plugin_macros.hpp"
 
+#include <utility>
+
 namespace phlex::experimental {
   /// @brief Proxy for registering module algorithm nodes.
   ///
   /// Passed to @c PHLEX_REGISTER_ALGORITHMS plugin entry points. Provides
   /// access to fold, observe, predicate, transform, and unfold registration.
   /// Users never construct this type directly.
-  template <typename T>
-  class module_graph_proxy : graph_proxy<T> {
-    using base = graph_proxy<T>;
+  template <typename T, bool BoundObject = false>
+  class module_graph_proxy : graph_proxy<T, BoundObject> {
+    using base = graph_proxy<T, BoundObject>;
 
   public:
     using base::graph_proxy;
 
-    // FIXME: make sure functions called from make<T>(...) are restricted to the functions below:
-    //        Users can call make<T>(...).fold(...) but not make<T>(...).provide(...)
-    using base::make;
+    template <typename U, typename... Args>
+    module_graph_proxy<U, true> make(Args&&... args)
+      requires(not BoundObject)
+    {
+      return this->template bind_to<module_graph_proxy, U>(std::forward<Args>(args)...);
+    }
 
     using base::fold;
     using base::observe;
+    using base::output;
     using base::predicate;
     using base::transform;
     using base::unfold;

--- a/phlex/module.hpp
+++ b/phlex/module.hpp
@@ -14,16 +14,16 @@ namespace phlex::experimental {
   /// Passed to @c PHLEX_REGISTER_ALGORITHMS plugin entry points. Provides
   /// access to fold, observe, predicate, transform, and unfold registration.
   /// Users never construct this type directly.
-  template <typename T, bool BoundObject = false>
-  class module_graph_proxy : graph_proxy<T, BoundObject> {
-    using base = graph_proxy<T, BoundObject>;
+  template <typename T>
+  class module_graph_proxy : graph_proxy<T> {
+    using base = graph_proxy<T>;
 
   public:
     using base::graph_proxy;
 
     template <typename U, typename... Args>
-    module_graph_proxy<U, true> make(Args&&... args)
-      requires(not BoundObject)
+    module_graph_proxy<U> make(Args&&... args)
+      requires(not is_bound_object<T>)
     {
       return this->template bind_to<module_graph_proxy, U>(std::forward<Args>(args)...);
     }

--- a/phlex/source.hpp
+++ b/phlex/source.hpp
@@ -13,16 +13,16 @@ namespace phlex::experimental {
   ///
   /// Passed to @c PHLEX_REGISTER_PROVIDERS plugin entry points. Only provide
   /// registration is accessible. Users never construct this type directly.
-  template <typename T, bool BoundObject = false>
-  class source_graph_proxy : graph_proxy<T, BoundObject> {
-    using base = graph_proxy<T, BoundObject>;
+  template <typename T>
+  class source_graph_proxy : graph_proxy<T> {
+    using base = graph_proxy<T>;
 
   public:
     using base::graph_proxy;
 
     template <typename U, typename... Args>
-    source_graph_proxy<U, true> make(Args&&... args)
-      requires(not BoundObject)
+    source_graph_proxy<U> make(Args&&... args)
+      requires(not is_bound_object<T>)
     {
       return this->template bind_to<source_graph_proxy, U>(std::forward<Args>(args)...);
     }

--- a/phlex/source.hpp
+++ b/phlex/source.hpp
@@ -6,21 +6,26 @@
 #include "phlex/core/graph_proxy.hpp"
 #include "phlex/detail/plugin_macros.hpp"
 
+#include <utility>
+
 namespace phlex::experimental {
   /// @brief Proxy for registering source (provider) nodes.
   ///
   /// Passed to @c PHLEX_REGISTER_PROVIDERS plugin entry points. Only provide
   /// registration is accessible. Users never construct this type directly.
-  template <typename T>
-  class source_graph_proxy : graph_proxy<T> {
-    using base = graph_proxy<T>;
+  template <typename T, bool BoundObject = false>
+  class source_graph_proxy : graph_proxy<T, BoundObject> {
+    using base = graph_proxy<T, BoundObject>;
 
   public:
     using base::graph_proxy;
 
-    // FIXME: make sure functions called from make<T>(...) are restricted to the functions below:
-    //        Users can call make<T>(...).provide(...) but not make<T>(...).fold(...)
-    using base::make;
+    template <typename U, typename... Args>
+    source_graph_proxy<U, true> make(Args&&... args)
+      requires(not BoundObject)
+    {
+      return this->template bind_to<source_graph_proxy, U>(std::forward<Args>(args)...);
+    }
 
     // Only provide(...) should be accessible
     using base::provide;

--- a/test/plugins/ij_source.cpp
+++ b/test/plugins/ij_source.cpp
@@ -2,9 +2,18 @@
 
 using namespace phlex;
 
+namespace {
+  class signed_value_provider {
+  public:
+    int provide_i(data_cell_index const& id) const { return static_cast<int>(id.number()); }
+  };
+}
+
 PHLEX_REGISTER_PROVIDERS(s)
 {
-  s.provide("provide_i", [](data_cell_index const& id) { return static_cast<int>(id.number()); })
+  // Explicitly test s.make<T> syntax for provider registration, in addition to the lambda syntax.
+  s.make<signed_value_provider>()
+    .provide("provide_i", &signed_value_provider::provide_i)
     .output_product("input", "i", "event");
   s.provide("provide_j", [](data_cell_index const& id) { return -static_cast<int>(id.number()); })
     .output_product("input", "j", "event");


### PR DESCRIPTION
This PR constrains what API is available in the graph-proxy objects used for registering nodes.  The following constructions will now emit compile-time errors:

1. Chained `make<T>` calls (e.g.):
    ```cpp
    g.make<T>(...).make<U>(...);
    ```

2. Creating computational nodes in sources (e.g.):
    ```cpp
    PHLEX_REGISTER_PROVIDERS(s) 
    {
      auto bound_obj = s.make<T>(...);
      bound_obj.provide(...);
      bound_obj.transform(...); // Oops, shouldn't be able to do this
    }

3. Creating provider nodes in modules (e.g.):
    ```cpp
    PHLEX_REGISTER_ALGORITHMS(m) 
    {
      auto bound_obj = m.make<T>(...);
      bound_obj.transform(...);
      bound_obj.provide(...); // Oops, shouldn't be able to do this
    }
    ```