### PR TITLE
Introduce layer_path class

### DIFF
--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -69,7 +69,7 @@ namespace phlex::experimental {
   std::size_t framework_graph::seen_cell_count(std::string const& layer_name,
                                                bool const missing_ok) const
   {
-    return hierarchy_.count_for(layer_name, missing_ok);
+    return hierarchy_.count_for(experimental::layer_path(layer_name), missing_ok);
   }
 
   std::size_t framework_graph::execution_count(std::string const& node_name) const

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -3,6 +3,7 @@
 #include "phlex/concurrency.hpp"
 #include "phlex/core/make_computational_edges.hpp"
 #include "phlex/model/product_store.hpp"
+#include "phlex/utilities/bulleted_list.hpp"
 
 #include "fmt/format.h"
 #include "fmt/ranges.h"
@@ -136,7 +137,7 @@ namespace phlex::experimental {
       return;
     }
     throw std::runtime_error(
-      fmt::format("\nConfiguration errors:\n  - {}", fmt::join(registration_errors_, "\n  - ")));
+      fmt::format("\nConfiguration errors:\n{}", bulleted_list(registration_errors_)));
   }
 
   void framework_graph::make_filter_edges()

--- a/phlex/core/index_router.cpp
+++ b/phlex/core/index_router.cpp
@@ -1,6 +1,7 @@
 #include "phlex/core/index_router.hpp"
 
 #include "phlex/model/flush_gate.hpp"
+#include "phlex/utilities/bulleted_list.hpp"
 #include "phlex/utilities/hashing.hpp"
 
 #include "fmt/std.h"
@@ -13,34 +14,6 @@
 #include <stdexcept>
 
 using namespace phlex::experimental;
