### PR TITLE
Add stage name to handle

### DIFF
--- a/form/storage/istorage.hpp
+++ b/form/storage/istorage.hpp
@@ -7,6 +7,7 @@
 #include "core/token.hpp"
 #include "form/config.hpp"
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/form/storage/istorage.hpp
+++ b/form/storage/istorage.hpp
@@ -7,7 +7,6 @@
 #include "core/token.hpp"
 #include "form/config.hpp"
 
-#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/phlex/core/make_computational_edges.cpp
+++ b/phlex/core/make_computational_edges.cpp
@@ -124,7 +124,6 @@ namespace phlex::experimental {
                           "data products",
                           input_product));
           }
-
           make_edge(node->output_port(), *port);
           providers.try_emplace(provider_name, std::move(node));
         }

--- a/phlex/core/provider_node.cpp
+++ b/phlex/core/provider_node.cpp
@@ -32,7 +32,8 @@ namespace phlex::experimental {
                 // produced per input index.
                 products new_products{1uz};
                 new_products.add(output_, std::move(new_product));
-                auto store = std::make_shared<product_store>(index, name_, std::move(new_products));
+                auto store =
+                  std::make_shared<product_store>(index, name_, std::move(new_products), stage_);
 
                 return {.store = std::move(store), .id = msg_id};
               }}

--- a/phlex/model/handle.hpp
+++ b/phlex/model/handle.hpp
@@ -5,6 +5,7 @@
 #include "phlex/model/fwd.hpp"
 #include "phlex/model/product_specification.hpp"
 
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -59,12 +60,14 @@ namespace phlex {
     // The 'product' parameter is not 'const_reference' to avoid avoid implicit type conversions.
     explicit handle(std::same_as<T> auto const& product,
                     data_cell_index const& id,
-                    experimental::product_specification const& key) :
+                    experimental::product_specification const& key,
+                    std::optional<experimental::identifier> stage = {}) :
       product_{&product},
       id_{&id},
       creator_plugin_{key.plugin()},
       creator_algorithm_{key.algorithm()},
-      suffix_(key.suffix())
+      suffix_(key.suffix()),
+      stage_(std::move(stage))
     {
     }
 
@@ -95,6 +98,13 @@ namespace phlex {
     }
     std::string_view suffix() const noexcept { return std::string_view(suffix_); }
     std::string_view layer() const noexcept { return std::string_view(id_->layer_name()); }
+    std::string_view stage() const noexcept
+    {
+      if (stage_.has_value()) {
+        return std::string_view(stage_.value());
+      }
+      return str_current;
+    }
     std::string layer_path() const { return id_->layer_path().to_string(); }
 
     template <typename U>
@@ -112,10 +122,20 @@ namespace phlex {
     experimental::identifier creator_algorithm_;
     experimental::identifier suffix_;
     experimental::type_id type_;
+    std::optional<experimental::identifier> stage_;
+
+    // Utilities for stage name access until configuration supports these
+    constexpr static std::string_view str_current = "CURRENT";
   };
 
   template <typename T>
   handle(T const&, data_cell_index const&, experimental::product_specification const&) -> handle<T>;
+
+  template <typename T>
+  handle(T const&,
+         data_cell_index const&,
+         experimental::product_specification const&,
+         std::optional<experimental::identifier>) -> handle<T>;
 }
 
 #endif // PHLEX_MODEL_HANDLE_HPP

--- a/phlex/model/product_store.cpp
+++ b/phlex/model/product_store.cpp
@@ -8,8 +8,12 @@ namespace phlex::experimental {
 
   product_store::product_store(data_cell_index_ptr id,
                                algorithm_name source,
-                               products new_products) :
-    products_{std::move(new_products)}, id_{std::move(id)}, source_{std::move(source)}
+                               products new_products,
+                               std::optional<identifier> stage) :
+    products_{std::move(new_products)},
+    id_{std::move(id)},
+    source_{std::move(source)},
+    stage_{std::move(stage)}
   {
   }
 

--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -12,6 +12,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -21,7 +22,8 @@ namespace phlex::experimental {
   public:
     explicit product_store(data_cell_index_ptr id,
                            algorithm_name source = default_source(),
-                           products new_products = {});
+                           products new_products = {},
+                           std::optional<identifier> stage = {});
     ~product_store();
     static product_store_ptr base(algorithm_name base_name = default_source());
 
