### PR TITLE
FORM Test Technology Loop Part 2

### DIFF
--- a/test/form/CMakeLists.txt
+++ b/test/form/CMakeLists.txt
@@ -9,7 +9,7 @@ if(FORM_USE_ROOT_STORAGE)
   target_include_directories(form_test_utils INTERFACE ${PROJECT_SOURCE_DIR})
 
   list(APPEND FORM_TEST_TECHNOLOGIES "ROOT_TTREE")
-#  if(FORM_USE_RNTUPLE_STORAGE)
+#  if(FORM_USE_RNTUPLE_STORAGE) #Example of what this loop will be used for
 #    list(APPEND FORM_TEST_TECHNOLOGIES "ROOT_RNTUPLE")
 #  endif()
 

--- a/test/form/CMakeLists.txt
+++ b/test/form/CMakeLists.txt
@@ -9,9 +9,9 @@ if(FORM_USE_ROOT_STORAGE)
   target_include_directories(form_test_utils INTERFACE ${PROJECT_SOURCE_DIR})
 
   list(APPEND FORM_TEST_TECHNOLOGIES "ROOT_TTREE")
-#  if(FORM_USE_RNTUPLE_STORAGE) #Example of what this loop will be used for
-#    list(APPEND FORM_TEST_TECHNOLOGIES "ROOT_RNTUPLE")
-#  endif()
+  #if(FORM_USE_RNTUPLE_STORAGE) #Example of what this loop will be used for
+  #  list(APPEND FORM_TEST_TECHNOLOGIES "ROOT_RNTUPLE")
+  #endif()
 
   foreach(TECH IN LISTS FORM_TEST_TECHNOLOGIES)
     cet_test(

--- a/test/form/CMakeLists.txt
+++ b/test/form/CMakeLists.txt
@@ -9,9 +9,9 @@ if(FORM_USE_ROOT_STORAGE)
   target_include_directories(form_test_utils INTERFACE ${PROJECT_SOURCE_DIR})
 
   list(APPEND FORM_TEST_TECHNOLOGIES "ROOT_TTREE")
-  #if(FORM_USE_RNTUPLE_STORAGE) #Example of what this loop will be used for
-  #  list(APPEND FORM_TEST_TECHNOLOGIES "ROOT_RNTUPLE")
-  #endif()
+#  if(FORM_USE_RNTUPLE_STORAGE)
+#    list(APPEND FORM_TEST_TECHNOLOGIES "ROOT_RNTUPLE")
+#  endif()
 
   foreach(TECH IN LISTS FORM_TEST_TECHNOLOGIES)
     cet_test(
@@ -107,6 +107,14 @@ if(FORM_USE_ROOT_STORAGE)
       "form_root_schema_write_test_${TECH}"
       "form_root_schema_read_test_${TECH}"
     )
+
+    cet_test("form_storage_test_${TECH}" USE_CATCH2_MAIN SOURCE form_storage_test.cpp LIBRARIES
+             root_storage
+             storage
+             form_test_utils
+    )
+    target_include_directories("form_storage_test_${TECH}" PRIVATE ${PROJECT_SOURCE_DIR}/form)
+    target_compile_definitions("form_storage_test_${TECH}" PRIVATE FORM_TEST_TECHNOLOGY="${TECH}")
   endforeach()
 endif()
 
@@ -127,10 +135,3 @@ cet_test(form_basics_test USE_CATCH2_MAIN SOURCE form_basics_test.cpp LIBRARIES
          form
 )
 target_include_directories(form_basics_test PRIVATE ${PROJECT_SOURCE_DIR}/form)
-
-cet_test(form_storage_test USE_CATCH2_MAIN SOURCE form_storage_test.cpp LIBRARIES
-         root_storage
-         storage
-         form_test_utils
-)
-target_include_directories(form_storage_test PRIVATE ${PROJECT_SOURCE_DIR}/form)

--- a/test/form/CMakeLists.txt
+++ b/test/form/CMakeLists.txt
@@ -112,9 +112,11 @@ if(FORM_USE_ROOT_STORAGE)
              root_storage
              storage
              form_test_utils
+             TEST_ARGS
+             --technology
+             ${TECH}
     )
     target_include_directories("form_storage_test_${TECH}" PRIVATE ${PROJECT_SOURCE_DIR}/form)
