### PR TITLE
Fix latent memory error exposed by `fixed_hierarchy_test`

### DIFF
--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -55,9 +55,10 @@ namespace {
     std::vector<layer_path> layer_paths;
     layer_paths.reserve(layer_path_strings.size());
     for (auto& lp : layer_path_strings) {
-      auto lp_as_ids = lp |
-                       std::views::transform([](auto& str) { return identifier(std::move(str)); }) |
-                       std::ranges::to<std::vector>();
+      auto lp_as_ids =
+        lp | std::views::as_rvalue |
+        std::views::transform([](auto&& str) { return identifier(std::move(str)); }) |
+        std::ranges::to<std::vector>();
       layer_paths.emplace_back(std::move(lp_as_ids));
     }
     return unique_paths(std::move(layer_paths));

--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -57,7 +57,7 @@ namespace {
     for (auto& lp : layer_path_strings) {
       auto lp_as_ids =
         lp | std::views::as_rvalue |
-        std::views::transform([](auto&& str) { return identifier(std::move(str)); }) |
+        std::views::transform([](std::string&& str) { return identifier(std::move(str)); }) |
         std::ranges::to<std::vector>();
       layer_paths.emplace_back(std::move(lp_as_ids));
     }

--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -52,14 +52,14 @@ namespace {
     std::vector<std::vector<std::string>>&& layer_path_strings)
   {
     using namespace phlex::experimental;
-    auto layer_paths =
-      std::move(layer_path_strings) | std::views::transform([](std::vector<std::string>& lp) {
-        auto lp_as_ids =
-          lp | std::views::transform([](auto& str) { return identifier(std::move(str)); }) |
-          std::ranges::to<std::vector>();
-        return layer_path(std::move(lp_as_ids));
-      }) |
-      std::ranges::to<std::vector<layer_path>>();
+    std::vector<layer_path> layer_paths;
+    layer_paths.reserve(layer_path_strings.size());
+    for (auto& lp : layer_path_strings) {
+      auto lp_as_ids = lp |
+                       std::views::transform([](auto& str) { return identifier(std::move(str)); }) |
+                       std::ranges::to<std::vector>();
+      layer_paths.emplace_back(std::move(lp_as_ids));
+    }
     return unique_paths(std::move(layer_paths));
   }
 }


### PR DESCRIPTION
I encountered a bug in the implementation of `convert_vector_vector_string` when creating a `fixed_hierarchy` object.  I ran the address sanitizer on the test and submitted its output to Claude Sonnet 4.6, which said:

> Root Cause: Use-after-move in `convert_vector_vector_string`
> The crash is a SEGV during destruction of a `std::vector<layer_path>`, caused by a use-after-move bug in fixed_hierarchy.cpp:47–53.
> 
> The problematic code (fixed_hierarchy.cpp:43–54):
>
> ```cpp
> std::vector<phlex::experimental::layer_path> convert_vector_vector_string(
>   std::vector<std::vector<std::string>>&& layer_paths)
> {
>   using namespace phlex::experimental;
>   return std::move(layer_paths) | std::views::transform([](std::vector<std::string>& lp) {
>            auto lp_as_ids =
>              lp | std::views::transform([](auto& str) { return identifier(std::move(str)); }) |
>              std::ranges::to<std::vector>();
>            return layer_path(std::move(lp_as_ids));
>          }) |
>          std::ranges::to<std::vector<layer_path>>();
> }
> ```
>
> The bug: `std::move(layer_paths)` passes the vector as an rvalue into `std::views::owning_view`, but the inner lambda takes `std::vector<std::string>& lp` — a lvalue reference. The `transform_view` lazily evaluates elements, so by the time `std::ranges::to<std::vector<layer_path>>()` materializes the results, the intermediate `layer_path` objects constructed during iteration share memory that the `owning_view` has already moved/destroyed.
>
> More precisely: `std::ranges::to<std::vector<layer_path>>` constructs the result vector by iterating the `transform_view`. During iteration, each element is constructed by the lambda and then moved into the result vector. However, the `layer_path` destructor (via `std::vector<identifier>`) is then called on the temporaries. ASan's `0xbebebebe`... pattern in `rbx/rdi/rsi` (the "poisoned" freed-memory canary) and the segfault inside `__asan::Allocator::AtomicallySetQuarantineFlagIfAllocated` confirm the memory backing the identifier strings was already freed or poisoned when the destructor ran.
>
> The immediate trigger is the test at fixed_hierarchy_test.cpp:32:
>
> ```cpp
> CHECK_THROWS_WITH(fixed_hierarchy{{}}, ContainsSubstring("Layer paths cannot be empty"));
> ```
> An empty inner vector `{}` causes layer_path to be constructed from an empty `std::vector<identifier>`, which immediately throws in `validate()`. The exception unwinds through `std::ranges::to<std::vector<layer_path>>` while the partially-constructed vector is being destroyed — at that point the `layer_path` destructor runs on memory that was moved-from or is otherwise in an invalid state.

Because this is a memory error, it does not necessarily manifest on all platforms/compiler combinations.  I encountered it by running on Alma Linux 9 with GCC 15.1; I did not encounter it running on macOS 26.5.1 with Apple clang 21.0.0.

This PR fixes the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Reworked `convert_vector_vector_string` in `phlex/model/fixed_hierarchy.cpp` to construct the `std::vector<layer_path>` with an explicit loop and `reserve()` instead of a `std::ranges` transform/to pipeline.
  - Preserved the existing conversion behavior by still moving each inner `std::string` into `identifier(std::move(str))` before building each `layer_path`.
  - This avoids the latent use-after-move / invalid-state issue that could occur during exception unwinding when an empty inner vector triggers `layer_path` validation failure.

- **Reliability**
  - Fixes the crash/memory-safety path exposed by constructing `fixed_hierarchy{{}}`, where `Layer paths cannot be empty` is thrown and partially built objects are now destroyed safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->