-
-namespace {
-  using layer_path_t = std::vector<std::string>;
-
-  std::size_t layer_hash_for_path(layer_path_t const& layer_path)
-  {
-    std::size_t result = "job"_id.hash();
-    for (auto const& layer_name : layer_path | std::views::drop(1)) {
-      result = hash(result, identifier{layer_name}.hash());
-    }
-    return result;
-  }
-
-  bool is_strict_prefix(layer_path_t const& candidate, layer_path_t const& other)
-  {
-    // FIXME: Use std::ranges::starts_with(other, candidate) once the compilers support it (C++23)
-    return candidate.size() < other.size() and
-           std::ranges::mismatch(other, candidate).in2 == std::ranges::end(candidate);
-  }
-
-  std::string delimited_layer_path(std::string_view const layer_path)
-  {
-    if (not layer_path.starts_with("/")) {
-      return fmt::format("/{}", layer_path);
-    }
-    return std::string{layer_path};
-  }
-}
 
 namespace phlex::experimental {
 
@@ -57,7 +30,7 @@ namespace phlex::experimental {
       void put_message(data_cell_index_ptr const& index, std::size_t message_id);
       void put_end_token(data_cell_index_ptr const& index, flush_gate const& fc);
 
-      bool matches_exactly(std::string const& layer_path) const;
+      bool matches_exactly(layer_path const& layer_path) const;
       bool is_parent_of(data_cell_index_ptr const& index) const;
 
     private:
@@ -93,9 +66,9 @@ namespace phlex::experimental {
       flusher_.try_put({.index = index, .count = static_cast<int>(fc.committed_total_count())});
     }
 
-    bool multilayer_slot::matches_exactly(std::string const& layer_path) const
+    bool multilayer_slot::matches_exactly(layer_path const& layer_path) const
     {
-      return layer_path.ends_with(delimited_layer_path(static_cast<std::string_view>(layer_)));
+      return layer_path.ends_with(layer_);
     }
 
     bool multilayer_slot::is_parent_of(data_cell_index_ptr const& index) const
@@ -131,16 +104,22 @@ namespace phlex::experimental {
     std::vector<identifier> unfold_input_layer_names,
     std::vector<identifier> unfold_output_layer_names)
   {
-    auto sorted_layer_paths = layer_paths_from_driver;
+    auto sorted_layer_paths =
+      layer_paths_from_driver | std::views::transform([](auto const& lp) {
+        auto lp_as_ids = lp |
+                         std::views::transform([](auto const& str) { return identifier(str); }) |
+                         std::ranges::to<std::vector>();
+        return layer_path(std::move(lp_as_ids));
+      }) |
+      std::ranges::to<std::vector<layer_path>>();
     std::ranges::sort(sorted_layer_paths);
 
     // In sorted order, a path can only be a prefix of paths that follow it.
-    for (std::size_t i = 0; i < sorted_layer_paths.size(); ++i) {
+    for (std::size_t i = 0; i + 1 < sorted_layer_paths.size(); ++i) {
       bool const is_not_lowest_layer =
-        i + 1 < sorted_layer_paths.size() and
-        is_strict_prefix(sorted_layer_paths[i], sorted_layer_paths[i + 1]);
+        sorted_layer_paths[i].is_strict_prefix_of(sorted_layer_paths[i + 1]);
       if (is_not_lowest_layer) {
-        auto const layer_hash = layer_hash_for_path(sorted_layer_paths[i]);
+        auto const layer_hash = sorted_layer_paths[i].hash();
         is_lowest_layer_hashes_.emplace(layer_hash, false);
       }
     }
@@ -252,19 +231,17 @@ namespace phlex::experimental {
       return it->second;
     }
 
-    std::string const layerish_path{static_cast<std::string_view>(index->layer_name())};
+    layer_path const layerish_path{{index->layer_name()}};
     auto broadcaster = index_set_node_for(layerish_path);
     index_set_node_cache_.insert({layer_hash, broadcaster});
     return broadcaster;
   }
 
-  auto index_router::index_set_node_for(std::string const& layer_path) -> detail::index_set_node_ptr
+  auto index_router::index_set_node_for(layer_path const& layer_path) -> detail::index_set_node_ptr
   {
-    std::string const search_token = delimited_layer_path(layer_path);
-
     std::vector<decltype(index_set_nodes_.begin())> candidates;
     for (auto it = index_set_nodes_.begin(), e = index_set_nodes_.end(); it != e; ++it) {
-      if (search_token.ends_with(delimited_layer_path(static_cast<std::string_view>(it->first)))) {
+      if (layer_path.ends_with(it->first)) {
         candidates.push_back(it);
       }
     }
@@ -277,10 +254,10 @@ namespace phlex::experimental {
       return nullptr;
     }
 
-    std::string msg = fmt::format("Multiple layers match specification {}:\n", layer_path);
-    for (auto const& it : candidates) {
-      msg += fmt::format("\n- {}", it->first);
-    }
+    std::string msg = fmt::format(
+      "Multiple layers match specification {}:\n{}",
+      layer_path,
+      bulleted_list(candidates | std::views::transform([](auto const& it) { return it->first; })));
     throw std::runtime_error(msg);
   }
 

--- a/phlex/core/index_router.cpp
+++ b/phlex/core/index_router.cpp
@@ -99,19 +99,11 @@ namespace phlex::experimental {
   {
   }
 
-  void index_router::establish_layers(
-    std::vector<std::vector<std::string>> const& layer_paths_from_driver,
-    std::vector<identifier> unfold_input_layer_names,
-    std::vector<identifier> unfold_output_layer_names)
+  void index_router::establish_layers(std::vector<layer_path> const& layer_paths_from_driver,
+                                      std::vector<identifier> unfold_input_layer_names,
+                                      std::vector<identifier> unfold_output_layer_names)
   {
-    auto sorted_layer_paths =
-      layer_paths_from_driver | std::views::transform([](auto const& lp) {
-        auto lp_as_ids = lp |
-                         std::views::transform([](auto const& str) { return identifier(str); }) |
-                         std::ranges::to<std::vector>();
-        return layer_path(std::move(lp_as_ids));
-      }) |
-      std::ranges::to<std::vector<layer_path>>();
+    auto sorted_layer_paths = layer_paths_from_driver;
     std::ranges::sort(sorted_layer_paths);
 
     // In sorted order, a path can only be a prefix of paths that follow it.

--- a/phlex/core/index_router.hpp
+++ b/phlex/core/index_router.hpp
@@ -91,7 +91,7 @@ namespace phlex::experimental {
     // correct for unfold outputs (the only source of unknown hashes) and consistent with
     // index_is_lowest_layer()'s fall-through default.
     bool is_lowest_layer_hash(std::size_t layer_hash) const;
-    detail::index_set_node_ptr index_set_node_for(std::string const& layer);
+    detail::index_set_node_ptr index_set_node_for(layer_path const& layer);
     detail::index_set_node_ptr index_set_node_for(data_cell_index_ptr const& index);
     std::pair<detail::multilayer_slots_ptr, detail::multilayer_slots_ptr> multilayer_slots_for(
       data_cell_index_ptr const& index);

--- a/phlex/core/index_router.hpp
+++ b/phlex/core/index_router.hpp
@@ -56,7 +56,7 @@ namespace phlex::experimental {
     explicit index_router(tbb::flow::graph& g);
     data_cell_index_ptr route(data_cell_index_ptr const& index, index_flushes flushes);
 
-    void establish_layers(std::vector<std::vector<std::string>> const& layer_paths_from_driver,
+    void establish_layers(std::vector<layer_path> const& layer_paths_from_driver,
                           std::vector<identifier> unfold_input_layer_names,
                           std::vector<identifier> unfold_output_layer_names);
 

--- a/phlex/core/input_arguments.hpp
+++ b/phlex/core/input_arguments.hpp
@@ -4,6 +4,7 @@
 #include "phlex/core/message.hpp"
 #include "phlex/core/product_selector.hpp"
 #include "phlex/model/handle.hpp"
+#include "phlex/utilities/bulleted_list.hpp"
 
 #include "fmt/format.h"
 
@@ -32,18 +33,16 @@ namespace phlex::experimental {
         std::ranges::to<std::vector>();
       if (products.empty()) {
         throw std::runtime_error(fmt::format(
-          "No products found matching the query {}\n Store (id {} from {}) contains:\n    - {}",
+          "No products found matching the query {}\n Store (id {} from {}) contains:\n{}",
           query,
           store->index()->to_string(),
           store->source().to_string(),
-          fmt::join(all_products | views::transform(&product_specification::to_string),
-                    "\n    - ")));
+          bulleted_list(all_products, /*indent=*/4)));
       }
       if (products.size() > 1) {
-        throw std::runtime_error(fmt::format(
-          "Multiple products found matching the query {}:\n    - {}",
-          query,
-          fmt::join(products | views::transform(&product_specification::to_string), "\n    - ")));
+        throw std::runtime_error(fmt::format("Multiple products found matching the query {}:\n{}",
+                                             query,
+                                             bulleted_list(products, /*indent=*/4)));
       }
       return store->get_handle<handle_arg_t>(products[0]);
     }

--- a/phlex/core/producer_catalog.cpp
+++ b/phlex/core/producer_catalog.cpp
@@ -1,4 +1,5 @@
 #include "phlex/core/producer_catalog.hpp"
+#include "phlex/utilities/bulleted_list.hpp"
 
 #include "fmt/format.h"
 #include "fmt/ranges.h"
@@ -75,9 +76,9 @@ namespace phlex::experimental {
     }
 
     if (candidates.size() > 1ull) {
-      std::string msg = fmt::format("More than one candidate matches the query {}: \n - {}\n",
+      std::string msg = fmt::format("More than one candidate matches the query {}: \n{}\n",
                                     query.to_string(),
-                                    fmt::join(std::views::keys(candidates), "\n - "));
+                                    bulleted_list(std::views::keys(candidates), /*indent=*/1));
       throw std::runtime_error(msg);
     }
 

--- a/phlex/model/CMakeLists.txt
+++ b/phlex/model/CMakeLists.txt
@@ -11,6 +11,7 @@ cet_make_library(
   data_layer_hierarchy.cpp
   data_cell_index.cpp
   identifier.cpp
+  layer_path.cpp
   product_matcher.cpp
   product_store.cpp
   products.cpp
@@ -39,6 +40,7 @@ install(
     data_layer_hierarchy.hpp
     data_cell_index.hpp
     identifier.hpp
+    layer_path.hpp
     product_matcher.hpp
     product_specification.hpp
     product_store.hpp

--- a/phlex/model/data_cell_index.cpp
+++ b/phlex/model/data_cell_index.cpp
@@ -68,6 +68,7 @@ namespace phlex {
     std::vector<experimental::identifier> layers(depth_ + 1);
     auto const* ptr = this;
     for (auto& layer : std::views::reverse(layers)) {
+      assert(ptr);
       layer = ptr->layer_name();
       ptr = ptr->parent_.get();
     }

--- a/phlex/model/data_cell_index.cpp
+++ b/phlex/model/data_cell_index.cpp
@@ -62,15 +62,16 @@ namespace phlex {
     return layer_name_;
   }
 
-  std::string data_cell_index::layer_path() const
+  experimental::layer_path data_cell_index::layer_path() const
   {
-    std::vector layers_in_reverse{std::string_view(layer_name_)};
-    auto next_parent = parent();
-    while (next_parent) {
-      layers_in_reverse.push_back(std::string_view(next_parent->layer_name()));
-      next_parent = next_parent->parent();
+    // We know how deep we are so we can pre-allocate and fill in reverse
+    std::vector<experimental::identifier> layers(depth_ + 1);
+    auto const* ptr = this;
+    for (auto& layer : std::views::reverse(layers)) {
+      layer = ptr->layer_name();
+      ptr = ptr->parent_.get();
     }
-    return fmt::format("/{}", fmt::join(std::views::reverse(layers_in_reverse), "/"));
+    return experimental::layer_path{std::move(layers)};
   }
 
   std::size_t data_cell_index::depth() const noexcept { return depth_; }

--- a/phlex/model/data_cell_index.cpp
+++ b/phlex/model/data_cell_index.cpp
@@ -1,16 +1,13 @@
 #include "phlex/model/data_cell_index.hpp"
 #include "phlex/utilities/hashing.hpp"
 
-#include "boost/algorithm/string.hpp"
 #include "fmt/format.h"
-#include "fmt/ranges.h"
 
 #include <algorithm>
+#include <cassert>
 #include <iterator>
 #include <map>
-#include <numeric>
 #include <ranges>
-#include <stdexcept>
 #include <string>
 
 using namespace std::string_literals;

--- a/phlex/model/data_cell_index.hpp
+++ b/phlex/model/data_cell_index.hpp
@@ -5,6 +5,7 @@
 
 #include "phlex/model/fwd.hpp"
 #include "phlex/model/identifier.hpp"
+#include "phlex/model/layer_path.hpp"
 
 #include <cstddef>
 #include <initializer_list>
@@ -23,7 +24,7 @@ namespace phlex {
     using hash_type = std::size_t;
     data_cell_index_ptr make_child(std::string layer_name, std::size_t data_cell_number) const;
     experimental::identifier const& layer_name() const noexcept;
-    std::string layer_path() const;
+    experimental::layer_path layer_path() const;
     std::size_t depth() const noexcept;
     data_cell_index_ptr parent(experimental::identifier const& layer_name) const;
     data_cell_index_ptr parent() const noexcept;

--- a/phlex/model/data_layer_hierarchy.cpp
+++ b/phlex/model/data_layer_hierarchy.cpp
@@ -39,7 +39,8 @@ namespace phlex::experimental {
 
   std::size_t data_layer_hierarchy::count_for(layer_path const& layer, bool const missing_ok) const
   {
-    // The assumption is that specified layer is the component of a layer path
+    // The assumption is that specified layer is a portion of a layer path
+    // sufficient to uniquely identify a layer
     std::vector<layer_entry const*> candidates;
     for (auto const& [_, entry] : layers_) {
       if (entry->layer_path.ends_with(layer)) {

--- a/phlex/model/data_layer_hierarchy.cpp
+++ b/phlex/model/data_layer_hierarchy.cpp
@@ -1,6 +1,8 @@
 #include "phlex/model/data_layer_hierarchy.hpp"
 #include "phlex/model/data_cell_index.hpp"
 
+#include "phlex/utilities/bulleted_list.hpp"
+
 #include "fmt/format.h"
 #include "fmt/std.h"
 #include "spdlog/spdlog.h"
@@ -35,32 +37,31 @@ namespace phlex::experimental {
     ++it->second->count;
   }
 
-  std::size_t data_layer_hierarchy::count_for(std::string const& layer, bool const missing_ok) const
+  std::size_t data_layer_hierarchy::count_for(layer_path const& layer, bool const missing_ok) const
   {
     // The assumption is that specified layer is the component of a layer path
-    std::string search_token = layer;
-    if (not layer.starts_with("/")) {
-      search_token = '/' + layer;
-    }
-
     std::vector<layer_entry const*> candidates;
     for (auto const& [_, entry] : layers_) {
-      if (entry->layer_path.ends_with(search_token)) {
+      if (entry->layer_path.ends_with(layer)) {
         candidates.push_back(entry.get());
       }
     }
 
     if (candidates.empty()) {
       return missing_ok ? 0ull
-                        : throw std::runtime_error("No layers match the specification " + layer);
+                        : throw std::runtime_error(
+                            fmt::format("No layers match the specification {}", layer));
     }
 
     if (candidates.size() > 1ull) {
-      std::string msg{"The following data layers match the specification " + layer + ":\n"};
-      for (auto const* entry : candidates) {
-        msg += "\n- " + entry->layer_path;
-      }
-      msg += "\n\nPlease specify the full layer path to disambiguate between them.";
+      std::string msg =
+        fmt::format("The following data layers match the specification {}:\n\n{}"
+                    "\n\nPlease specify the full layer path to disambiguate between them.",
+                    layer,
+                    bulleted_list(candidates | std::views::transform([](auto const* entry) {
+                                    return entry->layer_path;
+                                  }),
+                                  /*indent=*/0));
       throw std::runtime_error(msg);
     }
 

--- a/phlex/model/data_layer_hierarchy.cpp
+++ b/phlex/model/data_layer_hierarchy.cpp
@@ -1,11 +1,11 @@
 #include "phlex/model/data_layer_hierarchy.hpp"
-#include "phlex/model/data_cell_index.hpp"
 
 #include "phlex/utilities/bulleted_list.hpp"
 
 #include "fmt/format.h"
-#include "fmt/std.h"
 #include "spdlog/spdlog.h"
+
+#include <ranges>
 
 namespace {
   std::string const& maybe_name(std::string const& name)

--- a/phlex/model/data_layer_hierarchy.cpp
+++ b/phlex/model/data_layer_hierarchy.cpp
@@ -88,7 +88,7 @@ namespace phlex::experimental {
       auto child_prefix = !at_end ? indent + " ├ " : indent + " └ ";
       auto const& entry = *layers_.at(child_hash);
       result += "\n" + indent + " │ ";
-      result += fmt::format("\n{}{}: {}", child_prefix, maybe_name(child_name), entry.count);
+      result += fmt::format("\n{}{}: {}", child_prefix, maybe_name(child_name), entry.count.load());
 
       auto new_indent = indent;
       new_indent += at_end ? "   " : " │ ";

--- a/phlex/model/data_layer_hierarchy.hpp
+++ b/phlex/model/data_layer_hierarchy.hpp
@@ -5,6 +5,7 @@
 
 #include "phlex/model/data_cell_index.hpp"
 #include "phlex/model/fwd.hpp"
+#include "phlex/model/layer_path.hpp"
 
 #include "oneapi/tbb/concurrent_unordered_map.h"
 
@@ -25,7 +26,7 @@ namespace phlex::experimental {
     data_layer_hierarchy& operator=(data_layer_hierarchy&&) = delete;
 
     void increment_count(data_cell_index_ptr const& id);
-    std::size_t count_for(std::string const& layer, bool missing_ok = false) const;
+    std::size_t count_for(layer_path const& layer, bool missing_ok = false) const;
 
     void print() const;
 
@@ -39,13 +40,13 @@ namespace phlex::experimental {
                                std::string indent = {}) const;
 
     struct layer_entry {
-      layer_entry(identifier n, std::string path, std::size_t par_hash) :
+      layer_entry(identifier n, experimental::layer_path path, std::size_t par_hash) :
         name{std::move(n)}, layer_path{std::move(path)}, parent_hash{par_hash}
       {
       }
 
       identifier name;
-      std::string layer_path;
+      experimental::layer_path layer_path;
       std::size_t parent_hash;
       std::atomic<std::size_t> count{};
     };

--- a/phlex/model/data_layer_hierarchy.hpp
+++ b/phlex/model/data_layer_hierarchy.hpp
@@ -40,7 +40,7 @@ namespace phlex::experimental {
                                std::string indent = {}) const;
 
     struct layer_entry {
-      layer_entry(identifier n, experimental::layer_path path, std::size_t par_hash) :
+      layer_entry(identifier n, layer_path path, std::size_t par_hash) :
         name{std::move(n)}, layer_path{std::move(path)}, parent_hash{par_hash}
       {
       }

--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -75,7 +75,7 @@ namespace phlex {
     return data_cell_cursor{child, hierarchy_, driver_};
   }
 
-  std::string data_cell_cursor::layer_path() const { return index_->layer_path(); }
+  experimental::layer_path data_cell_cursor::layer_path() const { return index_->layer_path(); }
 
   // ================================================================================
   // data_cell_yielder implementation

--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -34,7 +34,7 @@ namespace {
     using namespace phlex::experimental::literals;
     std::set<std::size_t> hashes{"job"_idq.hash};
     for (layer_path const& path : layer_paths) {
-      // "job" was added explicityl so it doesn't matter whether it does or does not appear in path.hashes()
+      // "job" was added explicitly so it doesn't matter whether it does or does not appear in path.hashes()
       hashes.merge(path.hashes());
     }
     return hashes;

--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -34,6 +34,7 @@ namespace {
     using namespace phlex::experimental::literals;
     std::set<std::size_t> hashes{"job"_idq.hash};
     for (layer_path const& path : layer_paths) {
+      // "job" was added explicityl so it doesn't matter whether it does or does not appear in path.hashes()
       hashes.merge(path.hashes());
     }
     return hashes;

--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -14,19 +14,6 @@
 #include <stdexcept>
 
 namespace {
-  // Each path must be non-empty and may only contain "job" as the first element.
-  std::span<std::string const> validated_path(std::vector<std::string> const& path)
-  {
-    if (path.empty()) {
-      throw std::runtime_error("Layer paths cannot be empty.");
-    }
-    auto const rest = std::span{path}.subspan(path[0] == "job" ? 1 : 0);
-    if (std::ranges::contains(rest, "job")) {
-      throw std::runtime_error("Layer paths may only contain 'job' as the first element.");
-    }
-    return rest;
-  }
-
   // Builds the set of cumulative layer hashes that define the fixed hierarchy.
   // For example, if the layer paths are ["job", "run", "subrun"] and ["job", "spill"],
   // the hashes included will correspond to:
@@ -40,19 +27,29 @@ namespace {
   //   - "job/spill"
   //
   // Each path must be non-empty and may only contain "job" as the first element.
-  std::set<std::size_t> build_hashes(std::vector<std::vector<std::string>> const& layer_paths)
+  std::set<std::size_t> build_hashes(
+    std::vector<phlex::experimental::layer_path> const& layer_paths)
   {
     using namespace phlex::experimental;
-    identifier const job{"job"};
-    std::set<std::size_t> hashes{job.hash()};
-    for (std::vector<std::string> const& path : layer_paths) {
-      std::size_t cumulative_hash = job.hash();
-      for (auto const& name : validated_path(path)) {
-        cumulative_hash = hash(cumulative_hash, identifier{name}.hash());
-        hashes.insert(cumulative_hash);
-      }
+    using namespace phlex::experimental::literals;
+    std::set<std::size_t> hashes{"job"_idq.hash};
+    for (layer_path const& path : layer_paths) {
+      hashes.merge(path.hashes());
     }
     return hashes;
+  }
+
+  std::vector<phlex::experimental::layer_path> convert_vector_vector_string(
+    std::vector<std::vector<std::string>>&& layer_paths)
+  {
+    using namespace phlex::experimental;
+    return std::move(layer_paths) | std::views::transform([](std::vector<std::string>& lp) {
+             auto lp_as_ids =
+               lp | std::views::transform([](auto& str) { return identifier(std::move(str)); }) |
+               std::ranges::to<std::vector>();
+             return layer_path(std::move(lp_as_ids));
+           }) |
+           std::ranges::to<std::vector<layer_path>>();
   }
 }
 
@@ -99,7 +96,8 @@ namespace phlex {
   }
 
   fixed_hierarchy::fixed_hierarchy(std::vector<std::vector<std::string>> layer_paths) :
-    layer_paths_(std::move(layer_paths)), layer_hashes_(std::from_range, build_hashes(layer_paths_))
+    layer_paths_(convert_vector_vector_string(std::move(layer_paths))),
+    layer_hashes_(std::from_range, build_hashes(layer_paths_))
   {
   }
 

--- a/phlex/model/fixed_hierarchy.hpp
+++ b/phlex/model/fixed_hierarchy.hpp
@@ -4,6 +4,7 @@
 #include "phlex/phlex_model_export.hpp"
 
 #include "phlex/model/fwd.hpp"
+#include "phlex/model/layer_path.hpp"
 
 #include <cstddef>
 #include <initializer_list>
@@ -25,7 +26,7 @@ namespace phlex {
     // data-cell index to the underlying driver, returning a data_cell_cursor for the child.
     data_cell_cursor yield_child(std::string const& layer_name, std::size_t number) const;
 
-    std::string layer_path() const;
+    experimental::layer_path layer_path() const;
 
   private:
     friend class fixed_hierarchy;

--- a/phlex/model/fixed_hierarchy.hpp
+++ b/phlex/model/fixed_hierarchy.hpp
@@ -88,7 +88,7 @@ namespace phlex {
     data_cell_yielder yielder(experimental::framework_driver& d) const;
 
   private:
-    std::vector<std::vector<std::string>> layer_paths_;
+    std::vector<experimental::layer_path> layer_paths_;
     std::vector<std::size_t> layer_hashes_;
   };
 

--- a/phlex/model/handle.hpp
+++ b/phlex/model/handle.hpp
@@ -95,7 +95,7 @@ namespace phlex {
     }
     std::string_view suffix() const noexcept { return std::string_view(suffix_); }
     std::string_view layer() const noexcept { return std::string_view(id_->layer_name()); }
-    std::string layer_path() const { return id_->layer_path(); }
+    std::string layer_path() const { return id_->layer_path().to_string(); }
 
     template <typename U>
     friend class handle;

--- a/phlex/model/identifier.cpp
+++ b/phlex/model/identifier.cpp
@@ -4,20 +4,6 @@
 #include <boost/hash2/xxhash.hpp>
 
 namespace phlex::experimental {
-  identifier_query literals::operator""_idq(char const* lit, std::size_t len)
-  {
-    return {identifier::hash_string(std::string_view(lit, len))};
-  }
-
-  std::uint64_t identifier::hash_string(std::string_view str)
-  {
-    // Hash quality is very important here, since comparisons are done using only the hash
-    using namespace boost::hash2;
-    xxhash_64 h;
-    hash_append(h, {}, str);
-    return h.result();
-  }
-
   identifier::identifier(std::string_view str) : content_(str), hash_(hash_string(content_)) {}
   identifier::identifier(std::string&& str) : content_(std::move(str)), hash_(hash_string(content_))
   {
@@ -50,4 +36,6 @@ namespace phlex::experimental {
   {
     return identifier{std::string_view(lit, len)};
   }
+
+  bool identifier_query::operator()(identifier const& id) const noexcept { return id == (*this); }
 }

--- a/phlex/model/identifier.hpp
+++ b/phlex/model/identifier.hpp
@@ -79,6 +79,7 @@ namespace phlex::experimental {
 
   // Really trying to avoid the extra function call here
   inline std::string_view format_as(identifier const& id) { return std::string_view(id); }
+  inline std::size_t hash_value(identifier const& id) { return id.hash(); }
 }
 
 template <>

--- a/phlex/model/identifier.hpp
+++ b/phlex/model/identifier.hpp
@@ -3,6 +3,8 @@
 
 #include "phlex/phlex_model_export.hpp"
 
+#include <boost/hash2/hash_append.hpp>
+#include <boost/hash2/xxhash.hpp>
 #include <boost/json/fwd.hpp>
 
 #include <fmt/format.h>
@@ -16,15 +18,25 @@
 namespace phlex::experimental {
   /// If you're comparing to an identifier you know at compile time, you're probably not going to need
   /// to print it.
-  struct identifier_query {
+  class identifier;
+  struct PHLEX_MODEL_EXPORT identifier_query {
     std::uint64_t hash;
+    // This means an identifier_query can be used as a callable to check if it compares equal to an identifier
+    bool operator()(identifier const& id) const noexcept;
   };
 
   /// Carries around the string itself (as a shared_ptr to string to make copies lighter)
   /// along with a precomputed hash used for all comparisons
   class PHLEX_MODEL_EXPORT identifier {
   public:
-    static std::uint64_t hash_string(std::string_view str);
+    static constexpr std::uint64_t hash_string(std::string_view str)
+    {
+      // Hash quality is very important here, since comparisons are done using only the hash
+      using namespace boost::hash2;
+      xxhash_64 h;
+      hash_append(h, {}, str);
+      return h.result();
+    }
     // The default constructor is necessary so other classes containing identifiers
     // can have default constructors.
     identifier() = default;
@@ -74,7 +86,11 @@ namespace phlex::experimental {
   // Identifier UDL
   namespace literals {
     PHLEX_MODEL_EXPORT identifier operator""_id(char const* lit, std::size_t len);
-    PHLEX_MODEL_EXPORT identifier_query operator""_idq(char const* lit, std::size_t len);
+    consteval PHLEX_MODEL_EXPORT identifier_query operator""_idq(char const* lit, std::size_t len)
+    {
+      return {identifier::hash_string(std::string_view(lit, len))};
+    }
+
   }
 
   // Really trying to avoid the extra function call here

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -37,8 +37,9 @@ namespace phlex::experimental {
       throw std::runtime_error("Layer paths cannot be empty.");
     }
 
+    // We can use any_of because identifier_query has a function call operator
     if (layer_path_.size() > 1 &&
-        std::ranges::contains(std::span{layer_path_}.subspan(1), "job"_id)) {
+        std::ranges::any_of(std::span{layer_path_}.subspan(1), "job"_idq)) {
       throw std::runtime_error("Layer paths may only contain 'job' as the first element.");
     }
   }

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -37,6 +37,10 @@ namespace phlex::experimental {
   {
     return std::ranges::ends_with(layer_path_, other.layer_path_);
   }
+  bool layer_path::ends_with(identifier const& name) const noexcept
+  {
+    return not empty() and layer_path_.back() == name;
+  }
 
   std::string layer_path::to_string() const
   {

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -1,5 +1,7 @@
 #include "layer_path.hpp"
 
+#include "phlex/utilities/hashing.hpp"
+
 #include "boost/container_hash/hash.hpp"
 #include "fmt/format.h"
 #include "fmt/ranges.h"
@@ -7,7 +9,6 @@
 #include <algorithm>
 #include <ranges>
 
-using namespace std::literals;
 using namespace phlex::experimental::literals;
 
 namespace phlex::experimental {
@@ -22,14 +23,23 @@ namespace phlex::experimental {
       throw std::runtime_error(
         fmt::format("A complete layer path must start with '/job'. '{}' does not!", path));
     }
+
+    validate();
   }
 
-  bool layer_path::is_empty() const noexcept { return layer_path_.empty(); }
-
-  bool layer_path::is_complete() const noexcept
+  void layer_path::validate() const
   {
-    return not is_empty() and layer_path_[0] == "job"_idq;
+    using namespace literals;
+    if (layer_path_.empty()) {
+      throw std::runtime_error("Layer paths cannot be empty.");
+    }
+
+    if (layer_path_.size() > 1 &&
+        std::ranges::contains(std::span{layer_path_}.subspan(1), "job"_id)) {
+      throw std::runtime_error("Layer paths may only contain 'job' as the first element.");
+    }
   }
+  bool layer_path::is_complete() const noexcept { return layer_path_[0] == "job"_idq; }
 
   bool layer_path::is_strict_prefix_of(layer_path const& other) const noexcept
   {
@@ -52,25 +62,38 @@ namespace phlex::experimental {
     auto const& [it, other_it] = std::ranges::mismatch(rev_layer_path, rev_other_layer_path);
     return other_it == rev_other_layer_path.end();
   }
+
   bool layer_path::ends_with(identifier const& name) const noexcept
   {
-    return not is_empty() and layer_path_.back() == name;
+    return layer_path_.back() == name;
   }
 
   std::string layer_path::to_string() const
   {
     return fmt::format("{}{}", is_complete() ? "/" : "", fmt::join(layer_path_, "/"));
   }
+
   std::size_t layer_path::hash() const noexcept
   {
-    if (is_empty()) {
-      return 0;
-    }
-    if (layer_path_.size() == 1) {
-      return layer_path_[0].hash();
-    }
-    std::size_t seed = layer_path_[0].hash();
+    // incomplete paths have an implied "job" root in this calculation
+    // Need the experimental:: so it isn't confused for this function
+    std::size_t seed =
+      is_complete() ? "job"_idq.hash : experimental::hash("job"_idq.hash, layer_path_[0].hash());
     boost::hash_range(seed, layer_path_.begin() + 1, layer_path_.end());
     return seed;
+  }
+
+  std::set<std::size_t> layer_path::hashes() const
+  {
+    std::set<std::size_t> hashes;
+    // Add the appropriate first hash
+    std::size_t cumulative_hash =
+      is_complete() ? "job"_idq.hash : experimental::hash("job"_idq.hash, layer_path_[0].hash());
+    hashes.insert(cumulative_hash);
+    for (auto const& name : layer_path_ | std::views::drop(1)) {
+      cumulative_hash = experimental::hash(cumulative_hash, name.hash());
+      hashes.insert(cumulative_hash);
+    }
+    return hashes;
   }
 }

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -19,6 +19,9 @@ namespace phlex::experimental {
         std::views::filter([](auto const& sr) { return not sr.empty(); }) |
         std::views::transform([](auto const& sr) { return identifier(std::string_view(sr)); })}
   {
+    if (layer_path_.empty()) {
+      throw std::runtime_error("Layer paths cannot be empty.");
+    }
     if (path.starts_with("/") and not is_complete()) {
       throw std::runtime_error(
         fmt::format("A complete layer path must start with '/job'. '{}' does not!", path));

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -1,0 +1,44 @@
+#include "layer_path.hpp"
+
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+
+#include <algorithm>
+#include <ranges>
+
+using namespace std::literals;
+using namespace phlex::experimental::literals;
+
+namespace phlex::experimental {
+  layer_path::layer_path(std::string_view path) :
+    layer_path_{
+      std::from_range,
+      path | std::views::split('/') |
+        std::views::filter([](auto const& sr) { return not sr.empty(); }) |
+        std::views::transform([](auto const& sr) { return identifier(std::string_view(sr)); })}
+  {
+    if (path.starts_with("/") and not path.starts_with("/job")) {
+      throw std::runtime_error(
+        fmt::format("A complete layer path must start with '/job'. '{}' does not!", path));
+    }
+  }
+
+  bool layer_path::empty() const noexcept { return layer_path_.empty(); }
+
+  bool layer_path::complete() const noexcept { return not empty() and layer_path_[0] == "job"_idq; }
+
+  bool layer_path::is_strict_prefix_of(layer_path const& other) const noexcept
+  {
+    return std::ranges::starts_with(other.layer_path_, layer_path_);
+  }
+
+  bool layer_path::ends_with(layer_path const& other) const noexcept
+  {
+    return std::ranges::ends_with(layer_path_, other.layer_path_);
+  }
+
+  std::string layer_path::to_string() const
+  {
+    return fmt::format("{}{}", complete() ? "/" : "", fmt::join(layer_path_, "/"));
+  }
+}

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -30,12 +30,20 @@ namespace phlex::experimental {
 
   bool layer_path::is_strict_prefix_of(layer_path const& other) const noexcept
   {
-    return std::ranges::starts_with(other.layer_path_, layer_path_);
+    // starts_with / ends_with aren't supported until libstdc++ *16*
+    // return std::ranges::starts_with(other.layer_path_, layer_path_);
+    auto const& [it, other_it] = std::ranges::mismatch(layer_path_, other.layer_path_);
+    return it == layer_path_.end();
   }
 
   bool layer_path::ends_with(layer_path const& other) const noexcept
   {
-    return std::ranges::ends_with(layer_path_, other.layer_path_);
+    // starts_with / ends_with aren't supported until libstdc++ *16*
+    // return std::ranges::ends_with(layer_path_, other.layer_path_);
+    auto rev_layer_path = std::views::reverse(layer_path_);
+    auto rev_other_layer_path = std::views::reverse(other.layer_path_);
+    auto const& [it, other_it] = std::ranges::mismatch(rev_layer_path, rev_other_layer_path);
+    return other_it == rev_other_layer_path.end();
   }
   bool layer_path::ends_with(identifier const& name) const noexcept
   {

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -1,5 +1,6 @@
 #include "layer_path.hpp"
 
+#include "boost/container_hash/hash.hpp"
 #include "fmt/format.h"
 #include "fmt/ranges.h"
 
@@ -40,5 +41,17 @@ namespace phlex::experimental {
   std::string layer_path::to_string() const
   {
     return fmt::format("{}{}", complete() ? "/" : "", fmt::join(layer_path_, "/"));
+  }
+  std::size_t layer_path::hash() const noexcept
+  {
+    if (empty()) {
+      return 0;
+    }
+    if (layer_path_.size() == 1) {
+      return layer_path_[0].hash();
+    }
+    std::size_t seed = layer_path_[0].hash();
+    boost::hash_range(seed, layer_path_.begin() + 1, layer_path_.end());
+    return seed;
   }
 }

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -18,7 +18,7 @@ namespace phlex::experimental {
         std::views::filter([](auto const& sr) { return not sr.empty(); }) |
         std::views::transform([](auto const& sr) { return identifier(std::string_view(sr)); })}
   {
-    if (path.starts_with("/") and not path.starts_with("/job")) {
+    if (path.starts_with("/") and not complete()) {
       throw std::runtime_error(
         fmt::format("A complete layer path must start with '/job'. '{}' does not!", path));
     }
@@ -30,6 +30,10 @@ namespace phlex::experimental {
 
   bool layer_path::is_strict_prefix_of(layer_path const& other) const noexcept
   {
+    if (layer_path_.size() >= other.layer_path_.size()) {
+      // Optimization, and address Codex observation that a path is not a _strict_ prefix of itself
+      return false;
+    }
     // starts_with / ends_with aren't supported until libstdc++ *16*
     // return std::ranges::starts_with(other.layer_path_, layer_path_);
     auto const& [it, other_it] = std::ranges::mismatch(layer_path_, other.layer_path_);

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -18,15 +18,18 @@ namespace phlex::experimental {
         std::views::filter([](auto const& sr) { return not sr.empty(); }) |
         std::views::transform([](auto const& sr) { return identifier(std::string_view(sr)); })}
   {
-    if (path.starts_with("/") and not complete()) {
+    if (path.starts_with("/") and not is_complete()) {
       throw std::runtime_error(
         fmt::format("A complete layer path must start with '/job'. '{}' does not!", path));
     }
   }
 
-  bool layer_path::empty() const noexcept { return layer_path_.empty(); }
+  bool layer_path::is_empty() const noexcept { return layer_path_.empty(); }
 
-  bool layer_path::complete() const noexcept { return not empty() and layer_path_[0] == "job"_idq; }
+  bool layer_path::is_complete() const noexcept
+  {
+    return not is_empty() and layer_path_[0] == "job"_idq;
+  }
 
   bool layer_path::is_strict_prefix_of(layer_path const& other) const noexcept
   {
@@ -51,16 +54,16 @@ namespace phlex::experimental {
   }
   bool layer_path::ends_with(identifier const& name) const noexcept
   {
-    return not empty() and layer_path_.back() == name;
+    return not is_empty() and layer_path_.back() == name;
   }
 
   std::string layer_path::to_string() const
   {
-    return fmt::format("{}{}", complete() ? "/" : "", fmt::join(layer_path_, "/"));
+    return fmt::format("{}{}", is_complete() ? "/" : "", fmt::join(layer_path_, "/"));
   }
   std::size_t layer_path::hash() const noexcept
   {
-    if (empty()) {
+    if (is_empty()) {
       return 0;
     }
     if (layer_path_.size() == 1) {

--- a/phlex/model/layer_path.hpp
+++ b/phlex/model/layer_path.hpp
@@ -31,11 +31,15 @@ namespace phlex::experimental {
     /// Convert to string
     std::string to_string() const;
 
+    /// Hash
+    std::size_t hash() const noexcept;
+
   private:
     std::vector<identifier> layer_path_;
   };
 
   inline std::string format_as(layer_path const& lp) { return lp.to_string(); }
+  inline std::size_t hash_value(layer_path const& lp) { return lp.hash(); }
 }
 
 #endif // PHLEX_MODEL_LAYER_PATH_HPP

--- a/phlex/model/layer_path.hpp
+++ b/phlex/model/layer_path.hpp
@@ -11,7 +11,6 @@
 namespace phlex::experimental {
   class PHLEX_MODEL_EXPORT layer_path {
   public:
-    layer_path() = default;
     layer_path(std::vector<identifier> const& path) : layer_path_{path} {}
     layer_path(std::vector<identifier>&& path) : layer_path_{std::move(path)} {}
     layer_path(std::string_view path);
@@ -24,24 +23,19 @@ namespace phlex::experimental {
 
     auto operator<=>(layer_path const&) const noexcept = default;
 
-    bool empty() const noexcept;
+    bool is_empty() const noexcept;
 
     /// Is this path complete (does it start with "job")
-    bool complete() const noexcept;
+    bool is_complete() const noexcept;
 
-    /// Is this path a strict prefix of other
     bool is_strict_prefix_of(layer_path const& other) const noexcept;
 
-    /// Does this path end with other
     bool ends_with(layer_path const& other) const noexcept;
 
-    /// Does this path identify a layer called name
     bool ends_with(identifier const& name) const noexcept;
 
-    /// Convert to string
     std::string to_string() const;
 
-    /// Hash
     std::size_t hash() const noexcept;
 
   private:

--- a/phlex/model/layer_path.hpp
+++ b/phlex/model/layer_path.hpp
@@ -1,0 +1,41 @@
+#ifndef PHLEX_MODEL_LAYER_PATH_HPP
+#define PHLEX_MODEL_LAYER_PATH_HPP
+#include "phlex/model/identifier.hpp"
+#include "phlex/phlex_model_export.hpp"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace phlex::experimental {
+  class PHLEX_MODEL_EXPORT layer_path {
+  public:
+    layer_path() = default;
+    layer_path(std::vector<identifier> const& path) : layer_path_{path} {}
+    layer_path(std::vector<identifier>&& path) : layer_path_{std::move(path)} {}
+    layer_path(std::string_view path);
+
+    auto operator<=>(layer_path const&) const noexcept = default;
+
+    bool empty() const noexcept;
+
+    /// Is this path complete (does it start with "job")
+    bool complete() const noexcept;
+
+    /// Is this path a strict prefix of other
+    bool is_strict_prefix_of(layer_path const& other) const noexcept;
+
+    /// Does this path end with other
+    bool ends_with(layer_path const& other) const noexcept;
+
+    /// Convert to string
+    std::string to_string() const;
+
+  private:
+    std::vector<identifier> layer_path_;
+  };
+
+  inline std::string format_as(layer_path const& lp) { return lp.to_string(); }
+}
+
+#endif // PHLEX_MODEL_LAYER_PATH_HPP

--- a/phlex/model/layer_path.hpp
+++ b/phlex/model/layer_path.hpp
@@ -3,6 +3,7 @@
 #include "phlex/model/identifier.hpp"
 #include "phlex/phlex_model_export.hpp"
 
+#include <ostream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -14,6 +15,12 @@ namespace phlex::experimental {
     layer_path(std::vector<identifier> const& path) : layer_path_{path} {}
     layer_path(std::vector<identifier>&& path) : layer_path_{std::move(path)} {}
     layer_path(std::string_view path);
+
+    template <typename T>
+      requires std::constructible_from<std::string_view, T> && (!std::same_as<std::string_view, T>)
+    layer_path(T const& path) : layer_path(std::string_view(path))
+    {
+    }
 
     auto operator<=>(layer_path const&) const noexcept = default;
 
@@ -28,6 +35,9 @@ namespace phlex::experimental {
     /// Does this path end with other
     bool ends_with(layer_path const& other) const noexcept;
 
+    /// Does this path identify a layer called name
+    bool ends_with(identifier const& name) const noexcept;
+
     /// Convert to string
     std::string to_string() const;
 
@@ -40,6 +50,12 @@ namespace phlex::experimental {
 
   inline std::string format_as(layer_path const& lp) { return lp.to_string(); }
   inline std::size_t hash_value(layer_path const& lp) { return lp.hash(); }
+
+  // Required by catch2
+  inline std::ostream& operator<<(std::ostream& os, layer_path const& lp)
+  {
+    return os << lp.to_string();
+  }
 }
 
 #endif // PHLEX_MODEL_LAYER_PATH_HPP

--- a/phlex/model/layer_path.hpp
+++ b/phlex/model/layer_path.hpp
@@ -4,6 +4,7 @@
 #include "phlex/phlex_model_export.hpp"
 
 #include <ostream>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -11,8 +12,8 @@
 namespace phlex::experimental {
   class PHLEX_MODEL_EXPORT layer_path {
   public:
-    layer_path(std::vector<identifier> const& path) : layer_path_{path} {}
-    layer_path(std::vector<identifier>&& path) : layer_path_{std::move(path)} {}
+    layer_path(std::vector<identifier> const& path) : layer_path_{path} { validate(); }
+    layer_path(std::vector<identifier>&& path) : layer_path_{std::move(path)} { validate(); }
     layer_path(std::string_view path);
 
     template <typename T>
@@ -22,8 +23,6 @@ namespace phlex::experimental {
     }
 
     auto operator<=>(layer_path const&) const noexcept = default;
-
-    bool is_empty() const noexcept;
 
     /// Is this path complete (does it start with "job")
     bool is_complete() const noexcept;
@@ -36,10 +35,15 @@ namespace phlex::experimental {
 
     std::string to_string() const;
 
+    /// This function assumes incomplete paths have an implicit job root
     std::size_t hash() const noexcept;
+
+    /// Return hash of this path and every parent path
+    std::set<std::size_t> hashes() const;
 
   private:
     std::vector<identifier> layer_path_;
+    void validate() const;
   };
 
   inline std::string format_as(layer_path const& lp) { return lp.to_string(); }
@@ -51,5 +55,4 @@ namespace phlex::experimental {
     return os << lp.to_string();
   }
 }
-
 #endif // PHLEX_MODEL_LAYER_PATH_HPP

--- a/phlex/model/layer_path.hpp
+++ b/phlex/model/layer_path.hpp
@@ -3,10 +3,13 @@
 #include "phlex/model/identifier.hpp"
 #include "phlex/phlex_model_export.hpp"
 
+#include <compare>
+#include <concepts>
 #include <ostream>
 #include <set>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace phlex::experimental {

--- a/phlex/utilities/CMakeLists.txt
+++ b/phlex/utilities/CMakeLists.txt
@@ -16,6 +16,7 @@ install(
   FILES
     resumable_driver.hpp
     hashing.hpp
+    bulleted_list.hpp
     max_allowed_parallelism.hpp
     resource_usage.hpp
     simple_ptr_map.hpp

--- a/phlex/utilities/bulleted_list.hpp
+++ b/phlex/utilities/bulleted_list.hpp
@@ -16,7 +16,6 @@ namespace phlex::experimental {
 
     template <typename R>
     concept range_of_to_stringable = requires(std::ranges::range_value_t<R> const& val) {
-      !range_of_formattable<R>;
       { val.to_string() } -> std::same_as<std::string>;
     };
   }
@@ -31,6 +30,7 @@ namespace phlex::experimental {
   }
 
   template <detail::range_of_to_stringable R>
+    requires(!detail::range_of_formattable<R>)
   std::string bulleted_list(R const& rng, std::size_t indent = 2)
   {
     std::string prefix =

--- a/phlex/utilities/bulleted_list.hpp
+++ b/phlex/utilities/bulleted_list.hpp
@@ -21,6 +21,9 @@ namespace phlex::experimental {
   template <detail::range_of_formattable R>
   std::string bulleted_list(R const& rng, std::size_t indent = 2)
   {
+    if (std::ranges::empty(rng)) {
+      return "";
+    }
     std::string prefix =
       fmt::format("{blank:{indent}s}- ", fmt::arg("blank", ""), fmt::arg("indent", indent));
     std::string prefix_with_newline = fmt::format("\n{}", prefix);
@@ -31,6 +34,9 @@ namespace phlex::experimental {
     requires(!detail::range_of_formattable<R>)
   std::string bulleted_list(R const& rng, std::size_t indent = 2)
   {
+    if (std::ranges::empty(rng)) {
+      return "";
+    }
     std::string prefix =
       fmt::format("{blank:{indent}s}- ", fmt::arg("blank", ""), fmt::arg("indent", indent));
     std::string prefix_with_newline = fmt::format("\n{}", prefix);

--- a/phlex/utilities/bulleted_list.hpp
+++ b/phlex/utilities/bulleted_list.hpp
@@ -10,9 +10,7 @@
 namespace phlex::experimental {
   namespace detail {
     template <typename R>
-    concept range_of_formattable = requires(std::ranges::range_value_t<R> const& val) {
-      { fmt::format("{}", val) } -> std::same_as<std::string>;
-    };
+    concept range_of_formattable = fmt::formattable<std::ranges::range_value_t<R>>;
 
     template <typename R>
     concept range_of_to_stringable = requires(std::ranges::range_value_t<R> const& val) {

--- a/phlex/utilities/bulleted_list.hpp
+++ b/phlex/utilities/bulleted_list.hpp
@@ -1,0 +1,47 @@
+#ifndef PHLEX_UTILITIES_BULLETED_LIST_HPP
+#define PHLEX_UTILITIES_BULLETED_LIST_HPP
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <ranges>
+#include <string>
+
+namespace phlex::experimental {
+  namespace detail {
+    template <typename R>
+    concept range_of_formattable = requires(std::ranges::range_value_t<R> const& val) {
+      { fmt::format("{}", val) } -> std::same_as<std::string>;
+    };
+
+    template <typename R>
+    concept range_of_to_stringable = requires(std::ranges::range_value_t<R> const& val) {
+      !range_of_formattable<R>;
+      { val.to_string() } -> std::same_as<std::string>;
+    };
+  }
+
+  template <detail::range_of_formattable R>
+  std::string bulleted_list(R const& rng, std::size_t indent = 2)
+  {
+    std::string prefix =
+      fmt::format("{blank:{indent}s}- ", fmt::arg("blank", ""), fmt::arg("indent", indent));
+    std::string prefix_with_newline = fmt::format("\n{}", prefix);
+    return fmt::format("{}{}", prefix, fmt::join(rng, prefix_with_newline));
+  }
+
+  template <detail::range_of_to_stringable R>
+  std::string bulleted_list(R const& rng, std::size_t indent = 2)
+  {
+    std::string prefix =
+      fmt::format("{blank:{indent}s}- ", fmt::arg("blank", ""), fmt::arg("indent", indent));
+    std::string prefix_with_newline = fmt::format("\n{}", prefix);
+    return fmt::format(
+      "{}{}",
+      prefix,
+      fmt::join(rng | std::views::transform([](auto&& v) { return v.to_string(); }),
+                prefix_with_newline));
+  }
+}
+
+#endif // PHLEX_UTILITIES_BULLETED_LIST_HPP

--- a/plugins/layer_generator.cpp
+++ b/plugins/layer_generator.cpp
@@ -133,11 +133,13 @@ namespace phlex::experimental {
 
   index_generator layer_generator::execute(data_cell_index_ptr const cell)
   {
-    auto it = parent_to_children_.find(cell->layer_path());
+    // Used in drivers which are close to public API --> easier to stick to strings
+    auto cell_lp = cell->layer_path().to_string();
+    auto it = parent_to_children_.find(cell_lp);
     assert(it != parent_to_children_.cend());
 
     for (auto const& child : it->second) {
-      auto const full_child_path = cell->layer_path() + "/" + child;
+      auto const full_child_path = fmt::format("{}/{}", cell_lp, child);
       auto const& [_, total_per_parent, starting_value] = layers_.at(full_child_path);
       bool const has_children = parent_to_children_.contains(full_child_path);
       for (unsigned int i : std::views::iota(starting_value, total_per_parent + starting_value)) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ cet_test(type_deduction SOURCE type_deduction.cpp LIBRARIES
          phlex::metaprogramming
 )
 cet_test(type_id USE_CATCH2_MAIN SOURCE type_id.cpp LIBRARIES phlex::model_internal fmt::fmt)
+cet_test(layer_path USE_CATCH2_MAIN SOURCE layer_path.cpp LIBRARIES phlex::model_internal fmt::fmt)
 cet_test(identifier USE_CATCH2_MAIN SOURCE identifier.cpp LIBRARIES phlex::model phlex::configuration Boost::json)
 cet_test(
   yielding_driver

--- a/test/core_misc_test.cpp
+++ b/test/core_misc_test.cpp
@@ -3,6 +3,7 @@
 #include "phlex/core/glue.hpp"
 #include "phlex/core/registrar.hpp"
 #include "phlex/model/algorithm_name.hpp"
+#include "phlex/utilities/bulleted_list.hpp"
 #include <catch2/catch_test_macros.hpp>
 
 #include <boost/json.hpp>
@@ -44,6 +45,12 @@ TEST_CASE("algorithm_name tests", "[model]")
     algorithm_name an = algorithm_name::create("p:a");
     CHECK(an.match(algorithm_name::create("p:a")));
     CHECK_FALSE(an.match(algorithm_name::create("p:b")));
+  }
+  SECTION("Bulleted list of algorithm_name")
+  {
+    std::vector<algorithm_name> ans = {algorithm_name::create("p:a1"),
+                                       algorithm_name::create("p:a2")};
+    CHECK(bulleted_list(ans) == "  - p:a1\n  - p:a2");
   }
 }
 

--- a/test/core_misc_test.cpp
+++ b/test/core_misc_test.cpp
@@ -52,6 +52,11 @@ TEST_CASE("algorithm_name tests", "[model]")
                                        algorithm_name::create("p:a2")};
     CHECK(bulleted_list(ans) == "  - p:a1\n  - p:a2");
   }
+  SECTION("Empty bulleted list")
+  {
+    CHECK(bulleted_list(std::vector<identifier>{}) == "");
+    CHECK(bulleted_list(std::vector<algorithm_name>{}) == "");
+  }
 }
 
 TEST_CASE("consumer tests", "[core]")

--- a/test/layer_path.cpp
+++ b/test/layer_path.cpp
@@ -33,4 +33,11 @@ TEST_CASE("Layer path tests", "[layer_path]")
   CHECK(event_hashes.contains(subrun.hash()));
   CHECK(event_hashes.contains(event.hash()));
   CHECK_FALSE(event_hashes.contains(lumiblock.hash()));
+
+  // Validation
+  CHECK_THROWS(layer_path(""));
+  CHECK_THROWS(layer_path("/notajob/notarun"));
+  CHECK_THROWS(layer_path(std::vector<identifier>{}));
+  CHECK_THROWS(layer_path("/job/run/job"));
+  CHECK_THROWS(layer_path("subrun/job"));
 }

--- a/test/layer_path.cpp
+++ b/test/layer_path.cpp
@@ -1,0 +1,36 @@
+#include "phlex/model/layer_path.hpp"
+
+#include "catch2/catch_test_macros.hpp"
+
+using namespace phlex::experimental;
+
+TEST_CASE("Layer path tests", "[layer_path]")
+{
+  layer_path job = "/job";
+  layer_path run = "/job/run";
+  layer_path lumiblock = "/job/run/lumiblock";
+  layer_path subrun = "/job/run/subrun";
+  layer_path event = "/job/run/subrun/event";
+
+  identifier event_id = "event";
+  layer_path partial_event = "subrun/event";
+
+  CHECK(run.is_complete());
+  CHECK(run.is_strict_prefix_of(event));
+  CHECK(run.is_strict_prefix_of(subrun));
+  CHECK_FALSE(lumiblock.is_strict_prefix_of(event));
+
+  CHECK(event.ends_with(event_id));
+  CHECK_FALSE(partial_event.is_complete());
+  CHECK(event.ends_with(partial_event));
+  CHECK_FALSE(subrun.ends_with(partial_event));
+
+  CHECK(subrun.to_string() == "/job/run/subrun");
+
+  auto event_hashes = event.hashes();
+  CHECK(event_hashes.contains(job.hash()));
+  CHECK(event_hashes.contains(run.hash()));
+  CHECK(event_hashes.contains(subrun.hash()));
+  CHECK(event_hashes.contains(event.hash()));
+  CHECK_FALSE(event_hashes.contains(lumiblock.hash()));
+}


### PR DESCRIPTION
The new `layer_path` class is used in `index_router` and the related infrastructure.

I've kept strings and `vector<string>`s for now in drivers. That might be the next step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- CI / CodeQL
  - Resolved seven CodeQL alerts for unpinned third-party GitHub Actions (actions referenced with ref 'main'):
    - .github/actions/prepare-check-outputs/action.yaml: get_pr, detect_act
    - .github/actions/prepare-fix-outputs/action.yaml: get_pr
    - .github/actions/run-change-detection/action.yaml: filter
    - .github/actions/workflow-setup/action.yaml: prepare_check, prepare_fix, detect

- Code (Core Framework)
  - index_router
    - Migrated driver-provided layer paths to phlex::experimental::layer_path.
    - establish_layers(...) signature changed to accept std::vector<layer_path>.
    - index_set_node_for overload accepts layer_path const&; lookups and matching now use layer_path::ends_with, hash(), is_strict_prefix_of.
    - multilayer_slot matching adapted to layer_path API.
    - Ambiguity error messages reformatted using phlex::experimental::bulleted_list.
  - framework_graph
    - seen_cell_count now calls hierarchy_.count_for(experimental::layer_path(...)).
    - Registration-error messages use bulleted_list for formatting.
  - input_arguments & producer_catalog
    - Replaced manual fmt::join formatting with bulleted_list for product/candidate lists.

- Code (Model / Data Structures)
  - New: phlex::experimental::layer_path
    - Added phlex/model/layer_path.hpp and phlex/model/layer_path.cpp.
    - Represents std::vector<identifier>, validates semantics (rejects empty, enforces job-root rules), supports:
      - is_complete(), is_strict_prefix_of(), ends_with(layer_path/identifier), to_string()
      - hash() (implicit job-root behavior) and hashes() (cumulative parent hashes)
    - Integrates formatting, hashing helpers, and stream operator.
    - Constructors from vector<identifier> and declared string_view constructor (parses '/'-delimited input).
  - data_cell_index
    - layer_path() now returns experimental::layer_path (was std::string); implementation builds identifier sequence from parent chain.
  - data_layer_hierarchy
    - count_for() now takes layer_path const& (was std::string); matching uses entry->layer_path.ends_with(layer).
    - layer_entry stores experimental::layer_path.
    - Ambiguity messages use bulleted_list.
  - fixed_hierarchy
    - Stores layer_paths_ as std::vector<experimental::layer_path> (converted from nested vectors).
    - Builds layer_hashes_ via layer_path.hashes(); removed prior validated_path helper.
    - data_cell_cursor::layer_path() now returns experimental::layer_path.
  - handle
    - handle<T>::layer_path() returns std::string created from id_->layer_path().to_string() (clarifies ownership/format).
  - identifier
    - identifier::hash_string inlined as constexpr using xxhash_64.
    - operator""_idq made consteval to precompute identifier_query hashes at compile time.
    - Added inline hash_value(identifier const&) returning id.hash().
  - fixed_hierarchy / fixed_hierarchy.cpp reviewer note: potential out-of-bounds CodeQL concern for empty-vector conversion addressed by layer_path constructor's validate() which rejects empty entries.

- Utilities
  - Added phlex::experimental::bulleted_list (phlex/utilities/bulleted_list.hpp) to render ranges as indented bulleted strings with overloads for fmt-formattable and to_string()-able elements.

- Build System
  - phlex/model/CMakeLists.txt: added layer_path.cpp to library sources and layer_path.hpp to installed headers.
  - phlex/utilities/CMakeLists.txt: added bulleted_list.hpp to installed headers.
  - test/CMakeLists.txt: added Catch2 test target for layer_path.

- Tests
  - Added test/layer_path.cpp: Catch2 tests for construction, prefix relationships, completeness, ends_with, to_string, and hashes().
  - Extended test/core_misc_test.cpp with a test for bulleted_list formatting.

- Plugins
  - layer_generator
    - Uses the cell's layer_path string for parent_to_children_ lookup and builds child paths with fmt::format("{}/{}", cell_lp, child).

- Public API / Signature Changes (notable)
  - index_router::establish_layers(...) now accepts std::vector<layer_path>.
  - index_router::index_set_node_for(...) overload accepts layer_path const&.
  - phlex::data_cell_index::layer_path() now returns experimental::layer_path.
  - data_layer_hierarchy::count_for(...) now accepts layer_path const&.
  - fixed_hierarchy stores layer_paths_ as std::vector<experimental::layer_path>; data_cell_cursor::layer_path() returns experimental::layer_path.
  - handle<T>::layer_path() now returns std::string via to_string().
  - identifier operator""_idq is consteval; identifier::hash_string is constexpr.

- Notes / Review Impact
  - Broad migration from string-based layer identifiers to layer_path affects core model APIs and routing logic; consumer code and drivers should be reviewed for compatibility (drivers currently still supply strings/vectors in some conversion helpers; full driver migration may be required later).
  - Consistent, improved error-list formatting via bulleted_list across modules.
  - Several public/ABI-impacting changes warrant attention during integration and release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->