### PR TITLE
Fix fold-result type

### DIFF
--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -187,7 +187,7 @@ namespace phlex::experimental {
       if constexpr (requires { send(*result); }) {
         store->add_product(output()[0], send(*result));
       } else {
-        store->add_product(output()[0], std::move(result));
+        store->add_product(output()[0], std::move(*result));
       }
       // Reclaim some memory; it would be better to erase the entire entry from the map,
       // but that is not thread-safe.

--- a/test/fold.cpp
+++ b/test/fold.cpp
@@ -30,12 +30,26 @@
 #include "catch2/catch_test_macros.hpp"
 
 #include <atomic>
+#include <numeric>
 #include <string>
+#include <vector>
 
 using namespace phlex;
 
 namespace {
   void add(std::atomic<unsigned int>& counter, unsigned int number) { counter += number; }
+
+  void collect(std::vector<unsigned int>& numbers, unsigned int number)
+  {
+    numbers.push_back(number);
+  }
+
+  void verify_collected_numbers(std::vector<unsigned int> const& actual)
+  {
+    CHECK(actual.size() == 5u);
+    auto const sum = std::accumulate(actual.begin(), actual.end(), 0u);
+    CHECK(sum == 10u);
+  }
 
   // Provider algorithm
   unsigned int provide_number(data_cell_index const& id) { return id.number(); }
@@ -82,4 +96,32 @@ TEST_CASE("Different data layers of fold", "[graph]")
   CHECK(g.execution_count("verify_run_sum") == index_limit);
   CHECK(g.execution_count("verify_two_layer_job_sum") == 1);
   CHECK(g.execution_count("verify_job_sum") == 1);
+}
+
+TEST_CASE("Fold output without send consumed downstream", "[graph]")
+{
+  constexpr auto index_limit = 2u;
+  constexpr auto number_limit = 5u;
+
+  experimental::layer_generator gen;
+  gen.add_layer("run", {"job", index_limit});
+  gen.add_layer("event", {"run", number_limit});
+
+  experimental::framework_graph g{driver_for_test(gen)};
+
+  g.provide("provide_number", provide_number, concurrency::unlimited)
+    .output_product("input", "number", "event");
+
+  g.fold("collect_numbers", collect, concurrency::serial, "run")
+    .input_family(product_selector{.creator = "input", .layer = "event", .suffix = "number"})
+    .output_product_suffixes("numbers");
+
+  g.observe("verify_collected_numbers", verify_collected_numbers, concurrency::serial)
+    .input_family(
+      product_selector{.creator = "collect_numbers", .layer = "run", .suffix = "numbers"});
+
+  g.execute();
+
+  CHECK(g.execution_count("collect_numbers") == std::size_t{index_limit} * number_limit);
+  CHECK(g.execution_count("verify_collected_numbers") == index_limit);
 }


### PR DESCRIPTION
Resolves #641.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Code
- **Fixed incorrect pointer dereference in fold result handling**: Changed `std::move(result)` to `std::move(*result)` in the `commit` method's fallback path (when `send(*result)` is not available), ensuring the underlying object is moved rather than the smart pointer itself
  - This resolves type mismatches where downstream algorithms were incorrectly forced to request `unique_ptr<vector...>` instead of `vector<...>`

## Tests
- **Added test case for fold output without send semantics**: New `TEST_CASE("Fold output without send consumed downstream", "[graph]")` validates fold behavior when downstream consumption doesn't rely on the "send" mechanism
  - Includes helper functions `collect` and `verify_collected_numbers` to validate numeric accumulation and output value collection
  - Test constructs a two-layer graph, performs a fold operation, and verifies correct execution counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->