@@ -56,6 +58,7 @@ namespace phlex::experimental {
     data_cell_index_ptr id_;
     algorithm_name
       source_; // FIXME: Should not have to copy (the source should outlive the product store)
+    std::optional<identifier> stage_; // No value means current stage
   };
 
   PHLEX_MODEL_EXPORT product_store_ptr const& more_derived(product_store_ptr const& a,
@@ -101,7 +104,7 @@ namespace phlex::experimental {
   template <typename T>
   [[nodiscard]] handle<T> product_store::get_handle(product_specification const& key) const
   {
-    return handle<T>{products_.get<T>(key), *id_, key};
+    return handle<T>{products_.get<T>(key), *id_, key, stage_};
   }
 
   template <typename T>

--- a/test/product_handle.cpp
+++ b/test/product_handle.cpp
@@ -128,7 +128,7 @@ TEST_CASE("Retrieve product specification from handle", "[data model]")
   CHECK(h.stage() == "CURRENT");
 }
 
-TEST_CASE("Retrieve stage rom handle", "[data model]")
+TEST_CASE("Retrieve stage from handle", "[data model]")
 {
   int const number{3};
   spec_t spec("creator/three");

--- a/test/product_handle.cpp
+++ b/test/product_handle.cpp
@@ -4,12 +4,14 @@
 #include "catch2/catch_test_macros.hpp"
 
 #include <concepts>
+#include <optional>
 #include <string>
 #include <vector>
 
 using namespace phlex;
 using namespace phlex::experimental::literals;
 using spec_t = experimental::product_specification;
+using opt_id_t = std::optional<experimental::identifier>;
 
 namespace {
   struct Composer {
@@ -36,6 +38,8 @@ TEST_CASE("Can only construct handles with compatible types (compile-time checks
   static_assert(std::constructible_from<handle<int>, int, data_cell_index, spec_t>);
   static_assert(std::constructible_from<handle<int>, int const, data_cell_index, spec_t>);
   static_assert(std::constructible_from<handle<int>, int const&, data_cell_index, spec_t>);
+  static_assert(
+    std::constructible_from<handle<int>, int const&, data_cell_index, spec_t, opt_id_t>);
   static_assert(not std::constructible_from<handle<int>, double, data_cell_index, spec_t>);
 }
 
@@ -121,4 +125,14 @@ TEST_CASE("Retrieve product specification from handle", "[data model]")
   CHECK(h.creator().algorithm == "creator");
   CHECK(h.suffix() == "three");
   CHECK(h.layer() == "job");
+  CHECK(h.stage() == "CURRENT");
+}
+
+TEST_CASE("Retrieve stage rom handle", "[data model]")
+{
+  int const number{3};
+  spec_t spec("creator/three");
+
+  handle const h{number, *data_cell_index::job(), spec, "last"};
+  CHECK(h.stage() == "last");
 }

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -85,11 +85,17 @@ TEST_CASE("Explicit providers")
   g.transform("passer", pass_on, concurrency::unlimited)
     .input_family(
       product_selector{.creator = "vertices_maker", .layer = "spill", .suffix = "happy_vertices"});
-
+  g.observe(
+     "verify_explicit_stage",
+     [](handle<toy::VertexCollection> h) { CHECK(h.stage() == "CURRENT"); },
+     concurrency::unlimited)
+    .input_family(
+      product_selector{.creator = "vertices_maker", .layer = "spill", .suffix = "happy_vertices"});
   g.execute();
 
   CHECK(g.execution_count("passer") == num_spills);
   CHECK(g.execution_count("my_name_here") == num_spills);
+  CHECK(g.execution_count("verify_explicit_stage") == num_spills);
 }
 
 TEST_CASE("Implicit providers")
@@ -108,7 +114,9 @@ TEST_CASE("Implicit providers")
       product_selector{.creator = "vertices_maker", .layer = "spill", .suffix = "happy_vertices"});
 
   g.observe(
-     "verify_implicit_stage", [](toy::VertexCollection const&) {}, concurrency::unlimited)
+     "verify_implicit_stage",
+     [](handle<toy::VertexCollection> h) { CHECK(h.stage() == "previous_process"); },
+     concurrency::unlimited)
     .input_family(
       product_selector{.creator = "vertices_maker", .layer = "spill", .suffix = "happy_vertices"});
   g.execute();


### PR DESCRIPTION
This PR now just adds stage name to the `handle`. A test will be added after #664 is merged using that functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Added optional stage tracking to `phlex::handle<T>` and `phlex::experimental::product_store`, including new constructor parameters, stored stage state, and a `stage()` accessor that returns `"CURRENT"` when no stage is set.
  - Propagated stage information through handle creation so `product_store::get_handle()` now builds handles with the store’s stage.
  - Updated implicit provider edge construction to uniquify provider names before using them as keys, reducing collisions when providers share names.
  - Passed the node stage into per-input `product_store` construction in `provider_node`.

- **Tests**
  - Extended handle compile-time coverage to include construction with an optional stage argument.
  - Added runtime checks for `handle::stage()`, covering both default `"CURRENT"` and explicit stage values.
  - Updated provider tests to verify stage values for both explicit and implicit provider flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->