### PR TITLE
Improve AI integration with devcontainer and tools

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,7 +66,7 @@ VALIDATE_PYTHON_SYMLINK
 RUN bash <<'INSTALL_PODMAN_CLIENT'
 set -euo pipefail
 apt-get update
-apt-get install -y --no-install-recommends podman socat
+apt-get install -y --no-install-recommends ssh podman socat
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 INSTALL_PODMAN_CLIENT

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,6 +61,33 @@ fi
 echo "Python symlink validated: $python_link -> $(readlink "$python_link")"
 VALIDATE_PYTHON_SYMLINK
 
+# Remove the Ubuntu minimal dpkg excludes file so that subsequent package
+# installs populate /usr/share/man and /usr/share/doc normally.  Without this,
+# every apt-get install silently strips man pages and other documentation,
+# producing the "This system has been minimized" warning whenever `man` is run.
+# Also install man-db (the `man` command and database) and groff (the troff
+# rendering pipeline required to display man pages), then reinstall git and
+# git-man to restore man pages that were already stripped at image build time.
+# mandoc is added as a lightweight alternative renderer (e.g. for CI linting).
+RUN <<'INSTALL_MAN_TOOLS'
+set -euo pipefail
+# Remove the dpkg excludes file so future installs populate /usr/share/man.
+rm -f /etc/dpkg/dpkg.cfg.d/excludes
+apt-get update
+apt-get install -y --no-install-recommends man-db groff mandoc
+# Reinstall git and git-man to recover already-stripped man pages.
+apt-get install -y --no-install-recommends --reinstall git git-man
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+# Ubuntu minimal diverts /usr/bin/man to a stub shell script that prints the
+# "This system has been minimized" warning.  Installing man-db is not enough
+# to restore the real binary — the divert must be explicitly removed.
+if [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
+    rm -f /usr/bin/man
+    dpkg-divert --quiet --remove --rename /usr/bin/man
+fi
+INSTALL_MAN_TOOLS
+
 # Install podman client and socat inside the container to support nested
 # container communication and provide a 'docker' command alias.
 RUN bash <<'INSTALL_PODMAN_CLIENT'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -69,7 +69,7 @@ VALIDATE_PYTHON_SYMLINK
 # rendering pipeline required to display man pages), then reinstall git and
 # git-man to restore man pages that were already stripped at image build time.
 # mandoc is added as a lightweight alternative renderer (e.g. for CI linting).
-RUN <<'INSTALL_MAN_TOOLS'
+RUN bash <<'INSTALL_MAN_TOOLS'
 set -euo pipefail
 # Remove the dpkg excludes file so future installs populate /usr/share/man.
 rm -f /etc/dpkg/dpkg.cfg.d/excludes

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,19 @@
     "build": {
         "dockerfile": "Dockerfile"
     },
+    "runArgs": [],
     "workspaceFolder": "/workspaces/phlex",
     "remoteUser": "root",
     "remoteEnv": {
-        "KILO_CONFIG_CONTENT": "${localEnv:KILO_CONFIG_CONTENT}"
+        // KILO_CONFIG_CONTENT_DOCKER rewrites 127.0.0.1:PORT to
+        // host.docker.internal:RELAY_PORT for the socat relay used when
+        // headroom runs as a local proxy.  Passed through here so that
+        // post-create.sh can wire it into the container's .bashrc
+        // conditionally: if non-empty it sets KILO_CONFIG_CONTENT to this
+        // value; otherwise KILO_CONFIG_CONTENT is left unset and Kilo falls
+        // back to ~/.config/kilo/kilo.jsonc (bind-mounted from the host).
+        "KILO_CONFIG_CONTENT_DOCKER": "${localEnv:KILO_CONFIG_CONTENT_DOCKER}",
+        "KILO_API_KEY": "${localEnv:HEADROOM_UPSTREAM_KEY}"
     },
     "containerEnv": {
         "CMAKE_GENERATOR": "Ninja",
@@ -16,17 +25,18 @@
         "GNUPGHOME": "/root/.gnupg"
     },
     "mounts": [
+        "source=${localWorkspaceFolder}/../phlex-coding-guidelines,target=/workspaces/phlex-coding-guidelines,type=bind",
         "source=${localWorkspaceFolder}/../phlex-design,target=/workspaces/phlex-design,type=bind",
         "source=${localWorkspaceFolder}/../phlex-examples,target=/workspaces/phlex-examples,type=bind",
-        "source=${localWorkspaceFolder}/../phlex-coding-guidelines,target=/workspaces/phlex-coding-guidelines,type=bind",
         "source=${localWorkspaceFolder}/../phlex-spack-recipes,target=/workspaces/phlex-spack-recipes,type=bind",
-        "source=${localEnv:HOME}/.vscode-remote-user-data,target=/root/.vscode-server-insiders/data/User,type=bind",
-        "source=${localEnv:HOME}/.podman-proxy/podman.sock,target=/tmp/podman.sock,type=bind",
         "source=${localEnv:HOME}/.aws,target=/root/.aws,type=bind",
         "source=${localEnv:HOME}/.config/gh,target=/root/.config/gh,type=bind,readonly",
         "source=${localEnv:HOME}/.config/kilo,target=/root/.config/kilo,type=bind",
         "source=${localEnv:HOME}/.gnupg,target=/root/.gnupg,type=bind",
-        "source=${localEnv:HOME}/.kiro,target=/root/.kiro,type=bind"
+        "source=${localEnv:HOME}/.kiro,target=/root/.kiro,type=bind",
+        "source=phlex-kilo-data,target=/root/.local/share/kilo,type=volume",
+        "source=${localEnv:HOME}/.podman-proxy/podman.sock,target=/tmp/podman.sock,type=bind",
+        "source=${localEnv:HOME}/.vscode-remote-user-data,target=/root/.vscode-server-insiders/data/User,type=bind"
     ],
     "initializeCommand": "bash .devcontainer/ensure-repos.sh",
     "onCreateCommand": "bash .devcontainer/setup-repos.sh /workspaces",
@@ -78,7 +88,8 @@
                     "**/.venv/**": true,
                     "**/py_virtual_env/**": true
                 },
