### PR TITLE
Use `zendesk/setup-jsonnet` action for reliable `go-jsonnet` retrieval

### DIFF
--- a/.github/workflows/jsonnet-format-check.yaml
+++ b/.github/workflows/jsonnet-format-check.yaml
@@ -75,9 +75,6 @@ jobs:
         needs.setup.outputs.has_changes == 'true'
       )
     runs-on: ubuntu-latest
-    container:
-      image: docker.io/dysnix/jsonnet:latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -86,6 +83,12 @@ jobs:
           repository: ${{ needs.setup.outputs.repo }}
           path: ${{ needs.setup.outputs.checkout_path }}
           persist-credentials: false
+
+      - name: Setup jsonnet
+        id: setup-jsonnet
+        uses: zendesk/setup-jsonnet@74119dac8a540c99167a65f14aa1ee99ff143ec2 # v16
+        with:
+          github_token: ${{ github.token }}
 
       - name: Check Jsonnet formatting
         id: lint

--- a/.github/workflows/jsonnet-format-check.yaml
+++ b/.github/workflows/jsonnet-format-check.yaml
@@ -88,6 +88,7 @@ jobs:
         id: setup-jsonnet
         uses: zendesk/setup-jsonnet@74119dac8a540c99167a65f14aa1ee99ff143ec2 # v16
         with:
+          version: v0.22.0
           github_token: ${{ github.token }}
 
       - name: Check Jsonnet formatting

--- a/.github/workflows/jsonnet-format-fix.yaml
+++ b/.github/workflows/jsonnet-format-fix.yaml
@@ -100,15 +100,18 @@ jobs:
           repository: ${{ needs.setup.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
 
+      - name: Setup jsonnet
+        id: setup-jsonnet
+        uses: zendesk/setup-jsonnet@74119dac8a540c99167a65f14aa1ee99ff143ec2 # v16
+        with:
+          github_token: ${{ github.token }}
+
       - name: Apply Jsonnet formatting
         id: lint
         env:
           CHECKOUT_PATH: ${{ needs.setup.outputs.checkout_path }}
-        # yamllint disable rule:line-length
         run: |
-          docker run --rm -v "$GITHUB_WORKSPACE:/work" -w /work --user root docker.io/dysnix/jsonnet:latest \
-            sh -c "find \"$CHECKOUT_PATH\" \( -name '*.jsonnet' -o -name '*.libsonnet' \) -print0 | xargs -0 -r jsonnetfmt -i"
-        # yamllint enable
+          find "$CHECKOUT_PATH" \( -name '*.jsonnet' -o -name '*.libsonnet' \) -print0 | xargs -0 -r jsonnetfmt -i
         continue-on-error: true
 
       - name: Handle fix commit

--- a/.github/workflows/jsonnet-format-fix.yaml
+++ b/.github/workflows/jsonnet-format-fix.yaml
@@ -104,6 +104,7 @@ jobs:
         id: setup-jsonnet
         uses: zendesk/setup-jsonnet@74119dac8a540c99167a65f14aa1ee99ff143ec2 # v16
         with:
+          version: v0.22.0
           github_token: ${{ github.token }}
 
       - name: Apply Jsonnet formatting


### PR DESCRIPTION
- Fixes #648 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI/CD

- **Jsonnet tooling provisioning**: Replaced Docker container-based Jsonnet runtime (`docker.io/dysnix/jsonnet:latest`) with explicit action-based setup in both workflows
  - `jsonnet-format-check.yaml`: Added `Setup jsonnet` step using `zendesk/setup-jsonnet@v16` (pinned to `74119dac8a540c99167a65f14aa1ee99ff143ec2`) with `github_token` parameter
  - `jsonnet-format-fix.yaml`: Added `Setup jsonnet` step using the same `zendesk/setup-jsonnet@v16` action with `github_token` parameter

- **Command execution**: Both workflows now execute `jsonnetfmt` directly on the GitHub Actions runner instead of within a Docker container:
  - Check workflow: Uses `jsonnetfmt --test` on all `*.jsonnet` and `*.libsonnet` files to validate formatting
  - Fix workflow: Uses `jsonnetfmt -i` to apply formatting fixes in-place

- **Rationale**: The `zendesk/setup-jsonnet` action provides reliable, automated `go-jsonnet` binary retrieval and setup, improving reproducibility and reducing dependency on external Docker images

<!-- end of auto-generated comment: release notes by coderabbit.ai -->