### PR TITLE
Form read extend data type

### DIFF
--- a/form/form/CMakeLists.txt
+++ b/form/form/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(
 
 add_library(phlex::form ALIAS form)
 set_target_properties(form PROPERTIES EXPORT_NAME form)
+set_target_properties(form PROPERTIES OUTPUT_NAME phlex_form)
 
 install(TARGETS form EXPORT phlex LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
-install(FILES form_source_type_registry.hpp DESTINATION include/phlex/form/form)
+install(FILES form_source_type_registry.hpp DESTINATION include/phlex/form)

--- a/form/form/CMakeLists.txt
+++ b/form/form/CMakeLists.txt
@@ -5,14 +5,14 @@
 # Component(s) in the package:
 add_library(form SHARED form_reader.cpp form_writer.cpp config.cpp form_source_type_registry.cpp)
 
-target_link_libraries(form PRIVATE persistence phlex::model)
+target_link_libraries(form PRIVATE persistence PUBLIC phlex::model)
 
 target_include_directories(
-	form
-	PUBLIC
-		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/form>
-		$<INSTALL_INTERFACE:include/phlex>
+  form
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/form>
+    $<INSTALL_INTERFACE:include/phlex>
 )
 
 add_library(phlex::form ALIAS form)

--- a/form/form/CMakeLists.txt
+++ b/form/form/CMakeLists.txt
@@ -3,8 +3,20 @@
 # External dependencies: find_package( PHLEX )
 
 # Component(s) in the package:
-add_library(form form_reader.cpp form_writer.cpp config.cpp form_source_type_registry.cpp)
+add_library(form SHARED form_reader.cpp form_writer.cpp config.cpp form_source_type_registry.cpp)
 
-target_link_libraries(form persistence phlex::model)
+target_link_libraries(form PRIVATE persistence phlex::model)
 
-target_include_directories(form PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/form)
+target_include_directories(
+	form
+	PUBLIC
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/form>
+		$<INSTALL_INTERFACE:include/phlex>
+)
+
+add_library(phlex::form ALIAS form)
+set_target_properties(form PROPERTIES EXPORT_NAME form)
+
+install(TARGETS form EXPORT phlex LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+install(FILES form_source_type_registry.hpp DESTINATION include/phlex/form/form)

--- a/form/form/form_source_type_registry.cpp
+++ b/form/form/form_source_type_registry.cpp
@@ -28,18 +28,18 @@ namespace form::experimental {
   void register_form_product_type(std::string product_type,
                                   phlex::experimental::type_id type,
                                   std::type_info const& cpp_type,
-                                  form_source_reader_fn reader_fn)
+                                  form_source_product_from_data_fn product_from_data_fn)
   {
     if (product_type.empty()) {
       throw std::runtime_error("Cannot register empty FORM product type name");
     }
-    if (!reader_fn) {
-      throw std::runtime_error("Cannot register FORM product type with empty reader function");
+    if (!product_from_data_fn) {
+      throw std::runtime_error("Cannot register FORM product type with empty conversion function");
     }
 
     std::lock_guard<std::mutex> lock(form_type_registry_mutex());
     mutable_form_type_registry()[std::move(product_type)] =
-      form_source_type_entry{std::move(type), &cpp_type, std::move(reader_fn)};
+      form_source_type_entry{std::move(type), &cpp_type, std::move(product_from_data_fn)};
   }
 
   // Returns a pointer to the registry entry. The registry is is immutable after the first call to this function.

--- a/form/form/form_source_type_registry.cpp
+++ b/form/form/form_source_type_registry.cpp
@@ -63,6 +63,16 @@ namespace form::experimental {
 
     std::lock_guard<std::mutex> lock(form_type_registry_mutex());
     auto const& registry = mutable_form_type_registry();
+
+    // Prefer exact (type_info-based) identity to avoid collisions between
+    // coarse type_id categories (e.g. unsupported class containers).
+    for (auto const& [name, entry] : registry) {
+      if (entry.type_id.exact_compare(type)) {
+        return &name;
+      }
+    }
+
+    // Backward-compatible fallback for existing coarse matching behavior.
     for (auto const& [name, entry] : registry) {
       if (entry.type_id == type) {
         return &name;

--- a/form/form/form_source_type_registry.hpp
+++ b/form/form/form_source_type_registry.hpp
@@ -3,8 +3,6 @@
 #ifndef FORM_FORM_FORM_SOURCE_TYPE_REGISTRY_HPP
 #define FORM_FORM_FORM_SOURCE_TYPE_REGISTRY_HPP
 
-#include "form_reader.hpp"
-
 #include "phlex/model/products.hpp"
 #include "phlex/model/type_id.hpp"
 
@@ -16,23 +14,19 @@
 
 namespace form::experimental {
 
-  using form_source_reader_fn =
-    std::function<phlex::experimental::product_ptr(form_reader_interface& reader,
-                                                   std::string const& creator,
-                                                   std::string const& product_name,
-                                                   std::string const& index_str,
-                                                   std::string const& product_type)>;
+  using form_source_product_from_data_fn = std::function<phlex::experimental::product_ptr(
+    void const* data, std::string const& product_name, std::string const& index_str)>;
 
   struct form_source_type_entry {
     phlex::experimental::type_id type_id;
     std::type_info const* cpp_type{nullptr};
-    form_source_reader_fn reader_fn{};
+    form_source_product_from_data_fn product_from_data_fn{};
   };
 
   void register_form_product_type(std::string product_type,
                                   phlex::experimental::type_id type,
                                   std::type_info const& cpp_type,
-                                  form_source_reader_fn reader_fn);
+                                  form_source_product_from_data_fn product_from_data_fn);
 
   form_source_type_entry const* find_form_product_type(std::string const& product_type);
   std::string const* find_form_product_type_name(phlex::experimental::type_id const& type);
@@ -43,26 +37,21 @@ namespace form::experimental {
   {
     using product_type_t = std::remove_cvref_t<T>;
 
-    auto reader_fn =
-      [](form_reader_interface& reader,
-         std::string const& creator,
+    auto product_from_data_fn =
+      [](void const* data,
          std::string const& product_name,
-         std::string const& index_str,
-         std::string const& runtime_product_type) -> phlex::experimental::product_ptr {
-      (void)runtime_product_type;
-      product_with_name pb{product_name, nullptr, &typeid(product_type_t)};
-      reader.read(creator, index_str, pb);
-      if (!pb.data) {
+         std::string const& index_str) -> phlex::experimental::product_ptr {
+      if (!data) {
         throw std::runtime_error("FORM Error: Failed to retrieve product [" + product_name +
                                  "] for " + index_str);
       }
-      return phlex::experimental::product_for(*static_cast<product_type_t const*>(pb.data));
+      return phlex::experimental::product_for(*static_cast<product_type_t const*>(data));
     };
 
     register_form_product_type(std::move(product_type),
                                phlex::experimental::make_type_id<product_type_t>(),
                                typeid(product_type_t),
-                               std::move(reader_fn));
+                               std::move(product_from_data_fn));
   }
 
   template <typename T>

--- a/form/form_source.cpp
+++ b/form/form_source.cpp
@@ -142,8 +142,10 @@ namespace {
     {
       form::experimental::form_source_type_entry const* entry =
         form::experimental::find_form_product_type(product_type);
-      if (entry && entry->reader_fn) {
-        return entry->reader_fn(*reader_, creator, product_name, index_str, product_type);
+      if (entry && entry->cpp_type && entry->product_from_data_fn) {
+        form::experimental::product_with_name pb{product_name, nullptr, entry->cpp_type};
+        reader_->read(creator, index_str, pb);
+        return entry->product_from_data_fn(pb.data, product_name, index_str);
       }
       throw std::runtime_error("Unsupported FORM product type: " + product_type);
     }

--- a/form/persistence/persistence_reader.cpp
+++ b/form/persistence/persistence_reader.cpp
@@ -74,7 +74,6 @@ std::vector<std::string> PersistenceReader::listIndices(std::string const& creat
                              " from creator: " + creator);
   }
 
-  (void)label;
   std::string const full_label = buildFullLabel(creator, "index");
   return m_store_reader->listIndices(
     Token{config_item->file_name, full_label, config_item->technology}, m_tech_settings);

--- a/form/root_storage/root_rfield_read_container.cpp
+++ b/form/root_storage/root_rfield_read_container.cpp
@@ -10,6 +10,15 @@
 #include "TFile.h"
 
 #include <exception>
+#include <mutex>
+
+namespace {
+  std::mutex& root_rfield_read_mutex()
+  {
+    static std::mutex m;
+    return m;
+  }
+}
 
 namespace form::detail::experimental {
   ROOT_RField_Read_ContainerImp::ROOT_RField_Read_ContainerImp(std::string const& name) :
@@ -42,6 +51,8 @@ namespace form::detail::experimental {
 
   void ROOT_RField_Read_ContainerImp::prime(std::type_info const& type)
   {
+    std::lock_guard<std::mutex> guard(root_rfield_read_mutex());
+
     if (!m_tfile) {
       throw std::runtime_error("ROOT_RField_Read_ContainerImp::prime No file loaded");
     }
@@ -57,6 +68,8 @@ namespace form::detail::experimental {
 
   bool ROOT_RField_Read_ContainerImp::read(int id, void const** data, std::type_info const& type)
   {
+    std::lock_guard<std::mutex> guard(root_rfield_read_mutex());
+
     //Connect to file at the last possible moment at the cost of a little run-time branching
     if (!m_view) {
       if (!m_reader) { //First time this RNTuple is read this job
@@ -111,6 +124,8 @@ namespace form::detail::experimental {
 
   int ROOT_RField_Read_ContainerImp::entries()
   {
+    std::lock_guard<std::mutex> guard(root_rfield_read_mutex());
+
     if (!m_reader) {
       if (!m_tfile) {
         throw std::runtime_error("ROOT_RField_Read_ContainerImp::entries No file loaded");

--- a/form/storage/storage_reader.cpp
+++ b/form/storage/storage_reader.cpp
@@ -68,18 +68,14 @@ namespace {
       return std::nullopt;
     }
 
-    bool looks_hex = false;
     for (char ch : value) {
-      if (!std::isxdigit(static_cast<unsigned char>(ch))) {
+      if (!std::isdigit(static_cast<unsigned char>(ch))) {
         return std::nullopt;
-      }
-      if (std::isalpha(static_cast<unsigned char>(ch))) {
-        looks_hex = true;
       }
     }
 
     try {
-      return std::stoll(value, nullptr, looks_hex ? 16 : 10);
+      return std::stoll(value, nullptr, 10);
     } catch (...) {
       return std::nullopt;
     }

--- a/test/form/form_basics_test.cpp
+++ b/test/form/form_basics_test.cpp
@@ -305,24 +305,16 @@ TEST_CASE("form_reader_interface::indices exercises persistence listIndices path
   CHECK_THROWS_AS(reader.indices("creator", "prod"), std::runtime_error);
 }
 
-TEST_CASE("form_source_type_registry reader_fn throws when reader returns null data", "[form]")
+TEST_CASE("form_source_type_registry product_from_data_fn throws on null data", "[form]")
 {
   using namespace form::experimental;
-  using namespace form::experimental::config;
 
   ensure_builtin_form_product_types_registered();
   auto const* entry = find_form_product_type("std::vector<int>");
   REQUIRE(entry != nullptr);
-  REQUIRE(entry->reader_fn != nullptr);
+  REQUIRE(entry->product_from_data_fn != nullptr);
 
-  // With tech=0 the default Storage_Read_Container::read() never writes *data,
-  // so pb.data stays nullptr and the reader_fn throws at form_source_type_registry.hpp L56-57.
-  ItemConfig cfg;
-  cfg.addItem("prod", "dummy_reader_fn_test.root", 0);
-  form_reader_interface reader{cfg, tech_setting_config{}};
-
-  CHECK_THROWS_AS(entry->reader_fn(reader, "creator", "prod", "[]", "std::vector<int>"),
-                  std::runtime_error);
+  CHECK_THROWS_AS(entry->product_from_data_fn(nullptr, "prod", "[]"), std::runtime_error);
 }
 
 TEST_CASE("FORM source registry: unregistered type returns nullptr", "[form]")
@@ -351,18 +343,18 @@ TEST_CASE("FORM source registry: registration error paths", "[form]")
                       "",
                       make_type_id<int>(),
                       typeid(int),
-                      [](auto&, auto const&, auto const&, auto const&, auto const&)
+                      [](void const*, std::string const&, std::string const&)
                         -> phlex::experimental::product_ptr { return nullptr; }),
                     std::runtime_error);
   }
 
-  SECTION("null reader function throws")
+  SECTION("null conversion function throws")
   {
-    CHECK_THROWS_AS(
-      form::experimental::register_form_product_type("some_new_type_for_error_test",
-                                                     make_type_id<double>(),
-                                                     typeid(double),
-                                                     form::experimental::form_source_reader_fn{}),
-      std::runtime_error);
+    CHECK_THROWS_AS(form::experimental::register_form_product_type(
+                      "some_new_type_for_error_test",
+                      make_type_id<double>(),
+                      typeid(double),
+                      form::experimental::form_source_product_from_data_fn{}),
+                    std::runtime_error);
   }
 }


### PR DESCRIPTION
This PR refactors the FORM type registry to make it extensible, allowing users to register and read their own data types when using the FORM backend.

The main changes include:
- Isolate the type registry API and remove unnecessary form_reader dependencies.
- Make form_source_type_registry.hpp available for external use (e.g. in phlex-examples).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Build / packaging**
  - Switched `form` to a shared library with scoped linkage, generator-expression include paths, and a namespaced alias target `phlex::form`.
  - Added export/install rules for the library and installed `form_source_type_registry.hpp` as a public header.

- **Public API / extensibility**
  - Refactored the FORM type registry to use a new `form_source_product_from_data_fn` callback that produces `product_ptr` directly from raw data.
  - Removed the registry’s dependency on `form_reader`-based callbacks and updated the registry entry structure and registration API accordingly.
  - Made type lookup prefer exact `type_id` matches first, preserving the previous fallback for compatibility.

- **Runtime behavior**
  - Updated FORM source reading to deserialize into `product_with_name` and then convert via the registered `product_from_data_fn`.
  - Enforced decimal-only parsing in `parse_index_number`, dropping the previous hex-like acceptance.
  - Added process-wide mutex protection around ROOT RNTuple reader/view operations to improve thread safety.

- **Tests**
  - Updated FORM registry tests to cover the new null-data callback path and the new registration error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->