### PR TITLE
Fix workflow-dispatch action triggering of code-coverage

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -374,7 +374,7 @@ jobs:
           retention-days: 30
 
   coverage-upload:
-    needs: coverage
+    needs: [setup, coverage]
     if:
       ${{ needs.coverage.result == 'success' && needs.coverage.outputs.artifact_upload_available == 'true' &&
       github.actor != 'nektos/act' }}
@@ -386,6 +386,8 @@ jobs:
       - name: Check out source code for Codecov mapping
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ needs.setup.outputs.ref }}
+          repository: ${{ needs.setup.outputs.repo }}
           fetch-depth: 0
 
       - name: Download coverage bundle


### PR DESCRIPTION
I've been having trouble running the code-coverage via `workflow_dispatch` on `main` (see https://github.com/Framework-R-D/phlex/actions/runs/28241141170/job/83669733668).

### Diagnosis by Claude Sonnet 4.6

`coverage-upload` was missing `setup` in its needs list and was missing `ref:` and `repository:` in its checkout step. Without those, on a `workflow_dispatch` run where `main` advances between the coverage job starting and the coverage-upload job starting (which happened in PR #668), the upload job checks out a different commit than the one coverage was actually measured on. Codecov then tries to upload for that wrong commit SHA, which it has no record of, producing a 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **CI / coverage workflow**
  - Updated `.github/workflows/coverage.yaml` so `coverage-upload` now waits on both `setup` and `coverage`.
  - Made the Codecov checkout step explicit by passing the `ref` and `repository` values from `needs.setup.outputs`, ensuring the upload job checks out the same commit/repo used to generate coverage.
  - This prevents mismatched checkouts on `main` and avoids Codecov 404s for unknown commit SHAs when `main` advances between jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->