### PR TITLE
Fix emplacement of implicit providers for multiple downstream nodes

### DIFF
--- a/phlex/core/make_computational_edges.cpp
+++ b/phlex/core/make_computational_edges.cpp
@@ -115,7 +115,16 @@ namespace phlex::experimental {
                                                       identifier{bundle.layer},
                                                       identifier{bundle.stage});
           auto const provider_name = node->name().to_string();
-          provider_input_ports.try_emplace(provider_name, input_product, node->input_port());
+          auto [_, inserted] =
+            provider_input_ports.try_emplace(provider_name, input_product, node->input_port());
+          if (!inserted) {
+            throw std::runtime_error(
+              fmt::format("Failed to create implicit provider for product selector '{}'\n"
+                          "Implicit providers not yet supported for creators that created multiple "
+                          "data products",
+                          input_product));
+          }
+
           make_edge(node->output_port(), *port);
           providers.try_emplace(provider_name, std::move(node));
         }

--- a/phlex/core/make_computational_edges.cpp
+++ b/phlex/core/make_computational_edges.cpp
@@ -77,6 +77,18 @@ namespace phlex::experimental {
       index_router::head_ports_t unconsumed_head_ports;
       for (auto const& [node_name, ports] : head_ports) {
         for (auto const& [input_product, port] : ports) {
+          auto existing_provider_it = std::ranges::find_if(
+            provider_input_ports, [&input_product](auto const& provider_entry) {
+              return provider_entry.second.input_product == input_product;
+            });
+
+          if (existing_provider_it != provider_input_ports.end()) {
+            auto provider = providers.get(existing_provider_it->first);
+            assert(provider != nullptr);
+            make_edge(provider->output_port(), *port);
+            continue;
+          }
+
           // If we have a source node that can produce this product, use it.
           auto bundles = find_matching_implicit_providers(sources, input_product);
           if (bundles.empty()) {

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -98,10 +98,15 @@ TEST_CASE("Implicit providers")
     .input_family(
       product_selector{.creator = "vertices_maker", .layer = "spill", .suffix = "happy_vertices"});
 
+  g.observe(
+     "verify_implicit_stage", [](toy::VertexCollection const&) {}, concurrency::unlimited)
+    .input_family(
+      product_selector{.creator = "vertices_maker", .layer = "spill", .suffix = "happy_vertices"});
   g.execute();
 
   CHECK(g.execution_count("vertices_maker") == num_spills);
   CHECK(g.execution_count("passer") == num_spills);
+  CHECK(g.execution_count("verify_implicit_stage") == num_spills);
 }
 
 TEST_CASE("Throw when two sources with the same name are registered")

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -53,6 +53,15 @@ namespace {
                                           .layer = layer,
                                           .stage = stage});
       }
+
+      product_specification int_spec{"vertices_maker", "num_happy_vertices", make_type_id<int>()};
+      if (selector.match(int_spec, identifier{layer}, identifier{stage})) {
+        bundles.push_back(provider_bundle{.provider_function = give_me_vertices_erased,
+                                          .max_concurrency = concurrency::unlimited,
+                                          .spec = std::move(int_spec),
+                                          .layer = layer,
+                                          .stage = stage});
+      }
       return bundles;
     }
     index_generator indices() override { co_return; }
@@ -152,4 +161,25 @@ TEST_CASE("Throw when no provider found for required product")
   CHECK_THROWS_WITH(g.execute(),
                     ContainsSubstring("No provider found for the following required products:") &&
                       ContainsSubstring("nonexistent_creator") && ContainsSubstring("job"));
+}
+
+TEST_CASE("Throw when implicit provider insertion fails")
+{
+  experimental::framework_graph g;
+  g.source<vertices_source>("duplicate_vertices_source");
+
+  g.transform("passer", pass_on, concurrency::unlimited)
+    .input_family(
+      product_selector{.creator = "vertices_maker", .layer = "spill", .suffix = "happy_vertices"});
+  g.observe(
+     "observer", [](int) {}, concurrency::unlimited)
+    .input_family(product_selector{
+      .creator = "vertices_maker", .layer = "spill", .suffix = "num_happy_vertices"});
+
+  CHECK_THROWS_WITH(
+    g.execute(),
+    ContainsSubstring("Failed to create implicit provider for product selector 'vertices_maker/") &&
+      ContainsSubstring("happy_vertices") &&
+      ContainsSubstring(
+        "Implicit providers not yet supported for creators that created multiple data products"));
 }


### PR DESCRIPTION
Fix to bug encountered by @beojan and reported at #663 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Updated `edges_from_implicit_providers` in `phlex/core/make_computational_edges.cpp` to reuse an already-registered implicit provider when the same input product is requested by multiple downstream nodes.
  - Added a guard that checks `provider_input_ports` before creating a new provider node, preventing duplicate implicit providers for the same product.
  - When a matching provider already exists, the code now connects its output port directly to the current consumer and skips the old create-and-register path.

- **Behavior**
  - Fixes the emplacement of implicit providers for fan-out / multiple downstream consumers.
  - Removes the previous reliance on creating a new provider per match, which could trigger the multiple-provider runtime check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->