-                "github.copilot-chat.usePreReleaseVersion": false
+                "github.copilot-chat.usePreReleaseVersion": false,
+                "kilocode.new.extraCaCerts": ""
             },
             "extensions": [
                 "charliermarsh.ruff",

--- a/.devcontainer/ensure-repos.sh
+++ b/.devcontainer/ensure-repos.sh
@@ -51,6 +51,59 @@ clone_if_absent() {
   done
 }
 
+ensure_bind_dir() {
+  mkdir -p "$@"
+}
+
+# start_socat_relay LABEL KILL_PATTERN LISTEN_SPEC CONNECT_SPEC LOGFILE READY_TEST
+#
+# Start a background socat relay, waiting up to 2 s for it to become ready.
+#
+#   LABEL        - human-readable name for log messages
+#   KILL_PATTERN - argument to pkill -f to stop any existing relay
+#   LISTEN_SPEC  - socat first address (the listening side)
+#   CONNECT_SPEC - socat second address (the connecting side)
+#   LOGFILE      - path for socat stdout/stderr
+#   READY_TEST   - shell command whose exit code indicates readiness
+#
+# Returns 0 if the relay is ready, 1 otherwise.
+start_socat_relay() {
+  local label="$1"
+  local kill_pattern="$2"
+  local listen_spec="$3"
+  local connect_spec="$4"
+  local logfile="$5"
+  local ready_test="$6"
+
+  if ! command -v socat >/dev/null 2>&1; then
+    echo "WARNING: socat not found; cannot start ${label} relay" >&2
+    return 1
+  fi
+
+  # Stop any pre-existing relay process.
+  pkill -f "${kill_pattern}" 2>/dev/null || true
+  sleep 0.2
+
+  echo "Starting ${label} relay: ${listen_spec} -> ${connect_spec} ..."
+  nohup setsid socat "${listen_spec}" "${connect_spec}" > "${logfile}" 2>&1 &
+
+  # Wait up to 2 s for the relay to become ready.
+  local i=0
+  while [ "${i}" -lt 20 ]; do
+    eval "${ready_test}" 2>/dev/null && break
+    sleep 0.1
+    i=$(( i + 1 ))
+  done
+
+  if eval "${ready_test}" 2>/dev/null; then
+    echo "${label} relay ready"
+    return 0
+  else
+    echo "WARNING: ${label} relay did not become ready in time" >&2
+    return 1
+  fi
+}
+
 clone_if_absent phlex-design
 clone_if_absent phlex-examples
 clone_if_absent phlex-coding-guidelines
@@ -68,35 +121,16 @@ PODMAN_REAL_SOCKET="${XDG_RUNTIME_DIR:-/run/user/${USER_ID}}/podman/podman.sock"
 PROXY_DIR="${HOME}/.podman-proxy"
 PROXY_SOCKET="${PROXY_DIR}/podman.sock"
 
-# Kill any existing socat proxy for this socket
-pkill -f "socat UNIX-LISTEN:${PROXY_SOCKET}" || true
-# Wait for old process to die and socket to be removed
-sleep 0.2
-mkdir -p "${PROXY_DIR}"
-chmod 700 "${PROXY_DIR}"
-
-mkdir -p "${PROXY_DIR}"
-chmod 700 "${PROXY_DIR}"
+ensure_bind_dir -m 0700 "${PROXY_DIR}"
 
 if [ -S "${PODMAN_REAL_SOCKET}" ]; then
-  if command -v socat >/dev/null 2>&1; then
-    echo "Proxying Podman socket ${PODMAN_REAL_SOCKET} -> ${PROXY_SOCKET} ..."
-    # Use a background socat to proxy the real socket to the proxy socket.
-    # This socket will be bind-mounted at the SAME PATH in the container.
-    nohup setsid socat "UNIX-LISTEN:${PROXY_SOCKET},fork,reuseaddr,unlink-early" "UNIX-CONNECT:${PODMAN_REAL_SOCKET}" > /tmp/socat-podman.log 2>&1 &
-    # Wait for socket to be created
-    i=0
-    while [ $i -lt 20 ] && [ ! -S "${PROXY_SOCKET}" ]; do
-      sleep 0.1
-      i=$((i + 1))
-    done
-    if [ ! -S "${PROXY_SOCKET}" ]; then
-      echo "WARNING: Socket creation timed out; creating placeholder" >&2
-      socat "UNIX-LISTEN:${PROXY_SOCKET},fork,reuseaddr" "UNIX-CONNECT:${PODMAN_REAL_SOCKET}" &
-    fi
-  else
-    echo "WARNING: socat not found on host; act will not work inside the container" >&2
-  fi
+  start_socat_relay \
+    "Podman socket" \
+    "socat UNIX-LISTEN:${PROXY_SOCKET}" \
+    "UNIX-LISTEN:${PROXY_SOCKET},fork,reuseaddr,unlink-early" \
+    "UNIX-CONNECT:${PODMAN_REAL_SOCKET}" \
+    "/tmp/socat-podman.log" \
+    "[ -S '${PROXY_SOCKET}' ]" || true
 else
   echo "WARNING: Podman socket not found at ${PODMAN_REAL_SOCKET}" >&2
   echo "  To use 'act' inside the devcontainer, enable the Podman socket:" >&2
@@ -115,5 +149,45 @@ s = socket.socket(socket.AF_UNIX)
 s.bind('${PROXY_SOCKET}')
 " 2>/dev/null || touch "${PROXY_SOCKET}"
 fi
+
+# --- Headroom Proxy Relay for Devcontainer ---
+#
+# The headroom proxy is an SSH-tunnelled port bound only to 127.0.0.1 on this
+# host.  Rootless Podman uses pasta for container networking, so containers
+# reach the host via host.docker.internal (169.254.1.2) rather than via a
+# bridge interface.  However, pasta maps host.docker.internal to the host's
+# loopback only for ports that are actually listening on all interfaces --
+# headroom's port is bound to 127.0.0.1 only and is therefore unreachable.
+#
+# We relay headroom onto a different port on 0.0.0.0 so that containers can
+# reach it via host.docker.internal:$HEADROOM_RELAY_PORT.  A different port is
+# required because 0.0.0.0:$HEADROOM_PORT would conflict with the existing
+# 127.0.0.1:$HEADROOM_PORT listener.  KILO_CONFIG_CONTENT_DOCKER is passed into the
+# devcontainer and post-create.sh wires it into /root/.bashrc to point at
+# host.docker.internal:$HEADROOM_RELAY_PORT.
+
+HEADROOM_PORT="${HEADROOM_PORT:-9797}"
+HEADROOM_RELAY_PORT=$(( HEADROOM_PORT + 10000 ))
+HEADROOM_LOCAL="127.0.0.1:${HEADROOM_PORT}"
+
+if ss -tlnp 2>/dev/null | grep -q "127.0.0.1:${HEADROOM_PORT}"; then
+  start_socat_relay \
+    "Headroom proxy" \
+    "socat TCP-LISTEN:${HEADROOM_RELAY_PORT}" \
+    "TCP-LISTEN:${HEADROOM_RELAY_PORT},fork,reuseaddr" \
+    "TCP:${HEADROOM_LOCAL}" \
+    "/tmp/socat-headroom.log" \
+    "ss -tlnp 2>/dev/null | grep -q ':${HEADROOM_RELAY_PORT} '" || true
+else
+  echo "WARNING: headroom proxy not detected at ${HEADROOM_LOCAL}; skipping relay" >&2
+  echo "  Ensure the SSH tunnel is active (headroom running on your laptop)" >&2
+fi
+
+# Ensure remaining source bind mount points exist.
+ensure_bind_dir "$HOME/.aws"
+ensure_bind_dir "$HOME/.config/"{gh,kilo}
+ensure_bind_dir "$HOME/.gnupg"
+ensure_bind_dir "$HOME/.kiro"
+ensure_bind_dir "$HOME/.vscode-remote-user-data"
 
 echo "SUCCESS: .devcontainer/ensure-repos.sh completed successfully"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -51,6 +51,48 @@ p.write_text(
 PY
 fi
 
+# Expose repo scripts that follow the git-<subcommand> naming convention as
+# proper git subcommands by symlinking them into /usr/local/bin.  This makes
+# `git ai-commit` work in any directory without requiring scripts/ on PATH.
+ln -sf /workspaces/phlex/scripts/git-ai-commit /usr/local/bin/git-ai-commit
+
+# Adjust MANPATH to enable `git help ai-commit` to find the man page.
+# The scripts/man/man1 directory contains git-subcommand man pages.
+# Prepend the repo man directory and ensure the resulting MANPATH always has
+# an empty field (which tells man to search the system default paths).  When
+# there is no pre-existing MANPATH, or the existing one lacks an empty field,
+# a trailing colon is appended to provide one; if an empty field already
+# exists it is preserved as-is.
+cat >> /root/.bashrc <<'EOF'
+
+prepend_to_manpath() {
+  # Prepends one or more paths to MANPATH, preserving the position of any
+  # existing empty field (which tells man(1) where to insert the system
+  # default paths).  Handles unset, empty, or degenerate MANPATH safely.
+  # If MANPATH has no empty field, a trailing : is added (system paths last).
+  local prefix
+  prefix=$(IFS=:; echo "$*")
+  # Unset or degenerate (only colons): start fresh, system defaults last.
+  if [[ -z ${MANPATH+set} || -z "${MANPATH//:}" ]]; then
+    export MANPATH="${prefix}:"
+    return
+  fi
+  case "$MANPATH" in
+    *::*|*:|:*)
+      # Already has an empty field somewhere; prepend and keep it in place.
+      # :foo  -> newpath::foo  (leading : becomes embedded :: after prepend)
+      # foo:  -> newpath:foo:  (trailing : stays trailing)
+      # f::b  -> newpath:f::b  (embedded :: stays embedded)
+      export MANPATH="${prefix}:${MANPATH}" ;;
+    *)
+      # No empty field: add trailing : so system paths are still searched.
+      export MANPATH="${prefix}:${MANPATH}:" ;;
+  esac
+}
+
+prepend_to_manpath "/workspaces/phlex/scripts/man"
+EOF
+
 # Install pre-commit hooks if available.
 if command -v prek >/dev/null 2>&1; then
   prek install || true

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -17,6 +17,40 @@ EOF
 # installation on every rebuild.
 rm -f /root/.vscode-server-insiders/data/Machine/.installExtensionsMarker
 
+# Set KILO_CONFIG_CONTENT for interactive shells.  When KILO_CONFIG_CONTENT_DOCKER
+# is non-empty (headroom local proxy via socat relay), use it so that the baseURL
+# points at host.docker.internal rather than 127.0.0.1.  Otherwise leave
+# KILO_CONFIG_CONTENT unset so Kilo falls back to ~/.config/kilo/kilo.jsonc,
+# which is bind-mounted from the host and may point at an external provider.
+if [ -n "${KILO_CONFIG_CONTENT_DOCKER:-}" ]; then
+  printf 'export KILO_CONFIG_CONTENT=%q\n' "${KILO_CONFIG_CONTENT_DOCKER}" >> /root/.bashrc
+fi
+
+# Seed the Kilo Code auth token into the container-private data volume.
+# The volume is not shared with the host to avoid SQLite conflicts between
+# the Remote-SSH and devcontainer Kilo Code instances.  The API key is
+# passed in via the KILO_API_KEY remoteEnv variable.
+if [ -n "${KILO_API_KEY:-}" ]; then
+  mkdir -p /root/.local/share/kilo
+  touch /root/.local/share/kilo/auth.json
+  chmod 0600 /root/.local/share/kilo/auth.json
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+p = Path("/root/.local/share/kilo/auth.json")
+p.write_text(
+    json.dumps(
+        {"fnal-litellm": {"type": "api", "key": os.environ["KILO_API_KEY"]}},
+        indent=2,
+    )
+    + "\n",
+    encoding="utf-8",
+)
+PY
+fi
+
 # Install pre-commit hooks if available.
 if command -v prek >/dev/null 2>&1; then
   prek install || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,12 @@ repos:
       - id: check-executables-have-shebangs
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.16
     hooks:
       - id: ruff-format
         types_or: [python, pyi]
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.2
+    rev: v22.1.5
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
@@ -39,8 +39,8 @@ repos:
         files: ^scripts/
         types_or: [python]
         pass_filenames: false
-  - repo: https://github.com/BlankSpruce/gersemi
-    rev: 0.26.1
+  - repo: https://github.com/BlankSpruce/gersemi-pre-commit
+    rev: 0.27.7
     hooks:
       - id: gersemi
   - repo: https://github.com/google/go-jsonnet
@@ -52,12 +52,12 @@ repos:
         # We therefore exclude them from linting, but still format them.
         exclude: ^test/max-parallelism
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.1
+    rev: v3.8.3
     hooks:
       - id: prettier
         types_or: [yaml]
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.22.0
+    rev: v0.22.1
     hooks:
       - id: markdownlint-cli2
         args: [--fix]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,8 @@ outstanding findings before enforcement is tightened.
   type annotations (avoids forward-reference issues; Python >=3.12)
 - Test files: `test_*.py`; do NOT name files after stdlib modules (e.g. `types.py`)
 - PEP 8 naming; `CapWords` for classes, `snake_case` for everything else
+- When using the `read` tool for files, always use integer values for `offset`
+  and `limit` parameters — never float/double values
 
 ### CMake
 

--- a/scripts/git-ai-commit
+++ b/scripts/git-ai-commit
@@ -625,7 +625,10 @@ def _chat_antigravity(model: str, messages: list[dict[str, str]]) -> str:
             capture_output=True,
             text=True,
             check=False,
+            timeout=60,
         )
