### PR TITLE
Updates and improvements to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,8 @@ repos:
     hooks:
       - id: ruff-format
         types_or: [python, pyi]
+      - id: ruff
+        types_or: [python, pyi]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v22.1.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.16
+    rev: v0.15.19
     hooks:
       - id: ruff-format
         types_or: [python, pyi]
@@ -54,7 +54,7 @@ repos:
         # We therefore exclude them from linting, but still format them.
         exclude: ^test/max-parallelism
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.3
+    rev: v3.8.4
     hooks:
       - id: prettier
         types_or: [yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: ruff
         types_or: [python, pyi]
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.5
+    rev: v20.1.8
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]


### PR DESCRIPTION
- **Add ruff linter to pre-commit checks**
- **Back off to a `clang-format` compatible with the LLVM/Clang we're using**
- **Run `prek auto-update` excluding `clang-format`**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **CI / pre-commit**
  - Updated `.pre-commit-config.yaml` to refresh pre-commit hook repositories.
  - Added/updated the `ruff` linter hooks in the pre-commit setup.
  - Pinned `clang-format` to a version compatible with the current LLVM/Clang toolchain.
  - Ran `prek auto-update` while excluding the `clang-format` repository from that automated update.
  - Also bumped related hook repos, including `ruff-pre-commit` and `prettier`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->