### PR TITLE
Update CI container image to support Numba and libffi

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -217,7 +217,7 @@ set -euo pipefail
 spack --timestamp install --fail-fast -j "$(nproc)" -p 1 \
       --no-check-signature \
       gcc@15.2 target=x86_64_v3 \
-      +binutils+bootstrap+graphite~nvptx+piclibs+profiled+strip \
+      +binutils+graphite~nvptx+piclibs+strip \
       build_type=Release \
       languages=c,c++,fortran,lto \
       %c,cxx=gcc@13.3.0 # % must be LAST (along with ^ dependencies)
@@ -272,6 +272,11 @@ set -euo pipefail
 # Install core build utilities through Spack for both images
 . /entrypoint.sh
 
+# Recreate the environment view in this layer to avoid cross-layer rename
+# failures (EXDEV) when Spack rotates view -> view.old.<hash>.
+rm -rf "$PHLEX_SPACK_ENV/.spack-env/view"
+rm -rf "$PHLEX_SPACK_ENV"/.spack-env/view.old.*
+
 spack --timestamp install --fail-fast -j $(nproc) -p 1 \
   --no-add --only-concrete --no-check-signature \
   cmake lcov ninja py-gcovr py-pytest-cov py-pyyaml
@@ -321,6 +326,11 @@ set -euo pipefail
 # Install LLVM in its own layer to improve cache reuse
 . /entrypoint.sh
 
+# Recreate the environment view in this layer to avoid cross-layer rename
+# failures (EXDEV) when Spack rotates view -> view.old.<hash>.
+rm -rf "$PHLEX_SPACK_ENV/.spack-env/view"
+rm -rf "$PHLEX_SPACK_ENV"/.spack-env/view.old.*
+
 spack --timestamp install --fail-fast -j $(nproc) -p 1 \
   --no-add --only-concrete --no-check-signature llvm
 
@@ -347,6 +357,11 @@ set -euo pipefail
 
 # Install all concretized packages except phlex to share cache
 . /entrypoint.sh
+
+# Recreate the environment view in this layer to avoid cross-layer rename
+# failures (EXDEV) when Spack rotates view -> view.old.<hash>.
+rm -rf "$PHLEX_SPACK_ENV/.spack-env/view"
+rm -rf "$PHLEX_SPACK_ENV"/.spack-env/view.old.*
 
 spack --timestamp install --fail-fast -j $(nproc) -p 1 \
   --no-add --only-concrete --no-check-signature \
@@ -375,6 +390,11 @@ set -euo pipefail
 
 # Materialize dependencies needed for CI builds without installing Phlex
 . /entrypoint.sh
+
+# Recreate the environment view in this layer to avoid cross-layer rename
+# failures (EXDEV) when Spack rotates view -> view.old.<hash>.
+rm -rf "$PHLEX_SPACK_ENV/.spack-env/view"
+rm -rf "$PHLEX_SPACK_ENV"/.spack-env/view.old.*
 
 spack --timestamp install --fail-fast -j $(nproc) -p 1 \
   --no-add --only-concrete --only dependencies --no-check-signature \

--- a/ci/packages.yaml
+++ b/ci/packages.yaml
@@ -16,8 +16,8 @@
 
 packages:
   all:
-    target:
-      - x86_64_v3
+    require:
+      - target=x86_64_v3
     providers:
       "zlib-api:": [zlib]
 

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -15,7 +15,7 @@ spack:
     - py-pytest-cov # Needed for Python coverage reports
     - py-pyyaml # Needed by run-clang-tidy --export-fixes to merge per-TU fix files
     - |
-      llvm@22.1.3 +zstd +llvm_dylib +link_llvm_dylib ~lldb targets=x86
+      llvm@20.1.8 +zstd +llvm_dylib +link_llvm_dylib ~lldb targets=x86
 
   view:
     default:
@@ -44,6 +44,7 @@ spack:
 
     phlex:
       require:
+        - "@develop"
         - "+form"
         - "cxxstd=23"
         - "%cxx=gcc@15"

--- a/phlex/core/node_catalog.hpp
+++ b/phlex/core/node_catalog.hpp
@@ -16,9 +16,8 @@
 #include "phlex/core/source.hpp"
 #include "phlex/utilities/simple_ptr_map.hpp"
 