-    target_compile_definitions("form_storage_test_${TECH}" PRIVATE FORM_TEST_TECHNOLOGY="${TECH}")
   endforeach()
 endif()
 

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -12,9 +12,13 @@
 
 using namespace form::detail::experimental;
 
+namespace
+{
+  int const technology = form::test::getTechnology(FORM_TEST_TECHNOLOGY); //Defined in test/form/CMakeLists.txt
+}
+
 TEST_CASE("Storage_Container read wrong type", "[form]")
 {
-  int const technology = form::technology::ROOT_TTREE;
   std::vector<int> primes = {2, 3, 5, 7, 11, 13, 17, 19};
   form::test::write(technology, primes);
 
@@ -28,7 +32,6 @@ TEST_CASE("Storage_Container read wrong type", "[form]")
 
 TEST_CASE("Storage_Container sharing an Association", "[form]")
 {
-  int const technology = form::technology::ROOT_TTREE;
   std::vector<float> piData(10, 3.1415927);
   std::string indexData = "[EVENT=00000001;SEG=00000001]";
 
@@ -43,7 +46,6 @@ TEST_CASE("Storage_Container sharing an Association", "[form]")
 
 TEST_CASE("Storage_Container multiple containers in Association", "[form]")
 {
-  int const technology = form::technology::ROOT_TTREE;
   std::vector<float> piData(10, 3.1415927);
   std::vector<int> magicData(17);
   std::iota(magicData.begin(), magicData.end(), 42);
@@ -63,7 +65,6 @@ TEST_CASE("Storage_Container multiple containers in Association", "[form]")
 
 TEST_CASE("FORM Container setup error handling")
 {
-  int const technology = form::technology::ROOT_TTREE;
   auto file = createFile(technology, "testContainerErrorHandling.root", 'o');
   auto writeContainer = createWriteContainer(technology, "test/testData");
 
@@ -99,7 +100,7 @@ TEST_CASE("FORM Container setup error handling")
 }
 
 template <class T>
-void testFundamental(int const technology, T const expected)
+void testFundamental(T const expected)
 {
   SECTION(form::test::getTypeName<T>())
   {
@@ -120,25 +121,23 @@ void testFundamental(int const technology, T const expected)
 // current ROOT release and is therefore not tested here.
 TEST_CASE("Root branch read: fundamental scalar types round-trip", "[form]")
 {
-  int const technology = form::technology::ROOT_TTREE;
-  testFundamental(technology, static_cast<char>('r'));
-  testFundamental(technology, static_cast<unsigned char>(200));
-  testFundamental(technology, static_cast<short>(-1000));
-  testFundamental(technology, static_cast<unsigned short>(60000));
-  testFundamental(technology, -42000);
-  testFundamental(technology, 3000000000u);
-  testFundamental(technology, -9000000000L);
-  testFundamental(technology, 9000000000UL);
-  testFundamental(technology, -4000000000LL);
-  testFundamental(technology, 8000000000ULL);
-  testFundamental(technology, 3.14f);
-  testFundamental(technology, 2.718281828);
-  testFundamental(technology, true);
+  testFundamental(static_cast<char>('r'));
+  testFundamental(static_cast<unsigned char>(200));
+  testFundamental(static_cast<short>(-1000));
+  testFundamental(static_cast<unsigned short>(60000));
+  testFundamental(-42000);
+  testFundamental(3000000000u);
+  testFundamental(-9000000000L);
+  testFundamental(9000000000UL);
+  testFundamental(-4000000000LL);
+  testFundamental(8000000000ULL);
+  testFundamental(3.14f);
+  testFundamental(2.718281828);
+  testFundamental(true);
 }
 
 TEST_CASE("Root branch read: returns false when id exceeds entry count", "[form]")
 {
-  int const technology = form::technology::ROOT_TTREE;
   std::vector<int> data = {1, 2, 3};
   form::test::write(technology, data);
 
@@ -154,7 +153,6 @@ TEST_CASE("Root branch read: returns false when id exceeds entry count", "[form]
 
 TEST_CASE("Root branch read: throws when the named tree is absent from the file", "[form]")
 {
-  int const technology = form::technology::ROOT_TTREE;
   std::vector<int> data = {42};
   form::test::write(technology, data);
 
@@ -167,7 +165,6 @@ TEST_CASE("Root branch read: throws when the named tree is absent from the file"
 
 TEST_CASE("Root branch read: throws when the named branch is absent from the tree", "[form]")
 {
-  int const technology = form::technology::ROOT_TTREE;
   std::vector<int> data = {42};
   form::test::write(technology, data);
 
@@ -186,7 +183,6 @@ TEST_CASE("Root branch read: throws for a type with no ROOT dictionary", "[form]
   // exercises the "unsupported type" error path in read().
   struct LocalType {};
 
-  int const technology = form::technology::ROOT_TTREE;
   std::vector<int> data = {42};
   form::test::write(technology, data);
 
@@ -200,7 +196,6 @@ TEST_CASE("Root branch read: throws for a type with no ROOT dictionary", "[form]
 
 TEST_CASE("Root TTree write container: fill and commit are not implemented", "[form]")
 {
-  int const technology = form::technology::ROOT_TTREE;
   auto file = createFile(technology, "testTTreeWriteOps.root", 'o');
   auto writeAssoc = createWriteAssociation(technology, "testTTreeWriteOpsTree");
   writeAssoc->setFile(file);

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -5,16 +5,15 @@
 #include "TFile.h"
 #include "TTree.h"
 
-#include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <numeric>
 #include <vector>
 
 using namespace form::detail::experimental;
 
-namespace
-{
+namespace {
   int technology = form::technology::ROOT_TTREE; //Potentially overridden in main
                                                  //Global variable required by limitations of Catch2
 }
@@ -25,14 +24,14 @@ int main(int const argc, char** const argv)
 
   std::string tech_string;
   using namespace Catch::Clara;
-  auto cli = session.cli()
-    | Opt(tech_string, "technology")["--technology"]
-      ("FORM technology backend");
+  auto cli =
+    session.cli() | Opt(tech_string, "technology")["--technology"]("FORM technology backend");
 
   session.cli(cli);
 
   int const returnCode = session.applyCommandLine(argc, argv);
-  if(returnCode != 0) return returnCode;
+  if (returnCode != 0)
+    return returnCode;
 
   technology = form::test::getTechnology(tech_string);
 

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -13,11 +13,10 @@
 
 using namespace form::detail::experimental;
 
-namespace
-{
+namespace {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   int technology = form::technology::ROOT_TTREE; //Potentially overridden in main
-                                                 //Non-const global variable required by limitations of Catch2
+  //Non-const global variable required by limitations of Catch2
 }
 
 int main(int const argc, char** const argv)

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -15,8 +15,9 @@ using namespace form::detail::experimental;
 
 namespace
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   int technology = form::technology::ROOT_TTREE; //Potentially overridden in main
-                                                 //Global variable required by limitations of Catch2
+                                                 //Non-const global variable required by limitations of Catch2
 }
 
 int main(int const argc, char** const argv)

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -12,9 +12,9 @@
 
 using namespace form::detail::experimental;
 
-namespace
-{
-  int const technology = form::test::getTechnology(FORM_TEST_TECHNOLOGY); //Defined in test/form/CMakeLists.txt
+namespace {
+  int const technology =
+    form::test::getTechnology(FORM_TEST_TECHNOLOGY); //Defined in test/form/CMakeLists.txt
 }
 
 TEST_CASE("Storage_Container read wrong type", "[form]")

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -6,6 +6,7 @@
 #include "TTree.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_session.hpp>
 
 #include <numeric>
 #include <vector>
@@ -14,7 +15,28 @@ using namespace form::detail::experimental;
 
 namespace
 {
-  int const technology = form::test::getTechnology(FORM_TEST_TECHNOLOGY); //Defined in test/form/CMakeLists.txt
+  int technology = form::technology::ROOT_TTREE; //Potentially overridden in main
+                                                 //Global variable required by limitations of Catch2
+}
+
+int main(int const argc, char** const argv)
+{
+  Catch::Session session;
+
+  std::string tech_string;
+  using namespace Catch::Clara;
+  auto cli = session.cli()
+    | Opt(tech_string, "technology")["--technology"]
+      ("FORM technology backend");
+
+  session.cli(cli);
+
+  int const returnCode = session.applyCommandLine(argc, argv);
+  if(returnCode != 0) return returnCode;
+
+  technology = form::test::getTechnology(tech_string);
+
+  return session.run();
 }
 
 TEST_CASE("Storage_Container read wrong type", "[form]")


### PR DESCRIPTION
Extends FORM tests to run the basic storage tests for all technologies.  Tested with RNTuple branch in addition to TTree backend on the main branch.  This feature will eventually allow CI to enforce RNTuple testing as we continue to improve FORM.