### PR TITLE
workaround for numpy 2.5 typing origin change

### DIFF
--- a/plugins/python/python/phlex/_typing.py
+++ b/plugins/python/python/phlex/_typing.py
@@ -156,10 +156,17 @@ def normalize_type(tp: Any, globalns: Dict | None = None, localns: Dict | None =
     if origin is not None:
         args = typing.get_args(tp)
 
-        if origin is np.ndarray:  # numpy arrays
+        if origin in (np.ndarray, np.typing.NDArray):      # numpy arrays
             dtype_args: tuple[Any, ...] = ()
-            if len(args) >= 2:
+            # origin should point to the original type type, unless it is generic; it's
+            # probably debatable what it should be for numpy.ndarray, but for versions
+            # prior to 2.5, it follows Python builtin types, after it follows generics
+            if len(args) >= 2 and origin is np.ndarray:
+                # typing.List convention
                 dtype_args = typing.get_args(args[1])
+            elif len(args) == 1 and origin is np.typing.NDArray:
+                # generics convention
+                dtype_args = args
             if not dtype_args:
                 raise TypeError(
                     "np.ndarray annotations must supply a dtype, e.g. npt.NDArray[np.float64]"


### PR DESCRIPTION
In numpy 2.5, the `__origin__` of any `typing.NDArray[]` points to the generic type (ie. .`typing.NDArray` itself), rather than the base type (ie. `numpy.ndarray`). The latter is the convention for container types (e.g. `types.List`), the former for descriptive types like `types.UnionType`. It's probably an unintended consequence of this:
```
-NDArray: TypeAlias = np.ndarray[_AnyShape, dtype[_ScalarT]]
+type NDArray[ScalarT: np.generic] = np.ndarray[_AnyShape, np.dtype[ScalarT]]
```
Nevertheless, this PR supports both, regardless whether 2.5.0 is used in the wild and/or not fixed later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Updated `normalize_type` in `plugins/python/python/phlex/_typing.py` to recognize both `np.ndarray` and `np.typing.NDArray` as NumPy array origins.
  - Adjusted dtype extraction logic to handle both generic conventions:
    - `np.ndarray` continues to use the existing second-type-argument pattern when present.
    - `np.typing.NDArray` now uses its single type argument directly as the dtype.
  - This preserves compatibility with NumPy 2.5’s changed `__origin__` behavior while remaining compatible with the prior behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->