-#include "boost/pfr.hpp"
-
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace phlex::experimental {
@@ -26,7 +25,7 @@ namespace phlex::experimental {
     template <typename Ptr>
     auto registrar_for(std::vector<std::string>& errors)
     {
-      return registrar{boost::pfr::get<simple_ptr_map<Ptr>>(*this), errors};
+      return registrar{ptr_map_for<Ptr>(), errors};
     }
 
     std::size_t execution_count(std::string const& node_name) const;
@@ -41,6 +40,35 @@ namespace phlex::experimental {
     simple_ptr_map<declared_transform_ptr> transforms{};
     simple_ptr_map<provider_node_ptr> providers{};
     simple_ptr_map<source_ptr> sources{};
+
+  private:
+    template <typename>
+    static constexpr bool unknown_ptr_type_v{false};
+
+    template <typename Ptr>
+    auto& ptr_map_for()
+    {
+      // Note: We can eventually revert to boost::pfr::get once we move beyond LLVM 20.
+      if constexpr (std::is_same_v<Ptr, declared_predicate_ptr>) {
+        return predicates;
+      } else if constexpr (std::is_same_v<Ptr, declared_observer_ptr>) {
+        return observers;
+      } else if constexpr (std::is_same_v<Ptr, declared_output_ptr>) {
+        return outputs;
+      } else if constexpr (std::is_same_v<Ptr, declared_fold_ptr>) {
+        return folds;
+      } else if constexpr (std::is_same_v<Ptr, declared_unfold_ptr>) {
+        return unfolds;
+      } else if constexpr (std::is_same_v<Ptr, declared_transform_ptr>) {
+        return transforms;
+      } else if constexpr (std::is_same_v<Ptr, provider_node_ptr>) {
+        return providers;
+      } else if constexpr (std::is_same_v<Ptr, source_ptr>) {
+        return sources;
+      } else {
+        static_assert(unknown_ptr_type_v<Ptr>, "Unsupported node pointer type");
+      }
+    }
   };
 }
 

--- a/test/class_registration.cpp
+++ b/test/class_registration.cpp
@@ -52,8 +52,9 @@ namespace {
 
   void verify_results(int number, double temperature, std::string const& name)
   {
-    auto const expected = std::make_tuple(3, 98.5, "John");
-    CHECK(std::tie(number, temperature, name) == expected);
+    CHECK(number == 3);
+    CHECK(temperature == 98.5);
+    CHECK(name == "John");
   }
 }
 

--- a/test/function_registration.cpp
+++ b/test/function_registration.cpp
@@ -46,8 +46,9 @@ namespace {
 
   void verify_results(int number, double temperature, std::string const& name)
   {
-    auto const expected = std::make_tuple(3, 98.5, "John");
-    CHECK(std::tie(number, temperature, name) == expected);
+    CHECK(number == 3);
+    CHECK(temperature == 98.5);
+    CHECK(name == "John");
   }
 
 }


### PR DESCRIPTION
## Build System
- **Dockerfile optimization and updates**:
  - Modified GCC variant flags: Removed `+bootstrap` and `+profiled` variants while retaining `~nvptx` and `+strip`
  - Added cleanup steps: Explicitly remove Spack environment view directories (`$PHLEX_SPACK_ENV/.spack-env/view` and `view.old.*`) before subsequent installs to prevent cross-layer environment view rename issues
  - These changes support addition of Numpy and libffi to the CI environment

## Package Configuration
- **packages.yaml**: Converted global Spack package constraint from `target` list format (`target: - x86_64_v3`) to `require` directive format (`require: - target=x86_64_v3`)
  - Ensures consistent CPU target specification across the build environment
  - Use LLVM 20 (instead of LLVM 22) due to constraint `py-numpy` constraint

## Code changes to accommodate LLVM 20 limitations
- **phlex/code/node_catalog.hpp**: Replaced `boost::pfr::get` usage with wordier implementation when creating registrars
- **phlex/test/class_registration.cpp**: Replaced `std::tuple`-based check with checks of each tuple element
- **phlex/test/function_registration.cpp*: Replaced `std::tuple`-based check with checks of each tuple element