+    except subprocess.TimeoutExpired as exc:
+        raise _APIError("Antigravity CLI (agy) timed out after 60 seconds.", status=0) from exc
     except FileNotFoundError as exc:
         raise _Error(
             "Antigravity CLI (agy) not found in PATH. Ensure it is installed and available."

--- a/scripts/git-ai-commit
+++ b/scripts/git-ai-commit
@@ -9,34 +9,41 @@ This tool automatically gathers context from:
   - Staged changes (diff)
   - Git status and recent commit history
   - Repository-level guidance: AGENTS.md, AGENT.md, GEMINI.md, CLAUDE.md,
-    CONTEXT.md, INSTRUCTIONS.md, CONTRIBUTING.md, DEVELOPING.md, HACKING.md,
-    ARCHITECTURE.md, STYLEGUIDE.md, and CLANG_TIDY_CONFIGURATION.md.
-  - Tool-specific rules: .amazonq/rules/, .kiro/rules/, .kiro/steering/,
-    .gemini/rules/, .kilocode/, .cursorrules, .clinerules, .windsurfrules,
-    and q.rules.
+    CONTEXT.md, INSTRUCTIONS.md, CONTRIBUTING.md, HACKING.md,
+    ARCHITECTURE.md, and STYLEGUIDE.md.
+  - Tool-specific rules: .kilo/agent/, .kilo/command/, .amazonq/rules/,
+    .kiro/rules/, .kiro/steering/, .gemini/rules/, .kilocode/, .cursorrules,
+    .clinerules, .windsurfrules, and q.rules.
   - User-level guidance: ~/.config/git-ai-commit/instructions.md
   - Git commit template: (from `git config commit.template`)
 
 Usage
 -----
-  git-ai-commit [OPTIONS]
-  git ai-commit [OPTIONS]
+  git-ai-commit [OPTIONS] [-- GIT-COMMIT-OPTIONS]
+  git ai-commit [OPTIONS] [-- GIT-COMMIT-OPTIONS]
   git ai-commit --amend
   echo "context" | git ai-commit --yes
+  git ai-commit --yes -- --no-verify --signoff
 
 Options
 -------
   --amend              Amend the previous commit, including its message as context
   --context TEXT       Supplemental context/prompt for the AI
-  --backend BACKEND    API backend: kilo (default), github-models, copilot
-  --model   MODEL      Model name (env: GIT_AI_COMMIT_MODEL)
+  --backend BACKEND    API backend: kilo (default), github-models, copilot,
+                       antigravity, agy
+  --model   MODEL      Model name; defaults to azure/claude-haiku-4-5 for the
+                       kilo backend (gpt-4o for others, none for antigravity);
+                       large prompts auto-escalate to qwen/qwen3-coder-next on
+                       kilo unless a model is explicitly set (env:
+                       GIT_AI_COMMIT_MODEL or GIT_AI_COMMIT_KILO_MODEL)
   --api     URL        API base URL override (env: GIT_AI_COMMIT_API)
   --dry-run            Print generated message to stdout; do not commit
   -y/--yes             Commit without interactive confirmation
   -e/--edit            Open generated message in $EDITOR before committing
-  --no-verify          Pass --no-verify to git commit
   --no-instructions    Skip all instruction/context files; use only the diff
   -h/--help            Show this help and exit
+  --                   Pass all remaining arguments verbatim to git commit
+                       (e.g. --no-verify, --signoff, --gpg-sign=<key>)
 
 Backends
 --------
@@ -54,14 +61,22 @@ Backends
                 Default model: gpt-4o.
                 Token: exchanges a GitHub OAuth token for a short-lived Copilot token.
 
+  antigravity / agy
+                Antigravity CLI backend using `agy -p -`.
+                If a model is specified via --model (or GIT_AI_COMMIT_MODEL),
+                it is passed to `agy` as `--model <model>`. Otherwise,
+                `agy` uses its default configured model. No API token or URL
+                resolution is required for this backend.
+
 Environment variables
 ---------------------
   GIT_AI_COMMIT_TOKEN         API token (overrides all other token sources)
   GIT_AI_COMMIT_MODEL         Default model name
   GIT_AI_COMMIT_API           API base URL override
-  GIT_AI_COMMIT_BACKEND       Default backend (kilo, github-models, or copilot)
+  GIT_AI_COMMIT_BACKEND       Default backend (kilo, github-models, copilot, antigravity, or agy)
   GIT_AI_COMMIT_KILO_API      kilo backend base URL (default: https://litellm.fnal.gov/v1)
-  GIT_AI_COMMIT_KILO_MODEL    kilo backend default model (default: azure/claude-haiku-4-5)
+  GIT_AI_COMMIT_KILO_MODEL    kilo backend default model (default: azure/claude-haiku-4-5);
+                              setting this env var suppresses auto-escalation
   GIT_AI_COMMIT_KILO_PROVIDER kilo auth.json provider key (default: fnal-litellm)
 
 Token resolution (kilo backend):
@@ -81,6 +96,7 @@ Token resolution (github-models / copilot backends):
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import re
@@ -88,7 +104,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-import typing
+from typing import TextIO
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -107,23 +123,40 @@ _KILO_AUTH_JSON = Path.home() / ".local" / "share" / "kilo" / "auth.json"
 # environment variables to adapt to a different LiteLLM instance or model
 # naming convention.
 _DEFAULT_KILO_API = os.environ.get("GIT_AI_COMMIT_KILO_API", "https://litellm.fnal.gov/v1")
-_DEFAULT_MODEL_KILO = os.environ.get("GIT_AI_COMMIT_KILO_MODEL", "azure/claude-haiku-4-5")
+_KILO_MODEL_ENV = os.environ.get("GIT_AI_COMMIT_KILO_MODEL", "").strip()
+_DEFAULT_MODEL_KILO = _KILO_MODEL_ENV or "azure/claude-haiku-4-5"
+# True when the user has explicitly pinned a kilo model via the environment,
+# which suppresses auto-escalation even if the diff is large.
+_KILO_MODEL_PINNED_BY_ENV = bool(_KILO_MODEL_ENV)
 _DEFAULT_KILO_PROVIDER = os.environ.get("GIT_AI_COMMIT_KILO_PROVIDER", "fnal-litellm")
 _DEFAULT_MODEL_OTHER = "gpt-4o"
 
 _MAX_DIFF_CHARS = 60_000
 
+# When the kilo model was not explicitly chosen and the prompt exceeds this
+# character count, escalate to a free high-context model rather than risk
+# truncation or degraded output with the default (Haiku).  The threshold is
+# set conservatively below _MAX_DIFF_CHARS so that instruction files and log
+# context on top of a near-limit diff still trigger escalation.
+_ESCALATION_THRESHOLD_CHARS = 30_000
+_ESCALATION_MODEL_KILO = "qwen/qwen3-coder-next"
+
 _SYSTEM = textwrap.dedent("""\
     You are an expert software developer writing Git commit messages.
 
-    Rules:
-    - Subject line: imperative mood, ≤72 characters, no trailing period
-    - Separate subject from body with one blank line
-    - Body: explain *what* changed and *why*; use Markdown lists or inline
-      code spans where they genuinely aid clarity (not merely for decoration)
+    CRITICAL — respond with ONLY the commit message, nothing else.
+    Do not write any introduction, explanation, or commentary before or
+    after the message.  Do not wrap the message in a markdown code fence.
+    Your very first character must be the first character of the subject line.
+
+    Message rules:
+    - Subject line: imperative mood, ≤72 characters, no trailing period;
+      must be a complete, self-contained sentence (do not let the subject
+      run past the blank line into the body)
+    - Separate subject from body with exactly one blank line
+    - Body: explain *what* changed and *why*; bullet lists or inline code
+      spans where they genuinely aid clarity, not merely for decoration
     - Do NOT reproduce the diff verbatim or enumerate every changed file
-    - Respond with ONLY the commit message — no preamble, no sign-off
-      trailer, no markdown fence wrapping the entire message
 """)
 
 # ---------------------------------------------------------------------------
@@ -233,7 +266,7 @@ def _get_instructions(root: Path) -> str:
 
     When an AGENTS.md (or AGENT.md) file is present and non-empty it is
     treated as the authoritative summary of all project instructions.  In
-    that case the tool-specific rule directories (.kiro/, .amazonq/,
+    that case the tool-specific rule directories (.kilo/, .kiro/, .amazonq/,
     .kilocode/, .gemini/) and .github/copilot-instructions.md are skipped to
     avoid sending thousands of redundant tokens.
     """
@@ -269,7 +302,8 @@ def _get_instructions(root: Path) -> str:
         root / ".github" / "copilot-instructions.md",
     ]
     # Both .kiro/rules/ (this project's layout) and .kiro/steering/ (used in
-    # some other projects) are checked.
+    # some other projects) are checked.  .kilo/agent/ and .kilo/command/ cover
+    # projects using the modern Kilo config layout without a top-level AGENTS.md.
     tool_dirs = [
         root / ".amazonq" / "rules",
         root / ".amazonq" / "rules" / "memory-bank",
@@ -277,6 +311,8 @@ def _get_instructions(root: Path) -> str:
         root / ".kiro" / "steering",
         root / ".gemini" / "rules",
         root / ".kilocode",
+        root / ".kilo" / "agent",
+        root / ".kilo" / "command",
     ]
 
     # Determine whether an AGENTS.md / AGENT.md is present and non-empty.
@@ -384,6 +420,21 @@ def _gh_cli_token() -> str | None:
     return None
 
 
+def _gh_oauth_token() -> str | None:
+    """Return a GitHub OAuth token from env vars, gh CLI, or hosts file.
+
+    This deliberately ignores GIT_AI_COMMIT_TOKEN because that variable may
+    hold a non-GitHub key (e.g. a LiteLLM API key).  Used when a genuine
+    GitHub OAuth token is required, such as the Copilot token exchange.
+    """
+    for var in ("GITHUB_TOKEN", "GH_TOKEN"):
+        if val := os.environ.get(var, "").strip():
+            return val
+    if tok := _gh_cli_token():
+        return tok
+    return _gh_config_token()
+
+
 def _token(backend: str) -> str:
     """Resolve the best available API token for the given backend."""
     # GIT_AI_COMMIT_TOKEN always wins regardless of backend.
@@ -417,6 +468,72 @@ def _token(backend: str) -> str:
     raise _Error(
         "No API token found. Set GIT_AI_COMMIT_TOKEN, GITHUB_TOKEN, or run 'gh auth login'."
     )
+
+
+# ---------------------------------------------------------------------------
+# Response cleaning
+# ---------------------------------------------------------------------------
+
+
+def _clean_message(text: str) -> str:
+    """Strip model preamble and fenced code blocks from a raw API response.
+
+    Some models ignore the instruction to respond with only the commit message
+    and wrap their output in prose ("Here's the commit message:") and/or a
+    fenced code block.  This function normalises the response to a bare commit
+    message in both cases.
+
+    Strategy:
+    1. If a balanced fenced code block is present, extract the content of the
+       first one (the language tag, if any, is discarded).
+    2. Otherwise strip any lone opening or closing fence markers that appear
+       as the first or last non-empty line (models sometimes emit only a
+       trailing ````` ``` ````` without a matching opener, or vice-versa).
+    3. Drop any leading lines that look like a prose introduction — either a
+       line ending with ':' followed by a blank line, or any leading paragraph
+       whose first line does not look like a commit subject — but only when the
+       text does not itself begin with a conventional-commit subject
+       (e.g. "fix: ...", "feat(scope): ...").  Without that guard a subject
+       such as "fix: broken:\\n\\nbody" would be incorrectly truncated.
+    4. Strip surrounding whitespace.
+    """
+    # Extract the first balanced fenced code block if present.
+    fence_match = re.search(r"```[^\n]*\n(.*?)```", text, re.DOTALL)
+    if fence_match:
+        return fence_match.group(1).strip()
+
+    # Strip a lone closing fence on the last non-empty line (no matching opener
+    # was found above, so the model emitted an unbalanced trailing fence).
+    text = re.sub(r"\n```[^\n]*\s*\Z", "", text)
+    # Strip a lone opening fence on the first non-empty line.
+    text = re.sub(r"\A```[^\n]*\n", "", text)
+
+    # Strip leading prose preamble only when the text does not already start
+    # with a conventional-commit subject (type(scope)!: description).
+    if not re.match(r"^[a-z]+(?:\([^)]+\))?!?:\s", text):
+        # Case 1: leading paragraph ends with ':' followed by a blank line.
+        text = re.sub(r"\A.*?:\s*\n\s*\n", "", text, count=1, flags=re.DOTALL)
+        # Case 2: after the above, the first line still looks like prose (not
+        # a short imperative subject).  Detect by checking whether the first
+        # line is longer than 72 characters or begins with common prose
+        # patterns ("The ", "This ", "I ", sentence fragments, etc.).
+        first_line = text.split("\n", 1)[0].strip()
+        if len(first_line) > 72 or re.match(
+            r"^(?:The |This |These |I |Here |Note:|Below|Above|A |An )", first_line
+        ):
+            # Try to drop everything up to and including the first blank line
+            # to skip the prose introduction and land on the commit message.
+            remainder = re.sub(r"\A.*?\n\s*\n", "", text, count=1, flags=re.DOTALL)
+            if remainder.strip():
+                text = remainder
+            else:
+                # The whole response is a single prose paragraph with no blank
+                # line — nothing useful remains after stripping it, so return
+                # the raw text as-is and let the caller decide (the user will
+                # see it in the preview and can abort).
+                pass
+
+    return text.strip()
 
 
 # ---------------------------------------------------------------------------
@@ -455,7 +572,7 @@ def _chat(
             "model": model,
             "messages": messages,
             "temperature": 0.2,
-            "max_tokens": 1024,
+            "max_tokens": 2048,
         }
     ).encode()
     req = urllib.request.Request(
@@ -471,7 +588,8 @@ def _chat(
     try:
         with urllib.request.urlopen(req, timeout=60) as resp:
             data = json.loads(resp.read())
-            return data["choices"][0]["message"]["content"].strip()
+            raw = data["choices"][0]["message"]["content"]
+            return _clean_message(raw)
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors="replace")
         raise _APIError(f"HTTP {exc.code}: {body[:500]}", exc.code) from exc
@@ -479,6 +597,47 @@ def _chat(
         raise _APIError(f"Network error: {exc}") from exc
     except (KeyError, IndexError, json.JSONDecodeError) as exc:
         raise _APIError(f"Unexpected API response: {exc}") from exc
+
+
+def _chat_antigravity(model: str, messages: list[dict[str, str]]) -> str:
+    """Send *messages* to the antigravity CLI (agy) and return the reply."""
+    system_content = ""
+    user_content = ""
+    for m in messages:
+        if m["role"] == "system":
+            system_content = m["content"]
+        elif m["role"] == "user":
+            user_content = m["content"]
+
+    if system_content:
+        prompt = f"System Instructions:\n{system_content}\n\n{user_content}"
+    else:
+        prompt = user_content
+
+    cmd = ["agy", "-p", "-"]
+    if model:
+        cmd += ["--model", model]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise _Error(
+            "Antigravity CLI (agy) not found in PATH. Ensure it is installed and available."
+        ) from exc
+
+    if result.returncode != 0:
+        raise _APIError(
+            f"Antigravity CLI (agy) failed (exit code {result.returncode}):\n{result.stderr.strip()}",
+            result.returncode,
+        )
+
+    return _clean_message(result.stdout)
 
 
 # ---------------------------------------------------------------------------
@@ -511,7 +670,11 @@ def _build_messages(
         parts.append(f"\n## Agent instructions\n\n{instr}")
     if context:
         parts.append(f"\n## Supplemental context\n\n{context}")
-    parts.append("\n\nWrite a commit message for the staged changes above.")
+    parts.append(
+        "\n\nWrite the commit message for the staged changes above."
+        "  Remember: respond with the commit message text only —"
+        " start directly with the subject line."
+    )
 
     return [
         {"role": "system", "content": _SYSTEM},
@@ -556,23 +719,23 @@ def _edit(text: str) -> str:
 def _confirm(prompt: str) -> bool:
     """Prompt for y/N, opening /dev/tty if stdin is a pipe."""
     try:
-        if sys.stdin.isatty():
-            source = sys.stdin
-        else:
-            source = open("/dev/tty", encoding="utf-8")  # noqa: SIM115 — intentional, closed below
-        try:
+        with contextlib.ExitStack() as stack:
+            if sys.stdin.isatty():
+                source = sys.stdin
+            else:
+                # enter_context registers the file's __exit__ on the stack, so
+                # the file is closed automatically when the `with` block exits.
+                # codeql[py/file-not-closed]
+                source = stack.enter_context(open("/dev/tty", encoding="utf-8"))  # noqa: SIM115
             print(f"{prompt} [y/N] ", end="", flush=True)
             reply = source.readline().strip().lower()
-        finally:
-            if source is not sys.stdin:
-                source.close()
-        return reply in ("y", "yes")
+            return reply in ("y", "yes")
     except (EOFError, KeyboardInterrupt, OSError):
         print()
         return False
 
 
-def _print_rule(msg: str, *, file: typing.TextIO = sys.stderr) -> None:
+def _print_rule(msg: str, *, file: TextIO = sys.stderr) -> None:
     print(f"\n{'─' * 72}\n{msg}\n{'─' * 72}\n", file=file)
 
 
@@ -580,11 +743,13 @@ def _print_rule(msg: str, *, file: typing.TextIO = sys.stderr) -> None:
 # Backend resolution
 # ---------------------------------------------------------------------------
 
-_BACKENDS = ("kilo", "github-models", "copilot")
+_BACKENDS = ("kilo", "github-models", "copilot", "antigravity", "agy")
 
 
 def _resolve_backend_and_api(backend: str, api_override: str) -> tuple[str, str]:
     """Return (backend, api_base) after applying any --api override."""
+    if backend in ("antigravity", "agy"):
+        return backend, ""
     if api_override:
         return backend, api_override
     if backend == "kilo":
@@ -595,6 +760,8 @@ def _resolve_backend_and_api(backend: str, api_override: str) -> tuple[str, str]
 
 
 def _default_model(backend: str) -> str:
+    if backend in ("antigravity", "agy"):
+        return ""
     return _DEFAULT_MODEL_KILO if backend == "kilo" else _DEFAULT_MODEL_OTHER
 
 
@@ -609,6 +776,16 @@ def main() -> None:
     if default_backend not in _BACKENDS:
         default_backend = "kilo"
 
+    # Split argv on the first `--` separator.  Everything after `--` is passed
+    # verbatim to `git commit` without any interpretation by this script.
+    argv = sys.argv[1:]
+    if "--" in argv:
+        sep = argv.index("--")
+        extra_git_args: list[str] = argv[sep + 1 :]
+        argv = argv[:sep]
+    else:
+        extra_git_args = []
+
     ap = argparse.ArgumentParser(
         prog="git-ai-commit",
         description="Commit staged changes with an AI-generated commit message.",
@@ -616,7 +793,9 @@ def main() -> None:
             "Supplemental context can be piped on stdin:\n"
             "  echo 'Fixes #42' | git-ai-commit --yes\n\n"
             "Can also be invoked as a Git subcommand:\n"
-            "  git ai-commit [OPTIONS]"
+            "  git ai-commit [OPTIONS]\n\n"
+            "Options after -- are forwarded verbatim to git commit:\n"
+            "  git ai-commit --yes -- --no-verify --signoff"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -627,7 +806,7 @@ def main() -> None:
         default=default_backend,
         help=(
             "API backend to use: kilo (FNAL LiteLLM, default), "
-            "github-models, or copilot "
+            "github-models, copilot, antigravity, or agy "
             "(env: GIT_AI_COMMIT_BACKEND)"
         ),
     )
@@ -636,9 +815,10 @@ def main() -> None:
         default=os.environ.get("GIT_AI_COMMIT_MODEL", ""),
         metavar="MODEL",
         help=(
-            "Model name — defaults to azure/claude-haiku-4-5 for the kilo "
-            "backend and gpt-4o for others "
-            "(env: GIT_AI_COMMIT_MODEL)"
+            f"Model name — defaults to {_DEFAULT_MODEL_KILO} for the kilo "
+            f"backend and {_DEFAULT_MODEL_OTHER} for others; large prompts "
+            f"auto-escalate to {_ESCALATION_MODEL_KILO} unless a model is "
+            "explicitly set (env: GIT_AI_COMMIT_MODEL)"
         ),
     )
     ap.add_argument(
@@ -651,17 +831,18 @@ def main() -> None:
     ap.add_argument("--amend", action="store_true", help="Amend the previous commit")
     ap.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompt")
     ap.add_argument("-e", "--edit", action="store_true", help="Open message in $EDITOR")
-    ap.add_argument("--no-verify", action="store_true", help="Pass --no-verify to git commit")
     ap.add_argument(
         "--no-instructions",
         action="store_true",
         help="Skip all instruction/context files; send only the diff, status, and log",
     )
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
     backend, api_base = _resolve_backend_and_api(args.backend, args.api)
-    model = args.model or _default_model(backend)
-
+    # Track whether the model was explicitly chosen by the user (CLI or env).
+    # An explicit choice suppresses auto-escalation for large prompts.
+    model_explicit = bool(args.model.strip())
+    model = args.model.strip() or _default_model(backend)
     # Collect supplemental context from --context and/or stdin.
     ctx_parts: list[str] = []
     if args.context:
@@ -675,32 +856,72 @@ def main() -> None:
     try:
         root = _git_root()
         diff = _staged_diff(args.amend)
-        if not diff.strip() and not args.amend:
-            print("Nothing staged. Use 'git add' first.", file=sys.stderr)
-            sys.exit(0)
         status = _status()
         log = _recent_log()
         last_msg = _last_commit_message() if args.amend else ""
         instr = "" if args.no_instructions else _get_instructions(root)
-        tok = _token(backend)
+        tok = "" if backend in ("antigravity", "agy") else _token(backend)
     except _Error as exc:
         print(f"git-ai-commit: {exc}", file=sys.stderr)
         sys.exit(1)
 
+    if not diff.strip():
+        if not args.amend:
+            print("Nothing staged. Use 'git add' first.", file=sys.stderr)
+            sys.exit(0)
+        if not last_msg:
+            # --amend with nothing staged and no retrievable prior commit
+            # message would produce a near-empty prompt; abort early.
+            print(
+                "Nothing staged and no prior commit message found. "
+                "Stage changes or ensure HEAD exists before amending.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
     msgs = _build_messages(diff, status, log, context, root, last_msg, instr)
 
-    print(f"Generating commit message using {model} via {backend}…", file=sys.stderr)
+    # Auto-escalate to a free high-context model when the prompt is large and
+    # the user has not explicitly chosen a model.  This avoids degraded output
+    # (or silent truncation) from Haiku on large diffs without spending budget
+    # on azure models unnecessarily.
+    if (
+        backend == "kilo"
+        and not model_explicit
+        and not _KILO_MODEL_PINNED_BY_ENV
+        and sum(len(m["content"]) for m in msgs) > _ESCALATION_THRESHOLD_CHARS
+    ):
+        model = _ESCALATION_MODEL_KILO
+        print(
+            f"Prompt exceeds {_ESCALATION_THRESHOLD_CHARS:,} chars — "
+            f"escalating to {_ESCALATION_MODEL_KILO}.",
+            file=sys.stderr,
+        )
+
+    print(
+        f"Generating commit message using {model if model else '<auto>'} via {backend}…",
+        file=sys.stderr,
+    )
 
     # For the copilot backend, exchange the OAuth token for a short-lived one.
+    # Explicitly resolve a GitHub OAuth token rather than using tok directly —
+    # tok may be a non-GitHub key (e.g. GIT_AI_COMMIT_TOKEN set to a LiteLLM
+    # API key) that cannot be exchanged for a Copilot token.
     if backend == "copilot":
         try:
-            tok = _copilot_token(tok)
+            gh_tok = _gh_oauth_token()
+            if not gh_tok:
+                raise _Error("No GitHub OAuth token found for Copilot backend.")
+            tok = _copilot_token(gh_tok)
         except _Error as exc:
             print(f"git-ai-commit: {exc}", file=sys.stderr)
             sys.exit(1)
 
     try:
-        message = _chat(tok, api_base, model, msgs)
+        if backend in ("antigravity", "agy"):
+            message = _chat_antigravity(model, msgs)
+        else:
+            message = _chat(tok, api_base, model, msgs)
     except _APIError as primary_err:
         # If GitHub Models fails with an auth or connectivity error, retry via
         # the Copilot API.  This fallback is specific to the github-models
@@ -711,7 +932,14 @@ def main() -> None:
                 file=sys.stderr,
             )
             try:
-                copilot_tok = _copilot_token(tok)
+                # The Copilot token exchange requires a GitHub OAuth token.
+                # Re-resolve one explicitly rather than reusing tok, which
+                # may be a non-GitHub key (e.g. GIT_AI_COMMIT_TOKEN set to a
+                # LiteLLM API key).
+                gh_tok = _gh_oauth_token()
+                if not gh_tok:
+                    raise _Error("No GitHub OAuth token found for Copilot fallback.")
+                copilot_tok = _copilot_token(gh_tok)
                 message = _chat(copilot_tok, _COPILOT_API_BASE, model, msgs)
             except _Error as exc:
                 print(f"git-ai-commit: {exc}", file=sys.stderr)
@@ -742,9 +970,12 @@ def main() -> None:
         print("Aborted.", file=sys.stderr)
         sys.exit(0)
 
-    cmd = ["git", "commit"] + (["--amend"] if args.amend else []) + ["-m", message]
-    if args.no_verify:
-        cmd.append("--no-verify")
+    cmd = ["git", "commit"]
+    if args.amend:
+        cmd.append("--amend")
+    cmd += ["-m", message]
+    if extra_git_args:
+        cmd += extra_git_args
     try:
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as exc:

--- a/scripts/man/man1/git-ai-commit.1
+++ b/scripts/man/man1/git-ai-commit.1
@@ -1,0 +1,266 @@
+.\" git-ai-commit(1) — commit staged changes with an AI-generated message.
+.\" To make this page available via `git help ai-commit`, add the directory
+.\" containing this file's parent (scripts/man) to MANPATH:
+.\"   export MANPATH="$MANPATH:/path/to/phlex/scripts/man"
+.\" or symlink/copy it to $(git --man-path)/man1/git-ai-commit.1.
+.TH GIT\-AI\-COMMIT 1 "" "phlex" "Git AI Tools"
+.SH NAME
+git\-ai\-commit \- commit staged changes with an AI\-generated message
+.SH SYNOPSIS
+.nf
+\fBgit\-ai\-commit\fR [\fIOPTIONS\fR] [\fB\-\-\fR \fIGIT\-COMMIT\-OPTIONS\fR]
+\fBgit ai\-commit\fR [\fIOPTIONS\fR] [\fB\-\-\fR \fIGIT\-COMMIT\-OPTIONS\fR]
+\fBecho\fR \fI"context"\fR | \fBgit ai\-commit\fR \fB\-\-yes\fR
+.fi
+.SH DESCRIPTION
+\fBgit\-ai\-commit\fR analyses the Git index of the current repository and
+generates a detailed, informative commit message using a language model.
+It then optionally runs \fBgit commit\fR with the generated message.
+.PP
+The tool follows the git subcommand plugin convention: because the script is
+named \fBgit\-ai\-commit\fR and resides on \fBPATH\fR, Git recognises it as
+\fBgit ai\-commit\fR.
+.PP
+Supplemental context can be piped on standard input:
+.PP
+.RS 4
+.nf
+echo "Fixes #42" | git ai\-commit \-\-yes
+.fi
+.RE
+.SH CONTEXT SOURCES
+The following sources are read automatically and included in the prompt
+sent to the language model.  Pass \fB\-\-no\-instructions\fR to suppress all
+sources except the diff, status, and log.
+.TP
+\fBStaged diff\fR
+Output of \fBgit diff \-\-cached \-\-stat \-p\fR.
+.TP
+\fBGit status\fR
+Output of \fBgit status \-\-short\fR.
+.TP
+\fBRecent commits\fR
+Output of \fBgit log \-\-oneline \-10\fR.
+.TP
+\fBRepository guidance\fR
+\fBAGENTS.md\fR, \fBAGENT.md\fR, \fBGEMINI.md\fR, \fBCLAUDE.md\fR, \fBCONTEXT.md\fR,
+\fBINSTRUCTIONS.md\fR, \fBCONTRIBUTING.md\fR, \fBHACKING.md\fR, \fBARCHITECTURE.md\fR,
+\fBSTYLEGUIDE.md\fR, \fB.cursorrules\fR, \fB.clinerules\fR, \fB.windsurfrules\fR,
+\fBq.rules\fR, \fB.kilocoderules\fR, \fB.gemini\-rules\fR.
+.TP
+\fBTool\-specific rules\fR
+\fB.kilo/agent/\fR, \fB.kilo/command/\fR, \fB.amazonq/rules/\fR, \fB.kiro/rules/\fR,
+\fB.kiro/steering/\fR, \fB.gemini/rules/\fR, \fB.kilocode/\fR,
+\fB.github/copilot\-instructions.md\fR.
+These are skipped when \fBAGENTS.md\fR or \fBAGENT.md\fR is present and
+non\-empty, since those files are intended to synthesise the tool\-specific
+rules.
+.TP
+\fBUser\-level instructions\fR
+\fB~/.config/git\-ai\-commit/instructions.md\fR (primary),
+\fB~/.config/copilot/instructions.md\fR (fallback).
+.TP
+\fBGit commit template\fR
+The file referenced by \fBgit config commit.template\fR, if set.
+.SH OPTIONS
+.TP
+\fB\-\-amend\fR
+Amend the previous commit.  The prior commit message is included as
+context so the model can revise it based on the newly staged changes.
+Mutually exclusive with \fB\-\-dry\-run\fR in effect (the generated message is
+still shown for confirmation).
+.TP
+\fB\-\-context\fR \fITEXT\fR
+Additional context or instructions to append to the prompt.  Useful for
+noting issue numbers, rationale, or constraints the model should consider.
+Context provided on standard input is appended after any \fB\-\-context\fR text.
+.TP
+\fB\-\-backend\fR \fIBACKEND\fR
+API backend to use.  One of \fBkilo\fR (default), \fBgithub\-models\fR,
+\fBcopilot\fR, \fBantigravity\fR, or \fBagy\fR.  See \fBBACKENDS\fR below.
+Overridden by the \fBGIT_AI_COMMIT_BACKEND\fR environment variable.
+.TP
+\fB\-\-model\fR \fIMODEL\fR
+Model name to use.  Defaults to \fBazure/claude\-haiku\-4\-5\fR for the
+\fBkilo\fR backend, \fBgpt\-4o\fR for other backends, and none for the
+\fBantigravity\fR backend (which lets the CLI use its default model).
+When the \fBkilo\fR backend is selected and the model was not explicitly
+specified (neither via \fB\-\-model\fR nor via \fBGIT_AI_COMMIT_KILO_MODEL\fR /
+\fBGIT_AI_COMMIT_MODEL\fR), large prompts (>\~30,000 characters) are
+automatically escalated to \fBqwen/qwen3\-coder\-next\fR to avoid silent
+truncation.
+Overridden by the \fBGIT_AI_COMMIT_MODEL\fR environment variable.
+.TP
+\fB\-\-api\fR \fIURL\fR
+Override the API base URL.  Useful when pointing at a local or
+alternative LiteLLM proxy.
+Overridden by the \fBGIT_AI_COMMIT_API\fR environment variable.
+.TP
+\fB\-\-dry\-run\fR
+Generate the commit message and print it to standard output without
+running \fBgit commit\fR.  Useful for scripting or inspection.
+.TP
+\fB\-y\fR, \fB\-\-yes\fR
+Skip the interactive confirmation prompt and commit immediately.
+.TP
+\fB\-e\fR, \fB\-\-edit\fR
+Open the generated message in \fB$EDITOR\fR (falling back to \fB$VISUAL\fR,
+then \fBvi\fR) before committing.  Lines beginning with \fB#\fR are stripped.
+An empty message aborts the commit.
+.TP
+\fB\-\-no\-instructions\fR
+Skip all instruction and context files; include only the diff, status,
+and recent log in the prompt.  Reduces token usage and latency.
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print a short usage summary and exit.
+.TP
+\fB\-\-\fR \fIGIT\-COMMIT\-OPTIONS\fR
+Everything after the \fB\-\-\fR separator is forwarded verbatim to
+\fBgit commit\fR without interpretation.  Use this to pass options that
+\fBgit\-ai\-commit\fR does not handle directly, for example:
+.RS 8
+.nf
+git ai\-commit \-\-yes \-\- \-\-no\-verify \-\-signoff
+git ai\-commit \-\-yes \-\- \-\-gpg\-sign=KEYID
+.fi
+.RE
+.SH BACKENDS
+.TP
+\fBkilo\fR
+LiteLLM\-compatible endpoint using kilo credentials.  The default
+endpoint and model are tuned for the FNAL deployment; override via
+environment variables (see \fBENVIRONMENT\fR below).
+Token resolution order:
+.RS 8
+.IP "1." 4
+\fBGIT_AI_COMMIT_TOKEN\fR
+.IP "2." 4
+\fB~/.local/share/kilo/auth.json\fR (\fIfnal\-litellm\fR key)
+.IP "3." 4
+\fBGITHUB_TOKEN\fR / \fBGH_TOKEN\fR
+.IP "4." 4
+\fBgh auth token\fR
+.IP "5." 4
+\fB~/.config/gh/hosts.yml\fR
+.RE
+.TP
+\fBgithub\-models\fR
+GitHub Models inference API (\fIhttps://models.inference.ai.azure.com\fR).
+Default model: \fBgpt\-4o\fR.
+Falls back to the \fBcopilot\fR backend on HTTP 401 or 403.
+Token resolution order:
+.RS 8
+.IP "1." 4
+\fBGIT_AI_COMMIT_TOKEN\fR
+.IP "2." 4
+\fBGITHUB_TOKEN\fR / \fBGH_TOKEN\fR
+.IP "3." 4
+\fBgh auth token\fR
+.IP "4." 4
+\fB~/.config/gh/hosts.yml\fR
+.RE
+.TP
+\fBcopilot\fR
+GitHub Copilot API (\fIhttps://api.githubcopilot.com\fR).  Exchanges a
+GitHub OAuth token for a short\-lived Copilot bearer token before each
+request.  Default model: \fBgpt\-4o\fR.
+Token resolution order: same as \fBgithub\-models\fR.
+.TP
+\fBantigravity\fR (or \fBagy\fR)
+Antigravity CLI (\fBagy\fR). Runs the prompt non\-interactively via
+\fBagy \-p \-\fR. If a model is specified via \fB\-\-model\fR, it is forwarded
+as \fB\-\-model\fR to \fBagy\fR. Otherwise, \fBagy\fR uses its default
+configured model. No API token or URL resolution is required for this
+backend.
+.SH ENVIRONMENT
+.TP
+\fBGIT_AI_COMMIT_TOKEN\fR
+API token.  Takes precedence over all other token sources for all
+backends.
+.TP
+\fBGIT_AI_COMMIT_MODEL\fR
+Default model name.  Overrides the backend default and suppresses
+auto\-escalation.
+.TP
+\fBGIT_AI_COMMIT_API\fR
+API base URL override.  Applied before the backend default.
+.TP
+\fBGIT_AI_COMMIT_BACKEND\fR
+Default backend (\fBkilo\fR, \fBgithub\-models\fR, \fBcopilot\fR, \fBantigravity\fR, or \fBagy\fR).
+.TP
+\fBGIT_AI_COMMIT_KILO_API\fR
+Base URL for the \fBkilo\fR backend.  Default: \fIhttps://litellm.fnal.gov/v1\fR.
+.TP
+\fBGIT_AI_COMMIT_KILO_MODEL\fR
+Default model for the \fBkilo\fR backend.  Default: \fBazure/claude\-haiku\-4\-5\fR.
+Setting this variable suppresses auto\-escalation even for large prompts.
+.TP
+\fBGIT_AI_COMMIT_KILO_PROVIDER\fR
+Provider key in \fB~/.local/share/kilo/auth.json\fR.  Default: \fBfnal\-litellm\fR.
+.TP
+\fBEDITOR\fR, \fBVISUAL\fR
+Editor invoked by \fB\-\-edit\fR.  Checked in order; \fBvi\fR is the final fallback.
+.SH EXAMPLES
+Stage all changes and commit with a generated message, confirming interactively:
+.PP
+.RS 4
+.nf
+git add \-p
+git ai\-commit
+.fi
+.RE
+.PP
+Amend the last commit with an updated message reflecting new staged changes:
+.PP
+.RS 4
+.nf
+git add \-u
+git ai\-commit \-\-amend \-\-yes
+.fi
+.RE
+.PP
+Preview the generated message without committing:
+.PP
+.RS 4
+.nf
+git ai\-commit \-\-dry\-run
+.fi
+.RE
+.PP
+Commit immediately, skipping pre\-commit hooks, using the copilot backend:
+.PP
+.RS 4
+.nf
+git ai\-commit \-\-backend copilot \-\-yes \-\- \-\-no\-verify
+.fi
+.RE
+.PP
+Provide extra context from stdin:
+.PP
+.RS 4
+.nf
+echo "Closes #1234; keep message terse" | git ai\-commit \-\-yes
+.fi
+.RE
+.SH FILES
+.TP
+\fB~/.local/share/kilo/auth.json\fR
+Kilo credentials file; read for the \fBfnal\-litellm\fR provider key.
+.TP
+\fB~/.config/git\-ai\-commit/instructions.md\fR
+User\-level instructions included in every prompt.
+.TP
+\fBscripts/man/man1/git\-ai\-commit.1\fR
+This man page.  To make it available via \fBgit help ai\-commit\fR, add
+\fBscripts/man\fR to \fBMANPATH\fR:
+.RS 8
+.nf
+export MANPATH="$MANPATH:$(git rev\-parse \-\-show\-toplevel)/scripts/man"
+.fi
+.RE
+.SH SEE ALSO
+\fBgit\-commit\fR(1), \fBgit\-add\fR(1), \fBgit\-diff\fR(1)
+.SH AUTHORS
+Developed as part of the Phlex project
+(\fIhttps://github.com/Framework\-R\-D/phlex\fR).

--- a/scripts/test/test_git_ai_commit.py
+++ b/scripts/test/test_git_ai_commit.py
@@ -10,12 +10,20 @@ Coverage focuses on the three functions that received error-handling changes:
 - _kilo_auth_token  isinstance-based JSON structure validation
 - _gh_cli_token     explicit return None for non-zero / missing gh exit
 - _edit             FileNotFoundError and CalledProcessError surfaced as _Error
+
+Plus new tests for staged changes:
+
+- _gh_oauth_token   returns GitHub OAuth token (not LiteLLM keys)
+- _clean_message    strips model preamble and fenced code blocks
+- _KILO_MODEL_PINNED_BY_ENV, _ESCALATION_* constants
+- Empty staged change handling
 """
 
 from __future__ import annotations
 
 import importlib.machinery
 import importlib.util
+import io
 import json
 import subprocess
 import sys
@@ -42,8 +50,12 @@ _loader.exec_module(_M)
 # pylint: disable=protected-access
 _kilo_auth_token: Callable[[], str | None] = _M._kilo_auth_token  # type: ignore[attr-defined]
 _gh_cli_token: Callable[[], str | None] = _M._gh_cli_token  # type: ignore[attr-defined]
+_gh_oauth_token: Callable[[], str | None] = _M._gh_oauth_token  # type: ignore[attr-defined]
+_clean_message: Callable[[str], str] = _M._clean_message  # type: ignore[attr-defined]
 _edit: Callable[[str], str] = _M._edit  # type: ignore[attr-defined]
+_chat_antigravity: Callable[[str, list[dict[str, str]]], str] = _M._chat_antigravity  # type: ignore[attr-defined]
 _Error: type[Exception] = _M._Error  # type: ignore[attr-defined]
+_APIError: type[Exception] = _M._APIError  # type: ignore[attr-defined]
 # pylint: enable=protected-access
 
 
@@ -201,6 +213,244 @@ class TestGhCliToken:
 
 
 # ===========================================================================
+# _gh_oauth_token
+# ===========================================================================
+
+
+class TestGhOAuthToken:
+    """_gh_oauth_token returns a GitHub OAuth token.
+
+    This deliberately ignores GIT_AI_COMMIT_TOKEN because that variable may
+    hold a non-GitHub key (e.g. a LiteLLM API key). Used when a genuine
+    GitHub OAuth token is required, such as the Copilot token exchange.
+    """
+
+    def test_github_token_env_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GITHUB_TOKEN env var is used when set."""
+        for var in ("GIT_AI_COMMIT_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "ghs_oauth_token_123")
+        with patch.multiple(
+            _M,
+            _gh_cli_token=lambda: None,
+            _gh_config_token=lambda: None,
+        ):
+            assert _gh_oauth_token() == "ghs_oauth_token_123"
+
+    def test_github_token_env_used_first(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GITHUB_TOKEN takes precedence when both are set."""
+        for var in ("GIT_AI_COMMIT_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("GH_TOKEN", "ghs_oauth_token_abc")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghs_oauth_token_xyz")
+        with patch.multiple(
+            _M,
+            _gh_cli_token=lambda: None,
+            _gh_config_token=lambda: None,
+        ):
+            # GITHUB_TOKEN is checked first in _gh_oauth_token
+            assert _gh_oauth_token() == "ghs_oauth_token_xyz"
+
+    def test_gh_cli_token_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Falls back to gh CLI if no env vars set."""
+        for var in ("GIT_AI_COMMIT_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        mock_result = subprocess.CompletedProcess(
+            ["gh", "auth", "token"], returncode=0, stdout="ghs_cli_token\n", stderr=""
+        )
+        with patch("subprocess.run", return_value=mock_result):
+            with patch.multiple(
+                _M,
+                _gh_config_token=lambda: None,
+            ):
+                assert _gh_oauth_token() == "ghs_cli_token"
+
+    def test_gh_config_token_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Falls back to ~/.config/gh/hosts.yml if gh CLI not available."""
+        for var in ("GIT_AI_COMMIT_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with patch.multiple(
+                _M,
+                _gh_config_token=lambda: "ghs_hosts_file_token",
+            ):
+                assert _gh_oauth_token() == "ghs_hosts_file_token"
+
+    def test_git_ai_commit_token_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GIT_AI_COMMIT_TOKEN is deliberately ignored for GitHub OAuth."""
+        monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "not_a_github_oauth_token")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with patch.multiple(
+                _M,
+                _gh_config_token=lambda: "ghs_oauth_token_from_hosts",
+            ):
+                assert _gh_oauth_token() == "ghs_oauth_token_from_hosts"
+
+    def test_no_token_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No token sources available → None."""
+        for var in ("GIT_AI_COMMIT_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with patch.multiple(
+                _M,
+                _gh_config_token=lambda: None,
+            ):
+                assert _gh_oauth_token() is None
+
+
+# ===========================================================================
+# _clean_message
+# ===========================================================================
+
+
+class TestCleanMessage:
+    """_clean_message strips model preamble and fenced code blocks."""
+
+    def test_fenced_code_block_extracted(self) -> None:
+        """Content inside a fenced code block is extracted; the language tag is dropped."""
+        raw = (
+            "Here is the commit message:\n\n```text\nfeat: add new feature\n\n"
+            "- Implementation details\n```\n\nThat's all!"
+        )
+        expected = "feat: add new feature\n\n- Implementation details"
+        assert _clean_message(raw) == expected
+
+    def test_fenced_code_block_preserves_language_tag_content(self) -> None:
+        """Language tag after ``` is discarded, content is preserved."""
+        raw = """```json\n{\n  "message": "feat: add new feature"\n}\n```\n"""
+        expected = '{\n  "message": "feat: add new feature"\n}'
+        assert _clean_message(raw) == expected
+
+    def test_leading_prose_preamble_stripped(self) -> None:
+        """Lines ending with ':' followed by blank line are removed."""
+        raw = "Here is the commit message:\n\nfeat: add new feature\n\nAdditional context here."
+        expected = "feat: add new feature\n\nAdditional context here."
+        assert _clean_message(raw) == expected
+
+    def test_multiple_leading_preamble_lines_stripped(self) -> None:
+        """Multiple prose preamble lines are all removed."""
+        raw = (
+            "I have analyzed the changes.\n\nHere is the commit message:\n\nfeat: add new feature"
+        )
+        expected = "feat: add new feature"
+        assert _clean_message(raw) == expected
+
+    def test_no_preamble_returns_cleaned(self) -> None:
+        """Message without preamble is returned stripped."""
+        raw = "feat: add new feature  \n  \n  Some context.\n  "
+        expected = "feat: add new feature  \n  \n  Some context."
+        assert _clean_message(raw) == expected
+
+    def test_only_preamble_returns_empty(self) -> None:
+        """Message consisting only of prose preamble becomes empty."""
+        raw = "Here is the commit message:\n\n"
+        assert _clean_message(raw) == ""
+
+    def test_empty_string_returns_empty(self) -> None:
+        """Empty string returns empty string."""
+        assert _clean_message("") == ""
+
+    def test_fenced_code_with_no_language(self) -> None:
+        """Fence without language tag works correctly."""
+        raw = "```\nfeat: add new feature\n```\n"
+        expected = "feat: add new feature"
+        assert _clean_message(raw) == expected
+
+    def test_conventional_commit_subject_not_stripped(self) -> None:
+        """A clean conventional-commit message is never treated as preamble."""
+        raw = "fix: broken:\n\nActual body."
+        assert _clean_message(raw) == "fix: broken:\n\nActual body."
+
+    def test_conventional_commit_with_scope_not_stripped(self) -> None:
+        """A scoped conventional-commit subject is not treated as preamble."""
+        raw = "feat(api): add endpoint\n\nWired up the new handler."
+        assert _clean_message(raw) == raw
+
+    def test_breaking_change_subject_not_stripped(self) -> None:
+        """A breaking-change (!) conventional-commit subject is not treated as preamble."""
+        raw = "refactor!: rename all the things\n\nOld names were confusing."
+        assert _clean_message(raw) == raw
+
+
+# ===========================================================================
+# _KILO_MODEL_PINNED_BY_ENV constant
+# ===========================================================================
+
+
+class TestKiloModelPinnedByEnv:
+    """_KILO_MODEL_PINNED_BY_ENV is evaluated at import time."""
+
+    def test_constant_exists(self) -> None:
+        """_KILO_MODEL_PINNED_BY_ENV constant exists."""
+        assert hasattr(_M, "_KILO_MODEL_PINNED_BY_ENV")
+        assert isinstance(_M._KILO_MODEL_PINNED_BY_ENV, bool)
+
+
+# ===========================================================================
+# Empty staged change handling
+# ===========================================================================
+
+# _build_messages is used to verify the prompt wiring; pull it from the module.
+# pylint: disable=protected-access
+_build_messages = _M._build_messages  # type: ignore[attr-defined]
+# pylint: enable=protected-access
+
+
+class TestEmptyStagedChanges:
+    """Tests for the empty-diff guard introduced in main().
+
+    The guard has two branches:
+    - no --amend: exit 0 immediately with a hint message.
+    - --amend + no prior commit message: exit 1 with a descriptive message.
+
+    We test the detection logic by examining what _build_messages receives, and
+    also verify that the guard condition itself (`not diff.strip()`) is triggered
+    by the values that `_staged_diff` would return for an empty index.
+    """
+
+    def test_main_exits_0_when_no_staged_changes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """No staged diff and no --amend exits 0 with a hint message."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        monkeypatch.setattr(_M, "_token", lambda _backend: "tok")
+        # Simulate a non-tty (pipe) stdin with no content so the stdin-read
+        # branch is exercised without touching pytest's capture machinery.
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+
+        with pytest.raises(SystemExit) as exc:
+            _M.main()
+
+        assert exc.value.code == 0
+        _, err = capsys.readouterr()
+        assert "Nothing staged" in err
+
+    def test_build_messages_includes_diff_when_nonempty(self, tmp_path: Path) -> None:
+        """_build_messages embeds the diff verbatim in the user message when non-empty."""
+        diff = "diff --git a/foo.py b/foo.py\n+new line\n"
+        msgs = _build_messages(diff, "", "", "", tmp_path)
+        user_content = msgs[1]["content"]
+        assert diff in user_content
+
+    def test_build_messages_with_last_msg_for_amend(self, tmp_path: Path) -> None:
+        """When --amend provides a prior message, it appears in the prompt even with empty diff."""
+        prior = "fix: previous commit subject"
+        msgs = _build_messages("", "", "", "", tmp_path, last_msg=prior)
+        user_content = msgs[1]["content"]
+        assert prior in user_content
+
+
+# ===========================================================================
 # _edit
 # ===========================================================================
 
@@ -300,3 +550,129 @@ class TestEdit:
             with patch("pathlib.Path.read_text", side_effect=OSError("disk error")):
                 with pytest.raises(_Error, match="Could not read"):
                     _edit("original")
+
+
+# ===========================================================================
+# Antigravity Backend Tests
+# ===========================================================================
+
+
+class TestAntigravityBackend:
+    """Tests for the antigravity/agy backend."""
+
+    def test_resolve_backend_and_api(self) -> None:
+        """_resolve_backend_and_api returns empty string for antigravity/agy."""
+        backend, api = _M._resolve_backend_and_api("antigravity", "http://ignored")
+        assert backend == "antigravity"
+        assert api == ""
+
+        backend, api = _M._resolve_backend_and_api("agy", "")
+        assert backend == "agy"
+        assert api == ""
+
+    def test_default_model(self) -> None:
+        """_default_model returns empty string for antigravity/agy."""
+        assert _M._default_model("antigravity") == ""
+        assert _M._default_model("agy") == ""
+
+    def test_chat_antigravity_success_no_model(self) -> None:
+        """_chat_antigravity runs agy successfully without model."""
+        messages = [
+            {"role": "system", "content": "system instruction"},
+            {"role": "user", "content": "user query"},
+        ]
+
+        mock_completed = subprocess.CompletedProcess(
+            args=["agy", "-p", "-"],
+            returncode=0,
+            stdout="Generated Commit Message\n",
+            stderr="",
+        )
+
+        with patch("subprocess.run", return_value=mock_completed) as mock_run:
+            res = _chat_antigravity("", messages)
+            assert res == "Generated Commit Message"
+            mock_run.assert_called_once()
+            cmd, kwargs = mock_run.call_args
+            assert cmd[0] == ["agy", "-p", "-"]
+            assert kwargs["input"] == "System Instructions:\nsystem instruction\n\nuser query"
+
+    def test_chat_antigravity_success_with_model(self) -> None:
+        """_chat_antigravity runs agy successfully with model."""
+        messages = [
+            {"role": "user", "content": "user query"},
+        ]
+
+        mock_completed = subprocess.CompletedProcess(
+            args=["agy", "-p", "-", "--model", "my-model"],
+            returncode=0,
+            stdout="Generated Commit Message\n",
+            stderr="",
+        )
+
+        with patch("subprocess.run", return_value=mock_completed) as mock_run:
+            res = _chat_antigravity("my-model", messages)
+            assert res == "Generated Commit Message"
+            mock_run.assert_called_once()
+            cmd, kwargs = mock_run.call_args
+            assert cmd[0] == ["agy", "-p", "-", "--model", "my-model"]
+            assert kwargs["input"] == "user query"
+
+    def test_chat_antigravity_file_not_found(self) -> None:
+        """_chat_antigravity raises _Error if agy CLI is not found."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(_Error, match="not found in PATH"):
+                _chat_antigravity("my-model", [])
+
+    def test_chat_antigravity_nonzero_exit(self) -> None:
+        """_chat_antigravity raises _APIError if agy CLI fails."""
+        mock_completed = subprocess.CompletedProcess(
+            args=["agy"],
+            returncode=1,
+            stdout="",
+            stderr="invalid model",
+        )
+        with patch("subprocess.run", return_value=mock_completed):
+            with pytest.raises(_APIError, match="failed \\(exit code 1\\)"):
+                _chat_antigravity("my-model", [])
+
+    def test_main_with_antigravity_backend(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """main runs successfully with antigravity backend."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit", "--backend", "antigravity", "--yes"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "some diff")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        # Simulate a non-tty (pipe) stdin with no content.
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+
+        mock_completed = subprocess.CompletedProcess(
+            args=["agy", "-p", "-"],
+            returncode=0,
+            stdout="feat: mock commit message\n",
+            stderr="",
+        )
+
+        with patch(
+            "subprocess.run",
+            side_effect=[mock_completed, subprocess.CompletedProcess([], 0)],
+        ) as mock_run:
+            _M.main()
+
+            # The first call should be to 'agy' to generate the commit message.
+            # The second call should be 'git commit' with the message.
+            assert mock_run.call_count == 2
+
+            # Check the first call (agy)
+            agy_cmd = mock_run.call_args_list[0][0][0]
+            assert "agy" in agy_cmd
+
+            # Check the second call (git commit)
+            git_cmd = mock_run.call_args_list[1][0][0]
+            assert git_cmd == ["git", "commit", "-m", "feat: mock commit message"]

--- a/scripts/test/test_git_ai_commit.py
+++ b/scripts/test/test_git_ai_commit.py
@@ -642,7 +642,7 @@ class TestAntigravityBackend:
         tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """main runs successfully with antigravity backend."""
+        """Main runs successfully with antigravity backend."""
         monkeypatch.setattr(sys, "argv", ["git-ai-commit", "--backend", "antigravity", "--yes"])
         monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
         monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "some diff")


### PR DESCRIPTION
- **Attempt to prevent model errors with `qwen/qwen3-coder-next`**
- **Update pre-commit tools**
- **Support kilo (+ optional headroom proxy) in devcontainers**
- **Add Antigravity backend and man page git-ai-commit**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Development Container / Devcontainer tooling
- **Dockerfile**
  - Restored normal `man` behavior: removed Ubuntu dpkg manpage/doc excludes, installed `man-db`, `groff`, `mandoc`, reinstalled `git`/`git-man`, and removed the `/usr/bin/man` dpkg-divert stub when present.
  - Updated nested-container tooling install to include **`ssh`** alongside **`podman`** and **`socat`**.
- **devcontainer.json**
  - Added `runArgs: []`.
  - Updated Kilo configuration wiring: added `KILO_CONFIG_CONTENT_DOCKER` (with explanatory comments) and set `KILO_API_KEY` from `HEADROOM_UPSTREAM_KEY`, replacing prior `KILO_CONFIG_CONTENT` usage.
  - Updated mounts: added/reordered mounts and mounted a dedicated named volume `phlex-kilo-data` at `/root/.local/share/kilo` for Kilo state.
  - Editor setting: set `kilocode.new.extraCaCerts` to an empty string to suppress certificate prompts.
- **ensure-repos.sh**
  - Added helpers:
    - `ensure_bind_dir()` for creating reusable bind-mount source directories.
    - `start_socat_relay(...)` with readiness probing and standardized relay start/stop/logging.
  - Refactored **Podman socket proxy** logic to use the new helpers and hardened proxy dir permissions (`0700`).
  - Added **Headroom proxy** support via a `socat` relay (only when the headroom port is listening on `127.0.0.1`), enabling access for rootless Podman containers.
  - Ensured additional host bind-mount source dirs exist (e.g. `~/.aws`, `~/.config/{gh,kilo}`, `~/.gnupg`, `~/.kiro`, `~/.vscode-remote-user-data`).
- **post-create.sh**
  - Kilo shell/runtime wiring:
    - When `KILO_CONFIG_CONTENT_DOCKER` is set, exported `KILO_CONFIG_CONTENT` pointing at `host.docker.internal`.
    - When `KILO_API_KEY` is provided, seeded container-private Kilo auth at `/root/.local/share/kilo/auth.json` (mode `0600`) in the mounted volume.
  - Exposed repo helper as a `git` subcommand by symlinking `git-ai-commit` into `/usr/local/bin`.
  - Restored man-page usability by prepending the repo manpage directory to `MANPATH` via a `/root/.bashrc` helper.
## AI integration / `git-ai-commit` enhancements
- **scripts/git-ai-commit**
  - Added **Antigravity backend (`agy`)** integration:
    - Implemented `_chat_antigravity()` that invokes `agy` (optionally `--model`), handles missing CLI / timeout / non-zero exit errors, and normalizes output.
    - Extended backend routing to support `antigravity`/`agy`; updated default-model behavior so `agy` can use its own defaults unless `--model` is specified.
  - **Model error prevention / large-prompt handling for Kilo**
    - Added prompt-conditioning constants driven by `GIT_AI_COMMIT_KILO_MODEL`.
    - Implemented large-prompt **automatic escalation** (threshold ~30,000 chars) to a higher-context model (qwen/qwen3-coder-next-like), while supporting an environment “pinned” flag to suppress escalation.
    - Improved output robustness:
      - Tightened system prompt rules so model output must be **only the commit message** (no prose/preamble/code fences).
      - Added `_clean_message()` to extract fenced blocks when present and strip safe leading prose (guarded to avoid treating conventional-commit subjects as preambles).
  - CLI behavior improvements
    - Updated `main()` argument parsing to split on the first `--` and forward post-`--` arguments verbatim to `git commit`.
    - Forwarded extra git args after `git commit -m <message>` and removed the need for script-level `--no-verify` handling.
    - Added more explicit GitHub OAuth token resolution (`_gh_oauth_token()`), with precedence that **ignores `GIT_AI_COMMIT_TOKEN`**.
  - Instruction discovery expansion
    - Included `.kilo/agent/` and `.kilo/command/` instruction sources when no authoritative `AGENTS.md`/`AGENT.md` is present.
  - Interactive confirmation robustness
    - Refactored `_confirm` to manage `/dev/tty` via `contextlib.ExitStack`.
- **scripts/man/man1/git-ai-commit.1**
  - Added complete man page for `git ai-commit` / `git-ai-commit` covering behavior, option surface, backend/API selection (including `antigravity`/`agy`), environment variables, escalation rules, examples, and references.
## Code quality / tooling
- **.pre-commit-config.yaml**
  - Updated multiple hook versions for improved checks:
    - `ruff-pre-commit`, `mirrors-clang-format`, `gersemi`→`gersemi-pre-commit`, `mirrors-prettier`, `markdownlint-cli2`.
## Tests
- **scripts/test/test_git_ai_commit.py**
  - Expanded coverage for:
    - GitHub OAuth token precedence / fallback behavior (ignoring `GIT_AI_COMMIT_TOKEN`).
    - Commit-message cleaning (`_clean_message`) for prose stripping and fenced-block extraction.
    - Kilo pinned-model env constant validation.
    - Empty staged-diff behavior (including amend cases and prompt wiring).
    - Antigravity backend/API resolution and `agy` invocation/error handling, plus `main()` integration assertions (subprocess call order/message).
  - Added typed aliases for dynamically loaded internals (`_gh_oauth_token`, `_clean_message`, `_chat_antigravity`, `_APIError`).
## Docs / agent guidance
- **AGENTS.md**
  - Clarified constraints for the `read` tool: `offset` must be an integer and `limit` must use integer values.
## Security / CI
- Addressed **7 CodeQL alerts** for unpinned internal GitHub Actions (`actions/unpinned-tag`) across multiple workflow/action YAML files by ensuring internal action references use pinned commit hashes instead of `ref: main`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->