### PR TITLE
Update all workflows to use `action/checkout` 7.0.0 by SHA

### DIFF
--- a/.github/prompts/plan-exportReusableActions.prompt.md
+++ b/.github/prompts/plan-exportReusableActions.prompt.md
@@ -1305,7 +1305,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@${CHECKOUT_SHA} # v4
+      - uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
       - uses: raven-actions/actionlint@${ACTIONLINT_SHA} # v2
 EOF
 

--- a/.github/workflows/actionlint-check.yaml
+++ b/.github/workflows/actionlint-check.yaml
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}

--- a/.github/workflows/clang-format-check.yaml
+++ b/.github/workflows/clang-format-check.yaml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}

--- a/.github/workflows/clang-format-fix.yaml
+++ b/.github/workflows/clang-format-fix.yaml
@@ -91,7 +91,7 @@ jobs:
       commit_sha_short: ${{ steps.handle_commit.outputs.commit_sha_short }}
       patch_name: ${{ steps.handle_commit.outputs.patch_name }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           path: ${{ needs.setup.outputs.checkout_path }}
           ref: ${{ needs.setup.outputs.ref }}

--- a/.github/workflows/clang-tidy-check.yaml
+++ b/.github/workflows/clang-tidy-check.yaml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}

--- a/.github/workflows/clang-tidy-fix.yaml
+++ b/.github/workflows/clang-tidy-fix.yaml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           path: ${{ needs.setup.outputs.checkout_path }}
           ref: ${{ needs.setup.outputs.ref }}

--- a/.github/workflows/cmake-build.yaml
+++ b/.github/workflows/cmake-build.yaml
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           path: ${{ needs.setup.outputs.checkout_path }}
           ref: ${{ needs.setup.outputs.ref }}

--- a/.github/workflows/cmake-format-check.yaml
+++ b/.github/workflows/cmake-format-check.yaml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}

--- a/.github/workflows/cmake-format-fix.yaml
+++ b/.github/workflows/cmake-format-fix.yaml
@@ -92,7 +92,7 @@ jobs:
       patch_name: ${{ steps.handle_commit.outputs.patch_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           path: ${{ needs.setup.outputs.checkout_path }}
           ref: ${{ needs.setup.outputs.ref }}

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -230,7 +230,7 @@ jobs:
         shell: bash
 
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ env.local_checkout_path }}
@@ -299,13 +299,13 @@ jobs:
         id: set_log_path
         run: echo "path=$RUNNER_TEMP/codeql-alerts.log" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Checkout Phlex for scripts
         if: github.event_name == 'workflow_call'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           repository: Framework-R-D/phlex
           path: phlex

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -106,7 +106,7 @@ jobs:
         # yamllint enable
 
       - name: Check out source code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
@@ -384,7 +384,7 @@ jobs:
 
     steps:
       - name: Check out source code for Codecov mapping
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/header-guards-check.yaml
+++ b/.github/workflows/header-guards-check.yaml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}

--- a/.github/workflows/header-guards-fix.yaml
+++ b/.github/workflows/header-guards-fix.yaml
@@ -92,7 +92,7 @@ jobs:
       patch_name: ${{ steps.handle_commit.outputs.patch_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           path: ${{ needs.setup.outputs.checkout_path }}
           ref: ${{ needs.setup.outputs.ref }}

--- a/.github/workflows/jsonnet-format-check.yaml
+++ b/.github/workflows/jsonnet-format-check.yaml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           repository: ${{ needs.setup.outputs.repo }}

--- a/.github/workflows/jsonnet-format-fix.yaml
+++ b/.github/workflows/jsonnet-format-fix.yaml
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           path: ${{ needs.setup.outputs.checkout_path }}
           ref: ${{ needs.setup.outputs.ref }}

--- a/.github/workflows/markdown-check.yaml
+++ b/.github/workflows/markdown-check.yaml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}

--- a/.github/workflows/markdown-fix.yaml
+++ b/.github/workflows/markdown-fix.yaml
@@ -92,7 +92,7 @@ jobs:
       patch_name: ${{ steps.handle_commit.outputs.patch_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           path: ${{ needs.setup.outputs.checkout_path }}
           ref: ${{ needs.setup.outputs.ref }}

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
@@ -144,7 +144,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}

--- a/.github/workflows/python-fix.yaml
+++ b/.github/workflows/python-fix.yaml
@@ -91,7 +91,7 @@ jobs:
       commit_sha_short: ${{ steps.handle_commit.outputs.commit_sha_short }}
       patch_name: ${{ steps.handle_commit.outputs.patch_name }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           path: ${{ needs.setup.outputs.checkout_path }}
           ref: ${{ needs.setup.outputs.ref }}

--- a/.github/workflows/yaml-check.yaml
+++ b/.github/workflows/yaml-check.yaml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           ref: ${{ needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}

--- a/.github/workflows/yaml-fix.yaml
+++ b/.github/workflows/yaml-fix.yaml
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb95f68b377484df746e50259b3f3e1b745 # v7.0.0
         with:
           path: ${{ needs.setup.outputs.checkout_path }}
           ref: ${{ needs.setup.outputs.ref }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **CI / GitHub Actions**
  - Updated all workflow checkout steps to use pinned `actions/checkout` v7.0.0 commit SHAs instead of older pins.
  - Affected workflows include actionlint, clang-format, clang-tidy, CMake, CodeQL, coverage, header guards, JSONNet, markdown, Python, and YAML workflows.
  - Kept existing checkout settings unchanged where present (`ref`, `path`, `repository`, `persist-credentials`, and related conditional logic).

- **Docs / Workflow templates**
  - Updated the generated reusable-actions prompt snippet to reflect the new pinned `actions/checkout` SHA in the shell script skeleton example.

- **Scope**
  - No functional workflow behavior changed beyond the checkout pin updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->