### PR TITLE
Rationalize namespaces

### DIFF
--- a/docs/source/api/driver_proxy.rst
+++ b/docs/source/api/driver_proxy.rst
@@ -1,8 +1,8 @@
 driver_proxy
 =============
 
-.. doxygenclass:: phlex::experimental::driver_proxy
+.. doxygenclass:: phlex::detail::driver_proxy
    :members:
 
-.. doxygenstruct:: phlex::experimental::driver_bundle
+.. doxygenstruct:: phlex::detail::driver_bundle
    :members:

--- a/docs/source/api/module_graph_proxy.rst
+++ b/docs/source/api/module_graph_proxy.rst
@@ -1,5 +1,5 @@
 module_graph_proxy
 ===================
 
-.. doxygenclass:: phlex::experimental::module_graph_proxy
+.. doxygenclass:: phlex::detail::module_graph_proxy
    :members:

--- a/docs/source/api/source_graph_proxy.rst
+++ b/docs/source/api/source_graph_proxy.rst
@@ -1,5 +1,5 @@
 source_graph_proxy
 ===================
 
-.. doxygenclass:: phlex::experimental::source_graph_proxy
+.. doxygenclass:: phlex::detail::source_graph_proxy
    :members:

--- a/form/form/form_source_type_registry.cpp
+++ b/form/form/form_source_type_registry.cpp
@@ -26,7 +26,7 @@ namespace {
 namespace form::experimental {
 
   void register_form_product_type(std::string product_type,
-                                  phlex::experimental::type_id type,
+                                  phlex::detail::type_id type,
                                   std::type_info const& cpp_type,
                                   form_source_product_from_data_fn product_from_data_fn)
   {
@@ -57,7 +57,7 @@ namespace form::experimental {
     return &it->second;
   }
 
-  std::string const* find_form_product_type_name(phlex::experimental::type_id const& type)
+  std::string const* find_form_product_type_name(phlex::detail::type_id const& type)
   {
     ensure_builtin_form_product_types_registered();
 

--- a/form/form/form_source_type_registry.hpp
+++ b/form/form/form_source_type_registry.hpp
@@ -14,22 +14,22 @@
 
 namespace form::experimental {
 
-  using form_source_product_from_data_fn = std::function<phlex::experimental::product_ptr(
+  using form_source_product_from_data_fn = std::function<phlex::detail::product_ptr(
     void const* data, std::string const& product_name, std::string const& index_str)>;
 
   struct form_source_type_entry {
-    phlex::experimental::type_id type_id;
+    phlex::detail::type_id type_id;
     std::type_info const* cpp_type{nullptr};
     form_source_product_from_data_fn product_from_data_fn{};
   };
 
   void register_form_product_type(std::string product_type,
-                                  phlex::experimental::type_id type,
+                                  phlex::detail::type_id type,
                                   std::type_info const& cpp_type,
                                   form_source_product_from_data_fn product_from_data_fn);
 
   form_source_type_entry const* find_form_product_type(std::string const& product_type);
-  std::string const* find_form_product_type_name(phlex::experimental::type_id const& type);
+  std::string const* find_form_product_type_name(phlex::detail::type_id const& type);
   void ensure_builtin_form_product_types_registered();
 
   template <typename T>
@@ -37,19 +37,18 @@ namespace form::experimental {
   {
     using product_type_t = std::remove_cvref_t<T>;
 
-    auto product_from_data_fn =
-      [](void const* data,
-         std::string const& product_name,
-         std::string const& index_str) -> phlex::experimental::product_ptr {
+    auto product_from_data_fn = [](void const* data,
+                                   std::string const& product_name,
+                                   std::string const& index_str) -> phlex::detail::product_ptr {
       if (!data) {
         throw std::runtime_error("FORM Error: Failed to retrieve product [" + product_name +
                                  "] for " + index_str);
       }
-      return phlex::experimental::product_for(*static_cast<product_type_t const*>(data));
+      return phlex::detail::product_for(*static_cast<product_type_t const*>(data));
     };
 
     register_form_product_type(std::move(product_type),
-                               phlex::experimental::make_type_id<product_type_t>(),
+                               phlex::detail::make_type_id<product_type_t>(),
                                typeid(product_type_t),
                                std::move(product_from_data_fn));
   }

--- a/form/form_source.cpp
+++ b/form/form_source.cpp
@@ -59,7 +59,7 @@ namespace {
     return current;
   }
 
-  class FormInputSource : public phlex::experimental::source {
+  class FormInputSource : public phlex::source {
   public:
     FormInputSource(form::experimental::config::ItemConfig const& input_cfg,
                     form::experimental::config::tech_setting_config const& tech_cfg,
@@ -75,11 +75,11 @@ namespace {
       form::experimental::ensure_builtin_form_product_types_registered();
     }
 
-    phlex::experimental::provider_bundles create_providers(
+    phlex::detail::provider_bundles create_providers(
       phlex::product_selector const& selector) override
     {
       using namespace phlex::experimental;
-      provider_bundles bundles;
+      phlex::detail::provider_bundles bundles;
 
       std::string const* product_type_name =
         form::experimental::find_form_product_type_name(selector.type);
@@ -112,12 +112,12 @@ namespace {
           return this->read_product_from_form(actual_creator_, name, id.to_string(), product_type);
         };
 
-        bundles.push_back(
-          provider_bundle{.provider_function = std::function<provider_function_t>(provider_func),
-                          .max_concurrency = phlex::concurrency::serial,
-                          .spec = std::move(spec),
-                          .layer = std::string(selector_layer.trans_get_string()),
-                          .stage = std::string(selector_stage.trans_get_string())});
+        bundles.push_back(phlex::detail::provider_bundle{
+          .provider_function = std::function<phlex::detail::provider_function_t>(provider_func),
+          .max_concurrency = phlex::concurrency::serial,
+          .spec = std::move(spec),
+          .layer = std::string(selector_layer.trans_get_string()),
+          .stage = std::string(selector_stage.trans_get_string())});
       }
 
       return bundles;

--- a/form/form_source.cpp
+++ b/form/form_source.cpp
@@ -79,6 +79,7 @@ namespace {
       phlex::product_selector const& selector) override
     {
       using namespace phlex::experimental;
+      using namespace phlex::detail;
       phlex::detail::provider_bundles bundles;
 
       std::string const* product_type_name =
@@ -106,9 +107,8 @@ namespace {
 
         reader_->prime(actual_creator_, name, *selected_entry->cpp_type);
 
-        auto provider_func =
-          [this, name, product_type = *product_type_name](
-            phlex::data_cell_index const& id) -> phlex::experimental::product_ptr {
+        auto provider_func = [this, name, product_type = *product_type_name](
+                               phlex::data_cell_index const& id) -> phlex::detail::product_ptr {
           return this->read_product_from_form(actual_creator_, name, id.to_string(), product_type);
         };
 
@@ -135,10 +135,10 @@ namespace {
       }
     }
 
-    phlex::experimental::product_ptr read_product_from_form(std::string const& creator,
-                                                            std::string const& product_name,
-                                                            std::string const& index_str,
-                                                            std::string const& product_type)
+    phlex::detail::product_ptr read_product_from_form(std::string const& creator,
+                                                      std::string const& product_name,
+                                                      std::string const& index_str,
+                                                      std::string const& product_type)
     {
       form::experimental::form_source_type_entry const* entry =
         form::experimental::find_form_product_type(product_type);

--- a/phlex/app/load_module.cpp
+++ b/phlex/app/load_module.cpp
@@ -16,7 +16,7 @@
 
 using namespace std::string_literals;
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   namespace {
     constexpr std::string_view pymodule_name{"pymodule"};
@@ -24,11 +24,11 @@ namespace phlex::experimental {
     // If factory function goes out of scope, then the library is unloaded...and that's
     // bad.
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-    std::vector<std::function<detail::module_creator_t>> create_module;
+    std::vector<std::function<internal::module_creator_t>> create_module;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-    std::vector<std::function<detail::source_creator_t>> create_source;
+    std::vector<std::function<internal::source_creator_t>> create_source;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-    std::function<detail::driver_shim_t> create_driver;
+    std::function<internal::driver_shim_t> create_driver;
 
     template <typename creator_t>
     std::function<creator_t> plugin_loader(std::string const& spec, std::string const& symbol_name)
@@ -60,7 +60,7 @@ namespace phlex::experimental {
     }
   }
 
-  namespace detail {
+  namespace internal {
     boost::json::object adjust_config(std::string const& label, boost::json::object raw_config)
     {
       raw_config["module_label"] = label;
@@ -84,29 +84,25 @@ namespace phlex::experimental {
     }
   }
 
-  void load_module(phlex::detail::framework_graph& g,
-                   std::string const& label,
-                   boost::json::object raw_config)
+  void load_module(framework_graph& g, std::string const& label, boost::json::object raw_config)
   {
-    auto const adjusted_config = detail::adjust_config(label, std::move(raw_config));
+    auto const adjusted_config = internal::adjust_config(label, std::move(raw_config));
 
     auto const& spec = value_to<std::string>(adjusted_config.at("cpp"));
     auto& creator =
-      create_module.emplace_back(plugin_loader<detail::module_creator_t>(spec, "create_module"));
+      create_module.emplace_back(plugin_loader<internal::module_creator_t>(spec, "create_module"));
 
     configuration const config{adjusted_config};
     creator(g.module_proxy(config), config);
   }
 
-  void load_source(phlex::detail::framework_graph& g,
-                   std::string const& label,
-                   boost::json::object raw_config)
+  void load_source(framework_graph& g, std::string const& label, boost::json::object raw_config)
   {
-    auto const adjusted_config = detail::adjust_config(label, std::move(raw_config));
+    auto const adjusted_config = internal::adjust_config(label, std::move(raw_config));
 
     auto const& spec = value_to<std::string>(adjusted_config.at("cpp"));
     auto& creator =
-      create_source.emplace_back(plugin_loader<detail::source_creator_t>(spec, "create_source"));
+      create_source.emplace_back(plugin_loader<internal::source_creator_t>(spec, "create_source"));
 
     // FIXME: Should probably use the parameter name (e.g.) 'plugin_label' instead of
     //        'module_label', but that requires adjusting other parts of the system
@@ -117,7 +113,7 @@ namespace phlex::experimental {
     creator(g.source_proxy(config), config);
   }
 
-  void load_driver(phlex::detail::framework_graph& g, boost::json::object const& raw_config)
+  void load_driver(framework_graph& g, boost::json::object const& raw_config)
   {
     configuration const config{raw_config};
     auto const& spec = config.get<std::string>("cpp");
@@ -125,7 +121,7 @@ namespace phlex::experimental {
     // False positive: clang-analyzer cannot trace ownership through Boost's is_any_of<char>
     // internal reference counting in classification.hpp.
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks,clang-analyzer-cplusplus.NewDelete)
-    create_driver = plugin_loader<detail::driver_shim_t>(spec, "create_driver");
+    create_driver = plugin_loader<internal::driver_shim_t>(spec, "create_driver");
     driver_bundle result;
     create_driver(g.driver_proxy(required_sources), config, &result);
     g.add_driver(result);

--- a/phlex/app/load_module.cpp
+++ b/phlex/app/load_module.cpp
@@ -84,7 +84,9 @@ namespace phlex::experimental {
     }
   }
 
-  void load_module(framework_graph& g, std::string const& label, boost::json::object raw_config)
+  void load_module(phlex::detail::framework_graph& g,
+                   std::string const& label,
+                   boost::json::object raw_config)
   {
     auto const adjusted_config = detail::adjust_config(label, std::move(raw_config));
 
@@ -96,7 +98,9 @@ namespace phlex::experimental {
     creator(g.module_proxy(config), config);
   }
 
-  void load_source(framework_graph& g, std::string const& label, boost::json::object raw_config)
+  void load_source(phlex::detail::framework_graph& g,
+                   std::string const& label,
+                   boost::json::object raw_config)
   {
     auto const adjusted_config = detail::adjust_config(label, std::move(raw_config));
 
@@ -113,7 +117,7 @@ namespace phlex::experimental {
     creator(g.source_proxy(config), config);
   }
 
-  void load_driver(framework_graph& g, boost::json::object const& raw_config)
+  void load_driver(phlex::detail::framework_graph& g, boost::json::object const& raw_config)
   {
     configuration const config{raw_config};
     auto const& spec = config.get<std::string>("cpp");

--- a/phlex/app/load_module.hpp
+++ b/phlex/app/load_module.hpp
@@ -8,22 +8,21 @@
 
 #include "boost/json.hpp"
 
-namespace phlex::experimental {
-  namespace detail {
+namespace phlex::detail {
+  namespace internal {
     // Adjust_config adds the module_label as a parameter, and it checks if the 'py'
     // parameter exists, inserting the 'cpp: "pymodule"' configuration if necessary.
     RUN_PHLEX_EXPORT boost::json::object adjust_config(std::string const& label,
                                                        boost::json::object raw_config);
   }
 
-  RUN_PHLEX_EXPORT void load_module(phlex::detail::framework_graph& g,
+  RUN_PHLEX_EXPORT void load_module(framework_graph& g,
                                     std::string const& label,
                                     boost::json::object config);
-  RUN_PHLEX_EXPORT void load_source(phlex::detail::framework_graph& g,
+  RUN_PHLEX_EXPORT void load_source(framework_graph& g,
                                     std::string const& label,
                                     boost::json::object config);
-  RUN_PHLEX_EXPORT void load_driver(phlex::detail::framework_graph& g,
-                                    boost::json::object const& config);
+  RUN_PHLEX_EXPORT void load_driver(framework_graph& g, boost::json::object const& config);
 }
 
 #endif // PHLEX_APP_LOAD_MODULE_HPP

--- a/phlex/app/load_module.hpp
+++ b/phlex/app/load_module.hpp
@@ -16,13 +16,14 @@ namespace phlex::experimental {
                                                        boost::json::object raw_config);
   }
 
-  RUN_PHLEX_EXPORT void load_module(framework_graph& g,
+  RUN_PHLEX_EXPORT void load_module(phlex::detail::framework_graph& g,
                                     std::string const& label,
                                     boost::json::object config);
-  RUN_PHLEX_EXPORT void load_source(framework_graph& g,
+  RUN_PHLEX_EXPORT void load_source(phlex::detail::framework_graph& g,
                                     std::string const& label,
                                     boost::json::object config);
-  RUN_PHLEX_EXPORT void load_driver(framework_graph& g, boost::json::object const& config);
+  RUN_PHLEX_EXPORT void load_driver(phlex::detail::framework_graph& g,
+                                    boost::json::object const& config);
 }
 
 #endif // PHLEX_APP_LOAD_MODULE_HPP

--- a/phlex/app/phlex.cpp
+++ b/phlex/app/phlex.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* argv[])
     ("parallel,j",
        bpo::value<int>()->default_value(max_concurrency),
        "Maximum parallelism requested for the program")
-    ("version", ("Print phlex version ("s + phlex::experimental::version() + ")").c_str());
+    ("version", ("Print phlex version ("s + phlex::detail::version() + ")").c_str());
   // clang-format on
 
   // Parse the command line.
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
   }
 
   if (vm.count("version")) {
-    std::cout << "phlex " << phlex::experimental::version() << '\n';
+    std::cout << "phlex " << phlex::detail::version() << '\n';
     return 0;
   }
 
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
     max_concurrency = vm["parallel"].as<int>();
   }
   try {
-    phlex::experimental::run(configurations, max_concurrency);
+    phlex::detail::run(configurations, max_concurrency);
   } catch (std::exception const& e) {
     std::cerr << e.what() << '\n';
     return 1;

--- a/phlex/app/run.cpp
+++ b/phlex/app/run.cpp
@@ -17,7 +17,7 @@ namespace {
 namespace phlex::experimental {
   void run(boost::json::object const& configurations, int const max_parallelism)
   {
-    auto g = framework_graph::without_driver(max_parallelism);
+    auto g = phlex::detail::framework_graph::without_driver(max_parallelism);
 
     // It is allowed for users to not specify any modules
     boost::json::object module_configs;

--- a/phlex/app/run.cpp
+++ b/phlex/app/run.cpp
@@ -17,7 +17,7 @@ namespace {
 namespace phlex::detail {
   void run(boost::json::object const& configurations, int const max_parallelism)
   {
-    auto g = phlex::detail::framework_graph::without_driver(max_parallelism);
+    auto g = framework_graph::without_driver(max_parallelism);
 
     // It is allowed for users to not specify any modules
     boost::json::object module_configs;

--- a/phlex/app/run.cpp
+++ b/phlex/app/run.cpp
@@ -14,7 +14,7 @@ namespace {
   }
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
   void run(boost::json::object const& configurations, int const max_parallelism)
   {
     auto g = phlex::detail::framework_graph::without_driver(max_parallelism);

--- a/phlex/app/run.hpp
+++ b/phlex/app/run.hpp
@@ -7,7 +7,7 @@
 
 #include <optional>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   RUN_PHLEX_EXPORT void run(boost::json::object const& configurations, int max_parallelism);
 }
 

--- a/phlex/app/version.cpp.in
+++ b/phlex/app/version.cpp.in
@@ -1,6 +1,6 @@
 #include "phlex/app/version.hpp"
 
-namespace phlex::experimental {
+namespace phlex::detail {
   // clang-format off
   char const* version() { return "@CMAKE_PROJECT_VERSION@"; }
   // clang-format on

--- a/phlex/app/version.hpp
+++ b/phlex/app/version.hpp
@@ -3,7 +3,7 @@
 
 #include "phlex/run_phlex_export.hpp"
 
-namespace phlex::experimental {
+namespace phlex::detail {
   RUN_PHLEX_EXPORT char const* version();
 }
 #endif // PHLEX_APP_VERSION_HPP

--- a/phlex/core/concepts.hpp
+++ b/phlex/core/concepts.hpp
@@ -19,7 +19,7 @@ namespace phlex::detail {
 
   template <typename T>
   concept sendable = std::move_constructible<T> || requires(T& t) {
-    { phlex::experimental::send(t) } -> std::move_constructible;
+    { send(t) } -> std::move_constructible;
   };
 
   template <typename T, std::size_t N>

--- a/phlex/core/concepts.hpp
+++ b/phlex/core/concepts.hpp
@@ -1,6 +1,7 @@
 #ifndef PHLEX_CORE_CONCEPTS_HPP
 #define PHLEX_CORE_CONCEPTS_HPP
 
+#include "phlex/core/fold/send.hpp"
 #include "phlex/core/fwd.hpp"
 #include "phlex/metaprogramming/type_deduction.hpp"
 #include "phlex/model/fwd.hpp"
@@ -8,21 +9,21 @@
 #include <concepts>
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   template <typename T>
   concept not_void = !std::same_as<T, void>;
 
   template <typename T>
-  concept is_bound_object = not std::same_as<T, phlex::detail::void_tag>;
+  concept is_bound_object = not std::same_as<T, void_tag>;
 
   template <typename T>
   concept sendable = std::move_constructible<T> || requires(T& t) {
-    { send(t) } -> std::move_constructible;
+    { phlex::experimental::send(t) } -> std::move_constructible;
   };
 
   template <typename T, std::size_t N>
-  concept at_least_n_input_parameters = phlex::detail::number_parameters<T> >= N;
+  concept at_least_n_input_parameters = number_parameters<T> >= N;
 
   template <typename T>
   concept at_least_one_input_parameter = at_least_n_input_parameters<T, 1>;
@@ -31,23 +32,23 @@ namespace phlex::experimental {
   concept at_least_two_input_parameters = at_least_n_input_parameters<T, 2>;
 
   template <typename T>
-  concept at_least_one_output_object = phlex::detail::number_output_objects<T> >= 1ull;
+  concept at_least_one_output_object = number_output_objects<T> >= 1ull;
 
   template <typename T>
   concept first_input_parameter_is_non_const_lvalue_reference =
-    at_least_one_input_parameter<T> && phlex::detail::is_non_const_lvalue_reference<
-                                         phlex::detail::function_parameter_type<0, T>>::value;
+    at_least_one_input_parameter<T> &&
+    is_non_const_lvalue_reference<function_parameter_type<0, T>>::value;
 
   template <typename T>
   concept first_input_parameter_is_sendable =
-    at_least_one_input_parameter<T> && sendable<phlex::detail::function_parameter_type<0, T>>;
+    at_least_one_input_parameter<T> && sendable<function_parameter_type<0, T>>;
 
   template <typename T, typename R>
-  concept returns = std::same_as<phlex::detail::return_type<T>, R>;
+  concept returns = std::same_as<return_type<T>, R>;
 
   template <typename T, typename... Args>
-  concept expects_input_parameters = at_least_n_input_parameters<T, sizeof...(Args)> &&
-                                     phlex::detail::check_parameters<T, Args...>::value;
+  concept expects_input_parameters =
+    at_least_n_input_parameters<T, sizeof...(Args)> && check_parameters<T, Args...>::value;
 
   template <typename T>
   concept is_predicate_like = at_least_one_input_parameter<T> && returns<T, bool>;
@@ -56,12 +57,13 @@ namespace phlex::experimental {
   concept is_observer_like = at_least_one_input_parameter<T> && returns<T, void>;
 
   template <typename T>
-  concept is_output_like = std::is_member_function_pointer_v<T> &&
-                           expects_input_parameters<T, product_store const&> && returns<T, void>;
+  concept is_output_like =
+    std::is_member_function_pointer_v<T> &&
+    expects_input_parameters<T, phlex::experimental::product_store const&> && returns<T, void>;
 
   template <typename T>
-  concept is_provider_like = expects_input_parameters<T, data_cell_index const&> &&
-                             phlex::detail::number_output_objects<T> == 1ull;
+  concept is_provider_like =
+    expects_input_parameters<T, data_cell_index const&> && number_output_objects<T> == 1ull;
 
   template <typename T>
   concept is_fold_like =

--- a/phlex/core/concepts.hpp
+++ b/phlex/core/concepts.hpp
@@ -14,7 +14,7 @@ namespace phlex::experimental {
   concept not_void = !std::same_as<T, void>;
 
   template <typename T>
-  concept is_bound_object = not std::same_as<T, void_tag>;
+  concept is_bound_object = not std::same_as<T, phlex::detail::void_tag>;
 
   template <typename T>
   concept sendable = std::move_constructible<T> || requires(T& t) {
@@ -22,7 +22,7 @@ namespace phlex::experimental {
   };
 
   template <typename T, std::size_t N>
-  concept at_least_n_input_parameters = number_parameters<T> >= N;
+  concept at_least_n_input_parameters = phlex::detail::number_parameters<T> >= N;
 
   template <typename T>
   concept at_least_one_input_parameter = at_least_n_input_parameters<T, 1>;
@@ -31,23 +31,23 @@ namespace phlex::experimental {
   concept at_least_two_input_parameters = at_least_n_input_parameters<T, 2>;
 
   template <typename T>
-  concept at_least_one_output_object = number_output_objects<T> >= 1ull;
+  concept at_least_one_output_object = phlex::detail::number_output_objects<T> >= 1ull;
 
   template <typename T>
   concept first_input_parameter_is_non_const_lvalue_reference =
-    at_least_one_input_parameter<T> &&
-    is_non_const_lvalue_reference<function_parameter_type<0, T>>::value;
+    at_least_one_input_parameter<T> && phlex::detail::is_non_const_lvalue_reference<
+                                         phlex::detail::function_parameter_type<0, T>>::value;
 
   template <typename T>
   concept first_input_parameter_is_sendable =
-    at_least_one_input_parameter<T> && sendable<function_parameter_type<0, T>>;
+    at_least_one_input_parameter<T> && sendable<phlex::detail::function_parameter_type<0, T>>;
 
   template <typename T, typename R>
-  concept returns = std::same_as<return_type<T>, R>;
+  concept returns = std::same_as<phlex::detail::return_type<T>, R>;
 
   template <typename T, typename... Args>
-  concept expects_input_parameters =
-    at_least_n_input_parameters<T, sizeof...(Args)> && check_parameters<T, Args...>::value;
+  concept expects_input_parameters = at_least_n_input_parameters<T, sizeof...(Args)> &&
+                                     phlex::detail::check_parameters<T, Args...>::value;
 
   template <typename T>
   concept is_predicate_like = at_least_one_input_parameter<T> && returns<T, bool>;
@@ -60,8 +60,8 @@ namespace phlex::experimental {
                            expects_input_parameters<T, product_store const&> && returns<T, void>;
 
   template <typename T>
-  concept is_provider_like =
-    expects_input_parameters<T, data_cell_index const&> && number_output_objects<T> == 1ull;
+  concept is_provider_like = expects_input_parameters<T, data_cell_index const&> &&
+                             phlex::detail::number_output_objects<T> == 1ull;
 
   template <typename T>
   concept is_fold_like =

--- a/phlex/core/consumer.cpp
+++ b/phlex/core/consumer.cpp
@@ -1,14 +1,21 @@
 #include "phlex/core/consumer.hpp"
 
-namespace phlex::experimental {
-  consumer::consumer(algorithm_name name, std::vector<std::string> predicates) :
+namespace phlex::detail {
+  consumer::consumer(phlex::experimental::algorithm_name name,
+                     std::vector<std::string> predicates) :
     name_{std::move(name)}, predicates_{std::move(predicates)}
   {
   }
 
-  algorithm_name const& consumer::name() const noexcept { return name_; }
-  identifier const& consumer::plugin() const noexcept { return name_.plugin(); }
-  identifier const& consumer::algorithm() const noexcept { return name_.algorithm(); }
+  phlex::experimental::algorithm_name const& consumer::name() const noexcept { return name_; }
+  phlex::experimental::identifier const& consumer::plugin() const noexcept
+  {
+    return name_.plugin();
+  }
+  phlex::experimental::identifier const& consumer::algorithm() const noexcept
+  {
+    return name_.algorithm();
+  }
 
   std::vector<std::string> const& consumer::when() const noexcept { return predicates_; }
 }

--- a/phlex/core/consumer.hpp
+++ b/phlex/core/consumer.hpp
@@ -8,18 +8,18 @@
 #include <string>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class PHLEX_CORE_EXPORT consumer {
   public:
-    consumer(algorithm_name name, std::vector<std::string> predicates);
+    consumer(phlex::experimental::algorithm_name name, std::vector<std::string> predicates);
 
-    algorithm_name const& name() const noexcept;
-    identifier const& plugin() const noexcept;
-    identifier const& algorithm() const noexcept;
+    phlex::experimental::algorithm_name const& name() const noexcept;
+    phlex::experimental::identifier const& plugin() const noexcept;
+    phlex::experimental::identifier const& algorithm() const noexcept;
     std::vector<std::string> const& when() const noexcept;
 
   private:
-    algorithm_name name_;
+    phlex::experimental::algorithm_name name_;
     std::vector<std::string> predicates_;
   };
 }

--- a/phlex/core/declared_fold.cpp
+++ b/phlex/core/declared_fold.cpp
@@ -1,7 +1,7 @@
 #include "phlex/core/declared_fold.hpp"
 
-namespace phlex::experimental {
-  declared_fold::declared_fold(algorithm_name name,
+namespace phlex::detail {
+  declared_fold::declared_fold(phlex::experimental::algorithm_name name,
                                std::vector<std::string> predicates,
                                product_selectors input_products) :
     products_consumer{std::move(name), std::move(predicates), std::move(input_products)}

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -50,7 +50,7 @@ namespace phlex::experimental {
   };
 
   using declared_fold_ptr = std::unique_ptr<declared_fold>;
-  using declared_folds = simple_ptr_map<declared_fold_ptr>;
+  using declared_folds = phlex::detail::simple_ptr_map<declared_fold_ptr>;
 
   // =====================================================================================
 

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -57,7 +57,8 @@ namespace phlex::experimental {
   template <typename AlgorithmBits, typename InitTuple>
   class fold_node : public declared_fold, private count_stores {
     using all_parameter_types = typename AlgorithmBits::input_parameter_types;
-    using input_parameter_types = skip_first_type<all_parameter_types>; // Skip fold object
+    using input_parameter_types =
+      phlex::detail::skip_first_type<all_parameter_types>; // Skip fold object
     static constexpr auto num_inputs = std::tuple_size_v<input_parameter_types>;
     using result_type = std::decay_t<std::tuple_element_t<0, all_parameter_types>>;
 

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -45,7 +45,7 @@ namespace phlex::experimental {
 
     virtual tbb::flow::sender<message>& output_port() = 0;
     virtual tbb::flow::receiver<flush_message>& flush_port() = 0;
-    virtual product_specifications const& output() const = 0;
+    virtual phlex::detail::product_specifications const& output() const = 0;
     virtual std::size_t product_count() const = 0;
   };
 
@@ -76,7 +76,8 @@ namespace phlex::experimental {
               std::string partition) :
       declared_fold{std::move(algo_name), std::move(predicates), std::move(input_products)},
       initializer_{std::move(initializer)},
-      output_{to_product_specifications(name(), std::move(output), make_type_ids<result_type>())},
+      output_{to_product_specifications(
+        name(), std::move(output), phlex::detail::make_type_ids<result_type>())},
       partition_{std::move(partition)},
       flush_receiver_{g,
                       tbb::flow::unlimited,
@@ -145,7 +146,7 @@ namespace phlex::experimental {
 
     tbb::flow::receiver<flush_message>& flush_port() override { return flush_receiver_; }
     tbb::flow::sender<message>& output_port() override { return tbb::flow::output_port<0>(fold_); }
-    product_specifications const& output() const override { return output_; }
+    phlex::detail::product_specifications const& output() const override { return output_; }
 
     template <std::size_t... Is>
     void call(function_t const& ft,
@@ -196,7 +197,7 @@ namespace phlex::experimental {
 
     InitTuple initializer_;
     input_retriever_types<input_parameter_types> input_{input_arguments<input_parameter_types>()};
-    product_specifications output_;
+    phlex::detail::product_specifications output_;
     identifier partition_;
     tbb::flow::function_node<flush_message> flush_receiver_;
     join_or_none_t<num_inputs> join_;

--- a/phlex/core/declared_fold.hpp
+++ b/phlex/core/declared_fold.hpp
@@ -35,30 +35,29 @@
 #include <type_traits>
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class PHLEX_CORE_EXPORT declared_fold : public products_consumer {
   public:
-    declared_fold(algorithm_name name,
+    declared_fold(phlex::experimental::algorithm_name name,
                   std::vector<std::string> predicates,
                   product_selectors input_products);
     ~declared_fold() override;
 
     virtual tbb::flow::sender<message>& output_port() = 0;
     virtual tbb::flow::receiver<flush_message>& flush_port() = 0;
-    virtual phlex::detail::product_specifications const& output() const = 0;
+    virtual product_specifications const& output() const = 0;
     virtual std::size_t product_count() const = 0;
   };
 
   using declared_fold_ptr = std::unique_ptr<declared_fold>;
-  using declared_folds = phlex::detail::simple_ptr_map<declared_fold_ptr>;
+  using declared_folds = simple_ptr_map<declared_fold_ptr>;
 
   // =====================================================================================
 
   template <typename AlgorithmBits, typename InitTuple>
   class fold_node : public declared_fold, private count_stores {
     using all_parameter_types = typename AlgorithmBits::input_parameter_types;
-    using input_parameter_types =
-      phlex::detail::skip_first_type<all_parameter_types>; // Skip fold object
+    using input_parameter_types = skip_first_type<all_parameter_types>; // Skip fold object
     static constexpr auto num_inputs = std::tuple_size_v<input_parameter_types>;
     using result_type = std::decay_t<std::tuple_element_t<0, all_parameter_types>>;
 
@@ -66,7 +65,7 @@ namespace phlex::experimental {
     using function_t = typename AlgorithmBits::bound_type;
 
   public:
-    fold_node(algorithm_name algo_name,
+    fold_node(phlex::experimental::algorithm_name algo_name,
               std::size_t concurrency,
               std::vector<std::string> predicates,
               tbb::flow::graph& g,
@@ -77,8 +76,7 @@ namespace phlex::experimental {
               std::string partition) :
       declared_fold{std::move(algo_name), std::move(predicates), std::move(input_products)},
       initializer_{std::move(initializer)},
-      output_{to_product_specifications(
-        name(), std::move(output), phlex::detail::make_type_ids<result_type>())},
+      output_{to_product_specifications(name(), std::move(output), make_type_ids<result_type>())},
       partition_{std::move(partition)},
       flush_receiver_{g,
                       tbb::flow::unlimited,
@@ -127,7 +125,7 @@ namespace phlex::experimental {
     void emit_and_evict_if_done(data_cell_index_ptr const& fold_index)
     {
       if (auto counter = done_with(fold_index->hash())) {
-        auto parent = std::make_shared<product_store>(fold_index, name());
+        auto parent = std::make_shared<phlex::experimental::product_store>(fold_index, name());
         commit(parent);
         ++product_count_;
         tbb::flow::output_port<0>(fold_).try_put(
@@ -147,7 +145,7 @@ namespace phlex::experimental {
 
     tbb::flow::receiver<flush_message>& flush_port() override { return flush_receiver_; }
     tbb::flow::sender<message>& output_port() override { return tbb::flow::output_port<0>(fold_); }
-    phlex::detail::product_specifications const& output() const override { return output_; }
+    product_specifications const& output() const override { return output_; }
 
     template <std::size_t... Is>
     void call(function_t const& ft,
@@ -183,9 +181,10 @@ namespace phlex::experimental {
       return std::unique_ptr<result_type>(new result_type{std::get<Is>(init)...});
     }
 
-    auto commit(product_store_ptr& store)
+    auto commit(phlex::experimental::product_store_ptr& store)
     {
       auto& result = results_.at(store->index()->hash());
+      using phlex::experimental::send;
       if constexpr (requires { send(*result); }) {
         store->add_product(output()[0], send(*result));
       } else {
@@ -198,8 +197,8 @@ namespace phlex::experimental {
 
     InitTuple initializer_;
     input_retriever_types<input_parameter_types> input_{input_arguments<input_parameter_types>()};
-    phlex::detail::product_specifications output_;
-    identifier partition_;
+    product_specifications output_;
+    phlex::experimental::identifier partition_;
     tbb::flow::function_node<flush_message> flush_receiver_;
     join_or_none_t<num_inputs> join_;
     tbb::flow::multifunction_node<messages_t<num_inputs>, message_tuple<1>> fold_;

--- a/phlex/core/declared_observer.cpp
+++ b/phlex/core/declared_observer.cpp
@@ -1,7 +1,7 @@
 #include "phlex/core/declared_observer.hpp"
 
-namespace phlex::experimental {
-  declared_observer::declared_observer(algorithm_name name,
+namespace phlex::detail {
+  declared_observer::declared_observer(phlex::experimental::algorithm_name name,
                                        std::vector<std::string> predicates,
                                        product_selectors input_products) :
     products_consumer{std::move(name), std::move(predicates), std::move(input_products)}

--- a/phlex/core/declared_observer.hpp
+++ b/phlex/core/declared_observer.hpp
@@ -30,18 +30,18 @@
 #include <type_traits>
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   class PHLEX_CORE_EXPORT declared_observer : public products_consumer {
   public:
-    declared_observer(algorithm_name name,
+    declared_observer(phlex::experimental::algorithm_name name,
                       std::vector<std::string> predicates,
                       product_selectors input_products);
     ~declared_observer() override;
   };
 
   using declared_observer_ptr = std::unique_ptr<declared_observer>;
-  using declared_observers = phlex::detail::simple_ptr_map<declared_observer_ptr>;
+  using declared_observers = simple_ptr_map<declared_observer_ptr>;
 
   // =====================================================================================
 
@@ -55,7 +55,7 @@ namespace phlex::experimental {
     static constexpr auto number_output_products = 0;
     using node_ptr_type = declared_observer_ptr;
 
-    observer_node(algorithm_name algo_name,
+    observer_node(phlex::experimental::algorithm_name algo_name,
                   std::size_t concurrency,
                   std::vector<std::string> predicates,
                   tbb::flow::graph& g,

--- a/phlex/core/declared_observer.hpp
+++ b/phlex/core/declared_observer.hpp
@@ -41,7 +41,7 @@ namespace phlex::experimental {
   };
 
   using declared_observer_ptr = std::unique_ptr<declared_observer>;
-  using declared_observers = simple_ptr_map<declared_observer_ptr>;
+  using declared_observers = phlex::detail::simple_ptr_map<declared_observer_ptr>;
 
   // =====================================================================================
 

--- a/phlex/core/declared_output.cpp
+++ b/phlex/core/declared_output.cpp
@@ -2,12 +2,12 @@
 #include "phlex/configuration.hpp"
 #include "phlex/core/detail/make_algorithm_name.hpp"
 
-namespace phlex::experimental {
-  declared_output::declared_output(algorithm_name name,
+namespace phlex::detail {
+  declared_output::declared_output(phlex::experimental::algorithm_name name,
                                    std::size_t concurrency,
                                    std::vector<std::string> predicates,
                                    tbb::flow::graph& g,
-                                   detail::output_function_t&& ft) :
+                                   internal::output_function_t&& ft) :
     consumer{std::move(name), std::move(predicates)},
     node_{g, concurrency, [this, f = std::move(ft)](message const& msg) -> tbb::flow::continue_msg {
             f(*msg.store);

--- a/phlex/core/declared_output.hpp
+++ b/phlex/core/declared_output.hpp
@@ -18,17 +18,17 @@
 #include <string>
 #include <vector>
 
-namespace phlex::experimental {
-  namespace detail {
-    using output_function_t = std::function<void(product_store const&)>;
+namespace phlex::detail {
+  namespace internal {
+    using output_function_t = std::function<void(phlex::experimental::product_store const&)>;
   }
   class PHLEX_CORE_EXPORT declared_output : public consumer {
   public:
-    declared_output(algorithm_name name,
+    declared_output(phlex::experimental::algorithm_name name,
                     std::size_t concurrency,
                     std::vector<std::string> predicates,
                     tbb::flow::graph& g,
-                    detail::output_function_t&& ft);
+                    internal::output_function_t&& ft);
 
     tbb::flow::receiver<message>& port() noexcept;
     std::size_t num_calls() const { return calls_; }
@@ -39,7 +39,7 @@ namespace phlex::experimental {
   };
 
   using declared_output_ptr = std::unique_ptr<declared_output>;
-  using declared_outputs = phlex::detail::simple_ptr_map<declared_output_ptr>;
+  using declared_outputs = simple_ptr_map<declared_output_ptr>;
 }
 
 #endif // PHLEX_CORE_DECLARED_OUTPUT_HPP

--- a/phlex/core/declared_output.hpp
+++ b/phlex/core/declared_output.hpp
@@ -39,7 +39,7 @@ namespace phlex::experimental {
   };
 
   using declared_output_ptr = std::unique_ptr<declared_output>;
-  using declared_outputs = simple_ptr_map<declared_output_ptr>;
+  using declared_outputs = phlex::detail::simple_ptr_map<declared_output_ptr>;
 }
 
 #endif // PHLEX_CORE_DECLARED_OUTPUT_HPP

--- a/phlex/core/declared_predicate.cpp
+++ b/phlex/core/declared_predicate.cpp
@@ -1,7 +1,7 @@
 #include "phlex/core/declared_predicate.hpp"
 
-namespace phlex::experimental {
-  declared_predicate::declared_predicate(algorithm_name name,
+namespace phlex::detail {
+  declared_predicate::declared_predicate(phlex::experimental::algorithm_name name,
                                          std::vector<std::string> predicates,
                                          product_selectors input_products) :
     products_consumer{std::move(name), std::move(predicates), std::move(input_products)}

--- a/phlex/core/declared_predicate.hpp
+++ b/phlex/core/declared_predicate.hpp
@@ -45,7 +45,7 @@ namespace phlex::experimental {
   };
 
   using declared_predicate_ptr = std::unique_ptr<declared_predicate>;
-  using declared_predicates = simple_ptr_map<declared_predicate_ptr>;
+  using declared_predicates = phlex::detail::simple_ptr_map<declared_predicate_ptr>;
 
   // =====================================================================================
 

--- a/phlex/core/declared_predicate.hpp
+++ b/phlex/core/declared_predicate.hpp
@@ -32,11 +32,11 @@
 #include <type_traits>
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   class PHLEX_CORE_EXPORT declared_predicate : public products_consumer {
   public:
-    declared_predicate(algorithm_name name,
+    declared_predicate(phlex::experimental::algorithm_name name,
                        std::vector<std::string> predicates,
                        product_selectors input_products);
     ~declared_predicate() override;
@@ -45,7 +45,7 @@ namespace phlex::experimental {
   };
 
   using declared_predicate_ptr = std::unique_ptr<declared_predicate>;
-  using declared_predicates = phlex::detail::simple_ptr_map<declared_predicate_ptr>;
+  using declared_predicates = simple_ptr_map<declared_predicate_ptr>;
 
   // =====================================================================================
 
@@ -59,7 +59,7 @@ namespace phlex::experimental {
     static constexpr auto number_output_products = 0ull;
     using node_ptr_type = declared_predicate_ptr;
 
-    predicate_node(algorithm_name algo_name,
+    predicate_node(phlex::experimental::algorithm_name algo_name,
                    std::size_t concurrency,
                    std::vector<std::string> predicates,
                    tbb::flow::graph& g,

--- a/phlex/core/declared_transform.cpp
+++ b/phlex/core/declared_transform.cpp
@@ -1,7 +1,7 @@
 #include "phlex/core/declared_transform.hpp"
 
-namespace phlex::experimental {
-  declared_transform::declared_transform(algorithm_name name,
+namespace phlex::detail {
+  declared_transform::declared_transform(phlex::experimental::algorithm_name name,
                                          std::vector<std::string> predicates,
                                          product_selectors input_products) :
     products_consumer{std::move(name), std::move(predicates), std::move(input_products)}

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -61,7 +61,7 @@ namespace phlex::experimental {
     using input_parameter_types = typename AlgorithmBits::input_parameter_types;
 
     static constexpr auto num_inputs = AlgorithmBits::number_inputs;
-    static constexpr auto num_outputs = number_output_objects<function_t>;
+    static constexpr auto num_outputs = phlex::detail::number_output_objects<function_t>;
 
   public:
     using node_ptr_type = declared_transform_ptr;

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -46,12 +46,12 @@ namespace phlex::detail {
     ~declared_transform() override;
 
     virtual tbb::flow::sender<message>& output_port() = 0;
-    virtual phlex::detail::product_specifications const& output() const = 0;
+    virtual product_specifications const& output() const = 0;
     virtual std::size_t product_count() const = 0;
   };
 
   using declared_transform_ptr = std::unique_ptr<declared_transform>;
-  using declared_transforms = phlex::detail::simple_ptr_map<declared_transform_ptr>;
+  using declared_transforms = simple_ptr_map<declared_transform_ptr>;
 
   // =====================================================================================
 
@@ -61,7 +61,7 @@ namespace phlex::detail {
     using input_parameter_types = typename AlgorithmBits::input_parameter_types;
 
     static constexpr auto num_inputs = AlgorithmBits::number_inputs;
-    static constexpr auto num_outputs = phlex::detail::number_output_objects<function_t>;
+    static constexpr auto num_outputs = number_output_objects<function_t>;
 
   public:
     using node_ptr_type = declared_transform_ptr;
@@ -90,7 +90,7 @@ namespace phlex::detail {
           ++calls_;
           ++product_count_[store->index()->layer_hash()];
 
-          phlex::detail::products new_products{num_outputs};
+          products new_products{num_outputs};
           new_products.add_all(output_, std::move(result));
           auto new_store = std::make_shared<phlex::experimental::product_store>(
             store->index(), name(), std::move(new_products));
@@ -118,7 +118,7 @@ namespace phlex::detail {
     {
       return tbb::flow::output_port<0>(transform_);
     }
-    phlex::detail::product_specifications const& output() const override { return output_; }
+    product_specifications const& output() const override { return output_; }
 
     template <std::size_t... Is>
     auto call(function_t const& ft,
@@ -144,7 +144,7 @@ namespace phlex::detail {
     }
 
     input_retriever_types<input_parameter_types> input_{input_arguments<input_parameter_types>()};
-    phlex::detail::product_specifications output_;
+    product_specifications output_;
     join_or_none_t<num_inputs> join_;
     tbb::flow::multifunction_node<messages_t<num_inputs>, message_tuple<1u>> transform_;
     std::atomic<std::size_t> calls_;

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -46,7 +46,7 @@ namespace phlex::experimental {
     ~declared_transform() override;
 
     virtual tbb::flow::sender<message>& output_port() = 0;
-    virtual product_specifications const& output() const = 0;
+    virtual phlex::detail::product_specifications const& output() const = 0;
     virtual std::size_t product_count() const = 0;
   };
 
@@ -75,8 +75,8 @@ namespace phlex::experimental {
                    product_selectors input_products,
                    std::vector<std::string> output) :
       declared_transform{std::move(algo_name), std::move(predicates), std::move(input_products)},
-      output_{
-        to_product_specifications(name(), std::move(output), make_output_type_ids<function_t>())},
+      output_{to_product_specifications(
+        name(), std::move(output), phlex::detail::make_output_type_ids<function_t>())},
       join_{make_join_or_none<num_inputs>(g, name().to_string(), layers())},
       transform_{
         g,
@@ -89,7 +89,7 @@ namespace phlex::experimental {
           ++calls_;
           ++product_count_[store->index()->layer_hash()];
 
-          products new_products{num_outputs};
+          phlex::detail::products new_products{num_outputs};
           new_products.add_all(output_, std::move(result));
           auto new_store =
             std::make_shared<product_store>(store->index(), name(), std::move(new_products));
@@ -117,7 +117,7 @@ namespace phlex::experimental {
     {
       return tbb::flow::output_port<0>(transform_);
     }
-    product_specifications const& output() const override { return output_; }
+    phlex::detail::product_specifications const& output() const override { return output_; }
 
     template <std::size_t... Is>
     auto call(function_t const& ft,
@@ -143,7 +143,7 @@ namespace phlex::experimental {
     }
 
     input_retriever_types<input_parameter_types> input_{input_arguments<input_parameter_types>()};
-    product_specifications output_;
+    phlex::detail::product_specifications output_;
     join_or_none_t<num_inputs> join_;
     tbb::flow::multifunction_node<messages_t<num_inputs>, message_tuple<1u>> transform_;
     std::atomic<std::size_t> calls_;

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -51,7 +51,7 @@ namespace phlex::experimental {
   };
 
   using declared_transform_ptr = std::unique_ptr<declared_transform>;
-  using declared_transforms = simple_ptr_map<declared_transform_ptr>;
+  using declared_transforms = phlex::detail::simple_ptr_map<declared_transform_ptr>;
 
   // =====================================================================================
 

--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -36,11 +36,11 @@
 #include <type_traits>
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   class PHLEX_CORE_EXPORT declared_transform : public products_consumer {
   public:
-    declared_transform(algorithm_name name,
+    declared_transform(phlex::experimental::algorithm_name name,
                        std::vector<std::string> predicates,
                        product_selectors input_products);
     ~declared_transform() override;
@@ -67,7 +67,7 @@ namespace phlex::experimental {
     using node_ptr_type = declared_transform_ptr;
     static constexpr auto number_output_products = num_outputs;
 
-    transform_node(algorithm_name algo_name,
+    transform_node(phlex::experimental::algorithm_name algo_name,
                    std::size_t concurrency,
                    std::vector<std::string> predicates,
                    tbb::flow::graph& g,
@@ -75,13 +75,14 @@ namespace phlex::experimental {
                    product_selectors input_products,
                    std::vector<std::string> output) :
       declared_transform{std::move(algo_name), std::move(predicates), std::move(input_products)},
-      output_{to_product_specifications(
-        name(), std::move(output), phlex::detail::make_output_type_ids<function_t>())},
+      output_{
+        to_product_specifications(name(), std::move(output), make_output_type_ids<function_t>())},
       join_{make_join_or_none<num_inputs>(g, name().to_string(), layers())},
       transform_{
         g,
         concurrency,
         [this, ft = alg.release_algorithm()](messages_t<num_inputs> const& messages, auto& output) {
+          using namespace phlex::experimental::detail;
           auto const& msg = most_derived(messages);
           auto const& [store, message_id] = std::tie(msg.store, msg.id);
 
@@ -91,8 +92,8 @@ namespace phlex::experimental {
 
           phlex::detail::products new_products{num_outputs};
           new_products.add_all(output_, std::move(result));
-          auto new_store =
-            std::make_shared<product_store>(store->index(), name(), std::move(new_products));
+          auto new_store = std::make_shared<phlex::experimental::product_store>(
+            store->index(), name(), std::move(new_products));
 
           std::get<0>(output).try_put({.store = std::move(new_store), .id = message_id});
         }}

--- a/phlex/core/declared_unfold.cpp
+++ b/phlex/core/declared_unfold.cpp
@@ -13,7 +13,8 @@ namespace phlex::experimental {
     parent_{std::const_pointer_cast<product_store>(parent)},
     node_name_{std::move(node_name)},
     child_layer_name_{child_layer_name},
-    child_layer_hash_{hash(parent->index()->layer_hash(), identifier{child_layer_name_}.hash())}
+    child_layer_hash_{
+      phlex::detail::hash(parent->index()->layer_hash(), identifier{child_layer_name_}.hash())}
   {
   }
 

--- a/phlex/core/declared_unfold.cpp
+++ b/phlex/core/declared_unfold.cpp
@@ -5,28 +5,29 @@
 #include "fmt/std.h"
 #include "spdlog/spdlog.h"
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
-  generator::generator(product_store_const_ptr const& parent,
-                       algorithm_name node_name,
+  generator::generator(phlex::experimental::product_store_const_ptr const& parent,
+                       phlex::experimental::algorithm_name node_name,
                        std::string const& child_layer_name) :
-    parent_{std::const_pointer_cast<product_store>(parent)},
+    parent_{std::const_pointer_cast<phlex::experimental::product_store>(parent)},
     node_name_{std::move(node_name)},
     child_layer_name_{child_layer_name},
-    child_layer_hash_{
-      phlex::detail::hash(parent->index()->layer_hash(), identifier{child_layer_name_}.hash())}
+    child_layer_hash_{hash(parent->index()->layer_hash(),
+                           phlex::experimental::identifier{child_layer_name_}.hash())}
   {
   }
 
-  product_store_const_ptr generator::make_child(std::size_t const i,
-                                                phlex::detail::products new_products)
+  phlex::experimental::product_store_const_ptr generator::make_child(std::size_t const i,
+                                                                     products new_products)
   {
     auto child_index = parent_->index()->make_child(child_layer_name_, i);
     ++child_counts_;
-    return std::make_shared<product_store>(child_index, node_name_, std::move(new_products));
+    return std::make_shared<phlex::experimental::product_store>(
+      child_index, node_name_, std::move(new_products));
   }
 
-  declared_unfold::declared_unfold(algorithm_name name,
+  declared_unfold::declared_unfold(phlex::experimental::algorithm_name name,
                                    std::vector<std::string> predicates,
                                    product_selectors input_products,
                                    std::string child_layer) :

--- a/phlex/core/declared_unfold.cpp
+++ b/phlex/core/declared_unfold.cpp
@@ -18,7 +18,8 @@ namespace phlex::experimental {
   {
   }
 
-  product_store_const_ptr generator::make_child(std::size_t const i, products new_products)
+  product_store_const_ptr generator::make_child(std::size_t const i,
+                                                phlex::detail::products new_products)
   {
     auto child_index = parent_->index()->make_child(child_layer_name_, i);
     ++child_counts_;

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -43,7 +43,7 @@ namespace phlex::experimental {
 
     std::size_t child_layer_hash() const { return child_layer_hash_; }
     std::size_t child_count() const { return child_counts_; }
-    product_store_const_ptr make_child(std::size_t i, products new_products);
+    product_store_const_ptr make_child(std::size_t i, phlex::detail::products new_products);
 
   private:
     product_store_ptr parent_;
@@ -65,8 +65,8 @@ namespace phlex::experimental {
 
     virtual tbb::flow::sender<message>& output_port() = 0;
     virtual tbb::flow::sender<index_message>& output_index_port() = 0;
-    virtual tbb::flow::sender<unfold_flush>& flush_sender() = 0;
-    virtual product_specifications const& output() const = 0;
+    virtual tbb::flow::sender<phlex::detail::unfold_flush>& flush_sender() = 0;
+    virtual phlex::detail::product_specifications const& output() const = 0;
     virtual std::size_t product_count() const = 0;
 
     std::string const& child_layer() const noexcept { return child_layer_; }
@@ -100,9 +100,10 @@ namespace phlex::experimental {
                       std::move(predicates),
                       std::move(input_products),
                       std::move(child_layer_name)},
-      output_{to_product_specifications(name(),
-                                        std::move(output_product_suffixes),
-                                        make_type_ids<skip_first_type<return_type<Unfold>>>())},
+      output_{to_product_specifications(
+        name(),
+        std::move(output_product_suffixes),
+        phlex::detail::make_type_ids<skip_first_type<return_type<Unfold>>>())},
       join_{make_join_or_none<num_inputs>(g, name().to_string(), layers())},
       unfold_{g,
               concurrency,
@@ -142,11 +143,11 @@ namespace phlex::experimental {
     {
       return tbb::flow::output_port<1>(unfold_);
     }
-    tbb::flow::sender<unfold_flush>& flush_sender() override
+    tbb::flow::sender<phlex::detail::unfold_flush>& flush_sender() override
     {
       return tbb::flow::output_port<2>(unfold_);
     }
-    product_specifications const& output() const override { return output_; }
+    phlex::detail::product_specifications const& output() const override { return output_; }
 
     template <std::size_t... Is>
     void call(Predicate const& predicate,
@@ -167,7 +168,7 @@ namespace phlex::experimental {
       std::size_t counter = 0;
       auto running_value = obj.initial_value();
       while (std::invoke(predicate, obj, running_value)) {
-        products new_products{num_outputs};
+        phlex::detail::products new_products{num_outputs};
         auto new_id = unfolded_id->make_child(child_layer(), counter);
         if constexpr (requires { std::invoke(unfold, obj, running_value, *new_id); }) {
           auto [next_value, prods] = std::invoke(unfold, obj, running_value, *new_id);
@@ -192,10 +193,10 @@ namespace phlex::experimental {
     std::size_t product_count() const final { return product_count_.load(); }
 
     input_retriever_types<input_args> input_{input_arguments<input_args>()};
-    product_specifications output_;
+    phlex::detail::product_specifications output_;
     join_or_none_t<num_inputs> join_;
     tbb::flow::multifunction_node<messages_t<num_inputs>,
-                                  std::tuple<message, index_message, unfold_flush>>
+                                  std::tuple<message, index_message, phlex::detail::unfold_flush>>
       unfold_;
     std::atomic<std::size_t> msg_counter_{}; // Is this sufficient?  Probably not.
     std::atomic<std::size_t> calls_{};

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -82,9 +82,9 @@ namespace phlex::experimental {
 
   template <typename Object, typename Predicate, typename Unfold>
   class unfold_node : public declared_unfold {
-    using input_args = constructor_parameter_types<Object>;
+    using input_args = phlex::detail::constructor_parameter_types<Object>;
     static constexpr std::size_t num_inputs = std::tuple_size_v<input_args>;
-    static constexpr std::size_t num_outputs = number_output_objects<Unfold>;
+    static constexpr std::size_t num_outputs = phlex::detail::number_output_objects<Unfold>;
 
   public:
     unfold_node(algorithm_name algo_name,
@@ -103,7 +103,8 @@ namespace phlex::experimental {
       output_{to_product_specifications(
         name(),
         std::move(output_product_suffixes),
-        phlex::detail::make_type_ids<skip_first_type<return_type<Unfold>>>())},
+        phlex::detail::make_type_ids<
+          phlex::detail::skip_first_type<phlex::detail::return_type<Unfold>>>())},
       join_{make_join_or_none<num_inputs>(g, name().to_string(), layers())},
       unfold_{g,
               concurrency,

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -76,7 +76,7 @@ namespace phlex::experimental {
   };
 
   using declared_unfold_ptr = std::unique_ptr<declared_unfold>;
-  using declared_unfolds = simple_ptr_map<declared_unfold_ptr>;
+  using declared_unfolds = phlex::detail::simple_ptr_map<declared_unfold_ptr>;
 
   // =====================================================================================
 

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -43,8 +43,7 @@ namespace phlex::detail {
 
     std::size_t child_layer_hash() const { return child_layer_hash_; }
     std::size_t child_count() const { return child_counts_; }
-    phlex::experimental::product_store_const_ptr make_child(std::size_t i,
-                                                            phlex::detail::products new_products);
+    phlex::experimental::product_store_const_ptr make_child(std::size_t i, products new_products);
 
   private:
     phlex::experimental::product_store_ptr parent_;
@@ -66,8 +65,8 @@ namespace phlex::detail {
 
     virtual tbb::flow::sender<message>& output_port() = 0;
     virtual tbb::flow::sender<index_message>& output_index_port() = 0;
-    virtual tbb::flow::sender<phlex::detail::unfold_flush>& flush_sender() = 0;
-    virtual phlex::detail::product_specifications const& output() const = 0;
+    virtual tbb::flow::sender<unfold_flush>& flush_sender() = 0;
+    virtual product_specifications const& output() const = 0;
     virtual std::size_t product_count() const = 0;
 
     std::string const& child_layer() const noexcept { return child_layer_; }
@@ -77,15 +76,15 @@ namespace phlex::detail {
   };
 
   using declared_unfold_ptr = std::unique_ptr<declared_unfold>;
-  using declared_unfolds = phlex::detail::simple_ptr_map<declared_unfold_ptr>;
+  using declared_unfolds = simple_ptr_map<declared_unfold_ptr>;
 
   // =====================================================================================
 
   template <typename Object, typename Predicate, typename Unfold>
   class unfold_node : public declared_unfold {
-    using input_args = phlex::detail::constructor_parameter_types<Object>;
+    using input_args = constructor_parameter_types<Object>;
     static constexpr std::size_t num_inputs = std::tuple_size_v<input_args>;
-    static constexpr std::size_t num_outputs = phlex::detail::number_output_objects<Unfold>;
+    static constexpr std::size_t num_outputs = number_output_objects<Unfold>;
 
   public:
     unfold_node(phlex::experimental::algorithm_name algo_name,
@@ -101,11 +100,9 @@ namespace phlex::detail {
                       std::move(predicates),
                       std::move(input_products),
                       std::move(child_layer_name)},
-      output_{to_product_specifications(
-        name(),
-        std::move(output_product_suffixes),
-        phlex::detail::make_type_ids<
-          phlex::detail::skip_first_type<phlex::detail::return_type<Unfold>>>())},
+      output_{to_product_specifications(name(),
+                                        std::move(output_product_suffixes),
+                                        make_type_ids<skip_first_type<return_type<Unfold>>>())},
       join_{make_join_or_none<num_inputs>(g, name().to_string(), layers())},
       unfold_{g,
               concurrency,
@@ -145,11 +142,11 @@ namespace phlex::detail {
     {
       return tbb::flow::output_port<1>(unfold_);
     }
-    tbb::flow::sender<phlex::detail::unfold_flush>& flush_sender() override
+    tbb::flow::sender<unfold_flush>& flush_sender() override
     {
       return tbb::flow::output_port<2>(unfold_);
     }
-    phlex::detail::product_specifications const& output() const override { return output_; }
+    product_specifications const& output() const override { return output_; }
 
     template <std::size_t... Is>
     void call(Predicate const& predicate,

--- a/phlex/core/declared_unfold.hpp
+++ b/phlex/core/declared_unfold.hpp
@@ -33,21 +33,22 @@
 #include <utility>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   class PHLEX_CORE_EXPORT generator {
   public:
-    explicit generator(product_store_const_ptr const& parent,
-                       algorithm_name node_name,
+    explicit generator(phlex::experimental::product_store_const_ptr const& parent,
+                       phlex::experimental::algorithm_name node_name,
                        std::string const& child_layer_name);
 
     std::size_t child_layer_hash() const { return child_layer_hash_; }
     std::size_t child_count() const { return child_counts_; }
-    product_store_const_ptr make_child(std::size_t i, phlex::detail::products new_products);
+    phlex::experimental::product_store_const_ptr make_child(std::size_t i,
+                                                            phlex::detail::products new_products);
 
   private:
-    product_store_ptr parent_;
-    algorithm_name node_name_;
+    phlex::experimental::product_store_ptr parent_;
+    phlex::experimental::algorithm_name node_name_;
     // References declared_unfold::child_layer_, which outlives this short-lived object.
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::string const& child_layer_name_;
@@ -57,7 +58,7 @@ namespace phlex::experimental {
 
   class PHLEX_CORE_EXPORT declared_unfold : public products_consumer {
   public:
-    declared_unfold(algorithm_name name,
+    declared_unfold(phlex::experimental::algorithm_name name,
                     std::vector<std::string> predicates,
                     product_selectors input_products,
                     std::string child_layer);
@@ -87,7 +88,7 @@ namespace phlex::experimental {
     static constexpr std::size_t num_outputs = phlex::detail::number_output_objects<Unfold>;
 
   public:
-    unfold_node(algorithm_name algo_name,
+    unfold_node(phlex::experimental::algorithm_name algo_name,
                 std::size_t concurrency,
                 std::vector<std::string> predicates,
                 tbb::flow::graph& g,
@@ -169,7 +170,7 @@ namespace phlex::experimental {
       std::size_t counter = 0;
       auto running_value = obj.initial_value();
       while (std::invoke(predicate, obj, running_value)) {
-        phlex::detail::products new_products{num_outputs};
+        products new_products{num_outputs};
         auto new_id = unfolded_id->make_child(child_layer(), counter);
         if constexpr (requires { std::invoke(unfold, obj, running_value, *new_id); }) {
           auto [next_value, prods] = std::invoke(unfold, obj, running_value, *new_id);
@@ -194,10 +195,10 @@ namespace phlex::experimental {
     std::size_t product_count() const final { return product_count_.load(); }
 
     input_retriever_types<input_args> input_{input_arguments<input_args>()};
-    phlex::detail::product_specifications output_;
+    product_specifications output_;
     join_or_none_t<num_inputs> join_;
     tbb::flow::multifunction_node<messages_t<num_inputs>,
-                                  std::tuple<message, index_message, phlex::detail::unfold_flush>>
+                                  std::tuple<message, index_message, unfold_flush>>
       unfold_;
     std::atomic<std::size_t> msg_counter_{}; // Is this sufficient?  Probably not.
     std::atomic<std::size_t> calls_{};

--- a/phlex/core/detail/filter_impl.cpp
+++ b/phlex/core/detail/filter_impl.cpp
@@ -14,7 +14,7 @@ namespace {
   }
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
   decision_map::decision_map(unsigned int total_decisions) : total_decisions_{total_decisions} {}
 
   void decision_map::update(predicate_result result)
@@ -63,7 +63,8 @@ namespace phlex::experimental {
 
   data_map::data_map(for_output_t) : data_map{for_output_only()} {}
 
-  void data_map::update(std::size_t const msg_id, product_store_const_ptr const& store)
+  void data_map::update(std::size_t const msg_id,
+                        phlex::experimental::product_store_const_ptr const& store)
   {
     decltype(stores_)::accessor a;
     if (stores_.insert(a, msg_id)) {
@@ -98,9 +99,10 @@ namespace phlex::experimental {
     return false;
   }
 
-  std::vector<product_store_const_ptr> data_map::release_data(std::size_t const msg_id)
+  std::vector<phlex::experimental::product_store_const_ptr> data_map::release_data(
+    std::size_t const msg_id)
   {
-    std::vector<product_store_const_ptr> result;
+    std::vector<phlex::experimental::product_store_const_ptr> result;
     if (decltype(stores_)::accessor a; stores_.find(a, msg_id)) {
       result = std::move(a->second);
       stores_.erase(a);

--- a/phlex/core/detail/filter_impl.hpp
+++ b/phlex/core/detail/filter_impl.hpp
@@ -11,7 +11,7 @@
 
 #include <cassert>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   struct predicate_result {
     std::size_t msg_id;
     bool result;
@@ -53,7 +53,8 @@ namespace phlex::experimental {
 
   class PHLEX_CORE_EXPORT data_map {
     using stores_t =
-      oneapi::tbb::concurrent_hash_map<std::size_t, std::vector<product_store_const_ptr>>;
+      oneapi::tbb::concurrent_hash_map<std::size_t,
+                                       std::vector<phlex::experimental::product_store_const_ptr>>;
 
   public:
     struct for_output_t {};
@@ -63,12 +64,14 @@ namespace phlex::experimental {
 
     bool is_complete(std::size_t const msg_id) const;
 
-    void update(std::size_t const msg_id, product_store_const_ptr const& store);
-    std::vector<product_store_const_ptr> release_data(std::size_t const msg_id);
+    void update(std::size_t const msg_id,
+                phlex::experimental::product_store_const_ptr const& store);
+    std::vector<phlex::experimental::product_store_const_ptr> release_data(
+      std::size_t const msg_id);
 
   private:
     stores_t stores_;
-    std::vector<product_selector> const* input_products_;
+    product_selectors const* input_products_;
     std::size_t nargs_;
   };
 }

--- a/phlex/core/detail/make_algorithm_name.cpp
+++ b/phlex/core/detail/make_algorithm_name.cpp
@@ -3,7 +3,7 @@
 #include "phlex/model/algorithm_name.hpp"
 #include "phlex/model/identifier.hpp"
 
-namespace phlex::experimental::detail {
+namespace phlex::experimental::internal {
   algorithm_name make_algorithm_name(configuration const* config, std::string_view name)
   {
     return {config ? identifier(config->get<std::string_view>("module_label")) : ""_id,

--- a/phlex/core/detail/make_algorithm_name.hpp
+++ b/phlex/core/detail/make_algorithm_name.hpp
@@ -14,8 +14,7 @@ namespace phlex {
 
 namespace phlex::experimental {
   class algorithm_name;
-
-  namespace detail {
+  namespace internal {
     PHLEX_CORE_EXPORT algorithm_name make_algorithm_name(configuration const* config,
                                                          std::string_view name);
   }

--- a/phlex/core/detail/maybe_predicates.cpp
+++ b/phlex/core/detail/maybe_predicates.cpp
@@ -1,7 +1,7 @@
 #include "phlex/core/detail/maybe_predicates.hpp"
 #include "phlex/configuration.hpp"
 
-namespace phlex::experimental::detail {
+namespace phlex::detail::internal {
   std::optional<std::vector<std::string>> maybe_predicates(configuration const* config)
   {
     return config->get_if_present<std::vector<std::string>>("experimental_when");

--- a/phlex/core/detail/maybe_predicates.hpp
+++ b/phlex/core/detail/maybe_predicates.hpp
@@ -14,7 +14,7 @@ namespace phlex {
   class configuration;
 }
 
-namespace phlex::experimental::detail {
+namespace phlex::detail::internal {
   PHLEX_CORE_EXPORT std::optional<std::vector<std::string>> maybe_predicates(
     configuration const* config);
 }

--- a/phlex/core/detail/repeater_node.cpp
+++ b/phlex/core/detail/repeater_node.cpp
@@ -4,9 +4,11 @@
 
 #include <cassert>
 
-namespace phlex::experimental::detail {
+namespace phlex::detail::internal {
 
-  repeater_node::repeater_node(tbb::flow::graph& g, std::string node_name, identifier layer_name) :
+  repeater_node::repeater_node(tbb::flow::graph& g,
+                               std::string node_name,
+                               phlex::experimental::identifier layer_name) :
     base_t{g},
     indexer_{g},
     repeater_{g,

--- a/phlex/core/detail/repeater_node.hpp
+++ b/phlex/core/detail/repeater_node.hpp
@@ -13,14 +13,16 @@
 #include <memory>
 #include <string>
 
-namespace phlex::experimental::detail {
+namespace phlex::detail::internal {
 
   using repeater_node_input = std::tuple<message, indexed_end_token, index_message>;
 
   class PHLEX_CORE_EXPORT repeater_node :
     public tbb::flow::composite_node<repeater_node_input, message_tuple<1>> {
   public:
-    repeater_node(tbb::flow::graph& g, std::string node_name, identifier layer_name);
+    repeater_node(tbb::flow::graph& g,
+                  std::string node_name,
+                  phlex::experimental::identifier layer_name);
 
     tbb::flow::receiver<message>& data_port();
     tbb::flow::receiver<indexed_end_token>& flush_port();
@@ -62,7 +64,7 @@ namespace phlex::experimental::detail {
     cache_t cached_products_;
     std::atomic<bool> cache_enabled_{true};
     std::string node_name_;
-    identifier layer_;
+    phlex::experimental::identifier layer_;
   };
 }
 

--- a/phlex/core/filter.cpp
+++ b/phlex/core/filter.cpp
@@ -8,10 +8,10 @@
 #include <cassert>
 #include <ranges>
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 using namespace oneapi::tbb;
 
-namespace phlex::experimental {
+namespace phlex::detail {
   filter::filter(flow::graph& g, products_consumer& consumer) :
     filter_base{g},
     decisions_{static_cast<unsigned int>(consumer.when().size())},

--- a/phlex/core/filter.hpp
+++ b/phlex/core/filter.hpp
@@ -9,7 +9,7 @@
 
 #include "oneapi/tbb/flow_graph.h"
 
-namespace phlex::experimental {
+namespace phlex::detail {
   using filter_base =
     oneapi::tbb::flow::composite_node<std::tuple<message, predicate_result>,
                                       std::tuple<oneapi::tbb::flow::continue_msg>>;

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -29,7 +29,7 @@ namespace phlex::detail {
   framework_graph::framework_graph(driver_mode const mode, int const max_parallelism) :
     parallelism_limit_{static_cast<std::size_t>(max_parallelism)},
     src_{graph_,
-         [this](tbb::flow_control& fc) mutable -> phlex::detail::ready_flushes_then_emit {
+         [this](tbb::flow_control& fc) mutable -> ready_flushes_then_emit {
            assert(driver_);
            if (auto item = (*driver_)()) {
              return {.ready_flushes = cell_tracker_.report_and_evict_ready_flushes(*item),
@@ -39,30 +39,26 @@ namespace phlex::detail {
            return {};
          }},
     index_router_{graph_},
-    index_receiver_{
-      graph_,
-      tbb::flow::unlimited,
-      [this](phlex::detail::ready_flushes_then_emit const& input) -> phlex::data_cell_index_ptr {
-        auto&& [ready_flushes, index_to_emit] = input;
-        return index_router_.route(index_to_emit, std::move(ready_flushes));
-      }},
+    index_receiver_{graph_,
+                    tbb::flow::unlimited,
+                    [this](ready_flushes_then_emit const& input) -> data_cell_index_ptr {
+                      auto&& [ready_flushes, index_to_emit] = input;
+                      return index_router_.route(index_to_emit, std::move(ready_flushes));
+                    }},
     hierarchy_node_{graph_,
                     tbb::flow::unlimited,
-                    [this](phlex::data_cell_index_ptr const& index) -> tbb::flow::continue_msg {
+                    [this](data_cell_index_ptr const& index) -> tbb::flow::continue_msg {
                       hierarchy_.increment_count(index);
                       return {};
                     }},
     driver_mode_{mode}
   {
     if (driver_mode_ == driver_mode::default_driver) {
-      driver_.emplace([](phlex::detail::framework_driver& driver) {
-        driver.yield(phlex::data_cell_index::job());
-      });
+      driver_.emplace([](framework_driver& driver) { driver.yield(data_cell_index::job()); });
     }
 
     spdlog::cfg::load_env_levels();
-    spdlog::info("Number of worker threads: {}",
-                 phlex::detail::max_allowed_parallelism::active_value());
+    spdlog::info("Number of worker threads: {}", max_allowed_parallelism::active_value());
   }
 
   void framework_graph::add_driver(driver_bundle bundle)
@@ -94,7 +90,7 @@ namespace phlex::detail {
   std::size_t framework_graph::seen_cell_count(std::string const& layer_name,
                                                bool const missing_ok) const
   {
-    return hierarchy_.count_for(experimental::layer_path(layer_name), missing_ok);
+    return hierarchy_.count_for(phlex::experimental::layer_path(layer_name), missing_ok);
   }
 
   std::size_t framework_graph::execution_count(std::string const& node_name) const
@@ -167,8 +163,8 @@ namespace phlex::detail {
     if (registration_errors_.empty()) {
       return;
     }
-    throw std::runtime_error(fmt::format("\nConfiguration errors:\n{}",
-                                         phlex::detail::bulleted_list(registration_errors_)));
+    throw std::runtime_error(
+      fmt::format("\nConfiguration errors:\n{}", bulleted_list(registration_errors_)));
   }
 
   void framework_graph::make_filter_edges()

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -58,7 +58,8 @@ namespace phlex::experimental {
     }
 
     spdlog::cfg::load_env_levels();
-    spdlog::info("Number of worker threads: {}", max_allowed_parallelism::active_value());
+    spdlog::info("Number of worker threads: {}",
+                 phlex::detail::max_allowed_parallelism::active_value());
   }
 
   void framework_graph::add_driver(driver_bundle bundle)
@@ -163,8 +164,8 @@ namespace phlex::experimental {
     if (registration_errors_.empty()) {
       return;
     }
-    throw std::runtime_error(
-      fmt::format("\nConfiguration errors:\n{}", bulleted_list(registration_errors_)));
+    throw std::runtime_error(fmt::format("\nConfiguration errors:\n{}",
+                                         phlex::detail::bulleted_list(registration_errors_)));
   }
 
   void framework_graph::make_filter_edges()

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -65,7 +65,7 @@ namespace phlex::detail {
                  phlex::detail::max_allowed_parallelism::active_value());
   }
 
-  void framework_graph::add_driver(phlex::experimental::driver_bundle bundle)
+  void framework_graph::add_driver(driver_bundle bundle)
   {
     if (driver_mode_ != driver_mode::deferred_driver) {
       throw std::runtime_error(

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -14,7 +14,7 @@
 #include <format>
 #include <iostream>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   framework_graph framework_graph::with_default_driver(int const max_parallelism)
   {
     return framework_graph{driver_mode::default_driver, max_parallelism};
@@ -65,7 +65,7 @@ namespace phlex::experimental {
                  phlex::detail::max_allowed_parallelism::active_value());
   }
 
-  void framework_graph::add_driver(driver_bundle bundle)
+  void framework_graph::add_driver(phlex::experimental::driver_bundle bundle)
   {
     if (driver_mode_ != driver_mode::deferred_driver) {
       throw std::runtime_error(
@@ -225,22 +225,22 @@ namespace phlex::experimental {
     index_router::provider_input_ports_t provider_input_ports,
     std::map<std::string, named_index_ports> multilayer_join_index_ports)
   {
-    std::set<identifier> unfold_input_layer_names;
+    std::set<phlex::experimental::identifier> unfold_input_layer_names;
 
     // Count how many distinct unfold nodes consume each input layer.  When that count is
     // greater than one, the flush_gate for an index in that layer must collect a flush
     // message from every unfold before it knows the total number of children it will see.
-    std::map<identifier, std::size_t> unfold_count_per_input_layer;
+    std::map<phlex::experimental::identifier, std::size_t> unfold_count_per_input_layer;
     for (auto const& n : nodes_.unfolds | std::views::values) {
       for (auto const& input : n->input()) {
-        if (!static_cast<identifier const&>(input.layer).empty()) {
+        if (!static_cast<phlex::experimental::identifier const&>(input.layer).empty()) {
           unfold_input_layer_names.insert(input.layer);
-          ++unfold_count_per_input_layer[identifier{input.layer}];
+          ++unfold_count_per_input_layer[phlex::experimental::identifier{input.layer}];
         }
       }
     }
 
-    std::vector<identifier> unfold_output_layer_names;
+    std::vector<phlex::experimental::identifier> unfold_output_layer_names;
     for (auto const& n : nodes_.unfolds | std::views::values) {
       unfold_output_layer_names.emplace_back(n->child_layer());
     }
@@ -248,7 +248,8 @@ namespace phlex::experimental {
     // FIXME: All of this should be collapsed into one call to index_router::finalize()
     index_router_.establish_layers(
       fixed_hierarchy_.layer_paths(),
-      std::vector<identifier>(unfold_input_layer_names.begin(), unfold_input_layer_names.end()),
+      std::vector<phlex::experimental::identifier>(unfold_input_layer_names.begin(),
+                                                   unfold_input_layer_names.end()),
       unfold_output_layer_names);
     index_router_.register_unfold_count_per_input_layer(std::move(unfold_count_per_input_layer));
     index_router_.finalize(

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -29,7 +29,7 @@ namespace phlex::experimental {
   framework_graph::framework_graph(driver_mode const mode, int const max_parallelism) :
     parallelism_limit_{static_cast<std::size_t>(max_parallelism)},
     src_{graph_,
-         [this](tbb::flow_control& fc) mutable -> ready_flushes_then_emit {
+         [this](tbb::flow_control& fc) mutable -> phlex::detail::ready_flushes_then_emit {
            assert(driver_);
            if (auto item = (*driver_)()) {
              return {.ready_flushes = cell_tracker_.report_and_evict_ready_flushes(*item),
@@ -39,22 +39,25 @@ namespace phlex::experimental {
            return {};
          }},
     index_router_{graph_},
-    index_receiver_{graph_,
-                    tbb::flow::unlimited,
-                    [this](ready_flushes_then_emit const& input) -> data_cell_index_ptr {
-                      auto&& [ready_flushes, index_to_emit] = input;
-                      return index_router_.route(index_to_emit, std::move(ready_flushes));
-                    }},
+    index_receiver_{
+      graph_,
+      tbb::flow::unlimited,
+      [this](phlex::detail::ready_flushes_then_emit const& input) -> phlex::data_cell_index_ptr {
+        auto&& [ready_flushes, index_to_emit] = input;
+        return index_router_.route(index_to_emit, std::move(ready_flushes));
+      }},
     hierarchy_node_{graph_,
                     tbb::flow::unlimited,
-                    [this](data_cell_index_ptr const& index) -> tbb::flow::continue_msg {
+                    [this](phlex::data_cell_index_ptr const& index) -> tbb::flow::continue_msg {
                       hierarchy_.increment_count(index);
                       return {};
                     }},
     driver_mode_{mode}
   {
     if (driver_mode_ == driver_mode::default_driver) {
-      driver_.emplace([](framework_driver& driver) { driver.yield(data_cell_index::job()); });
+      driver_.emplace([](phlex::detail::framework_driver& driver) {
+        driver.yield(phlex::data_cell_index::job());
+      });
     }
 
     spdlog::cfg::load_env_levels();

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -190,8 +190,8 @@ namespace phlex::experimental {
     enum class driver_mode { default_driver, deferred_driver };
     explicit framework_graph(driver_mode mode, int max_parallelism);
 
-    resource_usage graph_resource_usage_{};
-    max_allowed_parallelism parallelism_limit_;
+    phlex::detail::resource_usage graph_resource_usage_{};
+    phlex::detail::max_allowed_parallelism parallelism_limit_;
     fixed_hierarchy fixed_hierarchy_;
     data_layer_hierarchy hierarchy_{};
     node_catalog nodes_{};

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -66,7 +66,7 @@ namespace phlex::experimental {
     std::size_t seen_cell_count(std::string const& layer_name, bool missing_ok = false) const;
     std::size_t execution_count(std::string const& node_name) const;
 
-    module_graph_proxy<void_tag> module_proxy(configuration const& config)
+    module_graph_proxy<phlex::detail::void_tag> module_proxy(configuration const& config)
     {
       return {config, graph_, nodes_, registration_errors_};
     }
@@ -169,7 +169,7 @@ namespace phlex::experimental {
      * - Optional instance of T (if not void_tag)
      * - Registration error collection
      */
-    template <typename T = void_tag, bool Construct = true, typename... Args>
+    template <typename T = phlex::detail::void_tag, bool Construct = true, typename... Args>
     glue<T> make_glue(Args&&... args)
     {
       std::shared_ptr<T> bound_object{nullptr};

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -193,17 +193,19 @@ namespace phlex::experimental {
     phlex::detail::resource_usage graph_resource_usage_{};
     phlex::detail::max_allowed_parallelism parallelism_limit_;
     fixed_hierarchy fixed_hierarchy_;
-    data_layer_hierarchy hierarchy_{};
+    phlex::detail::data_layer_hierarchy hierarchy_{};
     node_catalog nodes_{};
     std::map<std::string, filter> filters_{};
     // The graph_ object uses the filters_, nodes_, and hierarchy_ objects implicitly.
     tbb::flow::graph graph_{};
-    std::optional<framework_driver> driver_{};
+    std::optional<phlex::detail::framework_driver> driver_{};
     std::vector<std::string> registration_errors_{};
-    data_cell_tracker cell_tracker_{};
-    tbb::flow::input_node<ready_flushes_then_emit> src_;
+    phlex::detail::data_cell_tracker cell_tracker_{};
+    tbb::flow::input_node<phlex::detail::ready_flushes_then_emit> src_;
     index_router index_router_;
-    tbb::flow::function_node<ready_flushes_then_emit, data_cell_index_ptr, tbb::flow::lightweight>
+    tbb::flow::function_node<phlex::detail::ready_flushes_then_emit,
+                             phlex::data_cell_index_ptr,
+                             tbb::flow::lightweight>
       index_receiver_;
     tbb::flow::function_node<data_cell_index_ptr, tbb::flow::continue_msg, tbb::flow::lightweight>
       hierarchy_node_;

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -203,9 +203,8 @@ namespace phlex::detail {
     data_cell_tracker cell_tracker_{};
     tbb::flow::input_node<ready_flushes_then_emit> src_;
     index_router index_router_;
-    tbb::flow::
-      function_node<ready_flushes_then_emit, phlex::data_cell_index_ptr, tbb::flow::lightweight>
-        index_receiver_;
+    tbb::flow::function_node<ready_flushes_then_emit, data_cell_index_ptr, tbb::flow::lightweight>
+      index_receiver_;
     tbb::flow::function_node<data_cell_index_ptr, tbb::flow::continue_msg, tbb::flow::lightweight>
       hierarchy_node_;
     driver_mode driver_mode_{driver_mode::default_driver};

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -50,13 +50,11 @@ namespace phlex::detail {
     framework_graph(framework_graph&&) = delete;
     framework_graph& operator=(framework_graph&&) = delete;
 
-    void add_driver(phlex::experimental::driver_bundle bundle);
+    void add_driver(driver_bundle bundle);
 
     template <typename Generator>
       requires requires(std::shared_ptr<Generator> generator, std::vector<source const*> sources) {
-        {
-          experimental::driver_proxy{sources}.driver(generator)
-        } -> std::same_as<phlex::experimental::driver_bundle>;
+        { driver_proxy{sources}.driver(generator) } -> std::same_as<driver_bundle>;
       }
     void add_driver(std::shared_ptr<Generator> generator)
     {
@@ -68,19 +66,19 @@ namespace phlex::detail {
     std::size_t seen_cell_count(std::string const& layer_name, bool missing_ok = false) const;
     std::size_t execution_count(std::string const& node_name) const;
 
-    experimental::module_graph_proxy<void_tag> module_proxy(configuration const& config)
+    module_graph_proxy<void_tag> module_proxy(configuration const& config)
     {
       return {config, graph_, nodes_, registration_errors_};
     }
 
-    experimental::source_bundle source_proxy(configuration const& config)
+    source_bundle source_proxy(configuration const& config)
     {
       return {config, graph_, nodes_, registration_errors_};
     }
 
-    experimental::driver_proxy driver_proxy(std::vector<std::string> strings = {})
+    detail::driver_proxy driver_proxy(std::vector<std::string> strings = {})
     {
-      return experimental::driver_proxy(nodes_.sources_for(strings));
+      return detail::driver_proxy{nodes_.sources_for(strings)};
     }
 
     // Framework function registrations
@@ -171,7 +169,7 @@ namespace phlex::detail {
      * - Optional instance of T (if not void_tag)
      * - Registration error collection
      */
-    template <typename T = phlex::detail::void_tag, bool Construct = true, typename... Args>
+    template <typename T = void_tag, bool Construct = true, typename... Args>
     glue<T> make_glue(Args&&... args)
     {
       std::shared_ptr<T> bound_object{nullptr};
@@ -192,23 +190,22 @@ namespace phlex::detail {
     enum class driver_mode { default_driver, deferred_driver };
     explicit framework_graph(driver_mode mode, int max_parallelism);
 
-    phlex::detail::resource_usage graph_resource_usage_{};
-    phlex::detail::max_allowed_parallelism parallelism_limit_;
+    resource_usage graph_resource_usage_{};
+    max_allowed_parallelism parallelism_limit_;
     fixed_hierarchy fixed_hierarchy_;
-    phlex::detail::data_layer_hierarchy hierarchy_{};
+    data_layer_hierarchy hierarchy_{};
     node_catalog nodes_{};
     std::map<std::string, filter> filters_{};
     // The graph_ object uses the filters_, nodes_, and hierarchy_ objects implicitly.
     tbb::flow::graph graph_{};
-    std::optional<phlex::detail::framework_driver> driver_{};
+    std::optional<framework_driver> driver_{};
     std::vector<std::string> registration_errors_{};
-    phlex::detail::data_cell_tracker cell_tracker_{};
-    tbb::flow::input_node<phlex::detail::ready_flushes_then_emit> src_;
+    data_cell_tracker cell_tracker_{};
+    tbb::flow::input_node<ready_flushes_then_emit> src_;
     index_router index_router_;
-    tbb::flow::function_node<phlex::detail::ready_flushes_then_emit,
-                             phlex::data_cell_index_ptr,
-                             tbb::flow::lightweight>
-      index_receiver_;
+    tbb::flow::
+      function_node<ready_flushes_then_emit, phlex::data_cell_index_ptr, tbb::flow::lightweight>
+        index_receiver_;
     tbb::flow::function_node<data_cell_index_ptr, tbb::flow::continue_msg, tbb::flow::lightweight>
       hierarchy_node_;
     driver_mode driver_mode_{driver_mode::default_driver};

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -36,7 +36,7 @@ namespace phlex {
   class configuration;
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class PHLEX_CORE_EXPORT framework_graph {
   public:
     [[nodiscard]] static framework_graph with_default_driver(
@@ -50,11 +50,13 @@ namespace phlex::experimental {
     framework_graph(framework_graph&&) = delete;
     framework_graph& operator=(framework_graph&&) = delete;
 
-    void add_driver(driver_bundle bundle);
+    void add_driver(phlex::experimental::driver_bundle bundle);
 
     template <typename Generator>
       requires requires(std::shared_ptr<Generator> generator, std::vector<source const*> sources) {
-        { experimental::driver_proxy{sources}.driver(generator) } -> std::same_as<driver_bundle>;
+        {
+          experimental::driver_proxy{sources}.driver(generator)
+        } -> std::same_as<phlex::experimental::driver_bundle>;
       }
     void add_driver(std::shared_ptr<Generator> generator)
     {
@@ -66,12 +68,12 @@ namespace phlex::experimental {
     std::size_t seen_cell_count(std::string const& layer_name, bool missing_ok = false) const;
     std::size_t execution_count(std::string const& node_name) const;
 
-    module_graph_proxy<phlex::detail::void_tag> module_proxy(configuration const& config)
+    experimental::module_graph_proxy<void_tag> module_proxy(configuration const& config)
     {
       return {config, graph_, nodes_, registration_errors_};
     }
 
-    source_bundle source_proxy(configuration const& config)
+    experimental::source_bundle source_proxy(configuration const& config)
     {
       return {config, graph_, nodes_, registration_errors_};
     }

--- a/phlex/core/fwd.hpp
+++ b/phlex/core/fwd.hpp
@@ -5,7 +5,7 @@
 
 #include "oneapi/tbb/flow_graph.h"
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class consumer;
   class declared_output;
   class generator;

--- a/phlex/core/glue.cpp
+++ b/phlex/core/glue.cpp
@@ -4,7 +4,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace phlex::experimental::detail {
+namespace phlex::detail::internal {
   void verify_name(std::string const& name, configuration const* config)
   {
     if (not name.empty()) {

--- a/phlex/core/glue.hpp
+++ b/phlex/core/glue.hpp
@@ -22,10 +22,9 @@ namespace phlex {
   class configuration;
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
   struct node_catalog;
-
-  namespace detail {
+  namespace internal {
     PHLEX_CORE_EXPORT void verify_name(std::string const& name, configuration const* config);
   }
 
@@ -57,7 +56,7 @@ namespace phlex::experimental {
     auto fold(
       std::string name, auto f, concurrency c, std::string partition, InitArgs&&... init_args)
     {
-      detail::verify_name(name, config_);
+      internal::verify_name(name, config_);
       return fold_api{config_,
                       std::move(name),
                       phlex::detail::algorithm_bits(bound_obj_, std::move(f)),
@@ -72,7 +71,7 @@ namespace phlex::experimental {
     template <typename FT>
     auto observe(std::string name, FT f, concurrency c)
     {
-      detail::verify_name(name, config_);
+      internal::verify_name(name, config_);
       return make_registration<observer_node>(
         config_,
         std::move(name),
@@ -86,7 +85,7 @@ namespace phlex::experimental {
     template <typename FT>
     auto provide(std::string name, FT f, concurrency c)
     {
-      detail::verify_name(name, config_);
+      internal::verify_name(name, config_);
       return provider_api{config_,
                           std::move(name),
                           phlex::detail::algorithm_bits{bound_obj_, std::move(f)},
@@ -99,7 +98,7 @@ namespace phlex::experimental {
     template <typename FT>
     auto transform(std::string name, FT f, concurrency c)
     {
-      detail::verify_name(name, config_);
+      internal::verify_name(name, config_);
       return make_registration<transform_node>(
         config_,
         std::move(name),
@@ -113,7 +112,7 @@ namespace phlex::experimental {
     template <typename FT>
     auto predicate(std::string name, FT f, concurrency c)
     {
-      detail::verify_name(name, config_);
+      internal::verify_name(name, config_);
       return make_registration<predicate_node>(
         config_,
         std::move(name),
@@ -131,7 +130,7 @@ namespace phlex::experimental {
                 std::string destination_data_layer)
     {
       assert(!bound_obj_);
-      detail::verify_name(name, config_);
+      internal::verify_name(name, config_);
       return unfold_api<T, decltype(predicate), decltype(unfold)>{
         config_,
         std::move(name),
@@ -160,7 +159,7 @@ namespace phlex::experimental {
       auto [_, inserted] =
         nodes_.sources.try_emplace(name, std::make_unique<Source>(std::forward<Args>(args)...));
       if (not inserted) {
-        detail::add_to_error_messages(errors_, "Source", name); // From registrar.hpp
+        internal::add_to_error_messages(errors_, "Source", name); // From registrar.hpp
       }
     }
 

--- a/phlex/core/glue.hpp
+++ b/phlex/core/glue.hpp
@@ -59,7 +59,7 @@ namespace phlex::detail {
       internal::verify_name(name, config_);
       return fold_api{config_,
                       std::move(name),
-                      phlex::detail::algorithm_bits(bound_obj_, std::move(f)),
+                      algorithm_bits(bound_obj_, std::move(f)),
                       c,
                       graph_,
                       nodes_,
@@ -72,14 +72,13 @@ namespace phlex::detail {
     auto observe(std::string name, FT f, concurrency c)
     {
       internal::verify_name(name, config_);
-      return make_registration<observer_node>(
-        config_,
-        std::move(name),
-        phlex::detail::algorithm_bits{bound_obj_, std::move(f)},
-        c,
-        graph_,
-        nodes_,
-        errors_);
+      return make_registration<observer_node>(config_,
+                                              std::move(name),
+                                              algorithm_bits{bound_obj_, std::move(f)},
+                                              c,
+                                              graph_,
+                                              nodes_,
+                                              errors_);
     }
 
     template <typename FT>
@@ -88,7 +87,7 @@ namespace phlex::detail {
       internal::verify_name(name, config_);
       return provider_api{config_,
                           std::move(name),
-                          phlex::detail::algorithm_bits{bound_obj_, std::move(f)},
+                          algorithm_bits{bound_obj_, std::move(f)},
                           c,
                           graph_,
                           nodes_,
@@ -99,28 +98,26 @@ namespace phlex::detail {
     auto transform(std::string name, FT f, concurrency c)
     {
       internal::verify_name(name, config_);
-      return make_registration<transform_node>(
-        config_,
-        std::move(name),
-        phlex::detail::algorithm_bits{bound_obj_, std::move(f)},
-        c,
-        graph_,
-        nodes_,
-        errors_);
+      return make_registration<transform_node>(config_,
+                                               std::move(name),
+                                               algorithm_bits{bound_obj_, std::move(f)},
+                                               c,
+                                               graph_,
+                                               nodes_,
+                                               errors_);
     }
 
     template <typename FT>
     auto predicate(std::string name, FT f, concurrency c)
     {
       internal::verify_name(name, config_);
-      return make_registration<predicate_node>(
-        config_,
-        std::move(name),
-        phlex::detail::algorithm_bits{bound_obj_, std::move(f)},
-        c,
-        graph_,
-        nodes_,
-        errors_);
+      return make_registration<predicate_node>(config_,
+                                               std::move(name),
+                                               algorithm_bits{bound_obj_, std::move(f)},
+                                               c,
+                                               graph_,
+                                               nodes_,
+                                               errors_);
     }
 
     auto unfold(std::string name,
@@ -149,7 +146,7 @@ namespace phlex::detail {
                         config_,
                         std::move(name),
                         graph_,
-                        phlex::detail::delegate(bound_obj_, f),
+                        delegate(bound_obj_, f),
                         c};
     }
 

--- a/phlex/core/glue.hpp
+++ b/phlex/core/glue.hpp
@@ -60,7 +60,7 @@ namespace phlex::experimental {
       detail::verify_name(name, config_);
       return fold_api{config_,
                       std::move(name),
-                      algorithm_bits(bound_obj_, std::move(f)),
+                      phlex::detail::algorithm_bits(bound_obj_, std::move(f)),
                       c,
                       graph_,
                       nodes_,
@@ -73,13 +73,14 @@ namespace phlex::experimental {
     auto observe(std::string name, FT f, concurrency c)
     {
       detail::verify_name(name, config_);
-      return make_registration<observer_node>(config_,
-                                              std::move(name),
-                                              algorithm_bits{bound_obj_, std::move(f)},
-                                              c,
-                                              graph_,
-                                              nodes_,
-                                              errors_);
+      return make_registration<observer_node>(
+        config_,
+        std::move(name),
+        phlex::detail::algorithm_bits{bound_obj_, std::move(f)},
+        c,
+        graph_,
+        nodes_,
+        errors_);
     }
 
     template <typename FT>
@@ -88,7 +89,7 @@ namespace phlex::experimental {
       detail::verify_name(name, config_);
       return provider_api{config_,
                           std::move(name),
-                          algorithm_bits{bound_obj_, std::move(f)},
+                          phlex::detail::algorithm_bits{bound_obj_, std::move(f)},
                           c,
                           graph_,
                           nodes_,
@@ -99,26 +100,28 @@ namespace phlex::experimental {
     auto transform(std::string name, FT f, concurrency c)
     {
       detail::verify_name(name, config_);
-      return make_registration<transform_node>(config_,
-                                               std::move(name),
-                                               algorithm_bits{bound_obj_, std::move(f)},
-                                               c,
-                                               graph_,
-                                               nodes_,
-                                               errors_);
+      return make_registration<transform_node>(
+        config_,
+        std::move(name),
+        phlex::detail::algorithm_bits{bound_obj_, std::move(f)},
+        c,
+        graph_,
+        nodes_,
+        errors_);
     }
 
     template <typename FT>
     auto predicate(std::string name, FT f, concurrency c)
     {
       detail::verify_name(name, config_);
-      return make_registration<predicate_node>(config_,
-                                               std::move(name),
-                                               algorithm_bits{bound_obj_, std::move(f)},
-                                               c,
-                                               graph_,
-                                               nodes_,
-                                               errors_);
+      return make_registration<predicate_node>(
+        config_,
+        std::move(name),
+        phlex::detail::algorithm_bits{bound_obj_, std::move(f)},
+        c,
+        graph_,
+        nodes_,
+        errors_);
     }
 
     auto unfold(std::string name,
@@ -147,7 +150,7 @@ namespace phlex::experimental {
                         config_,
                         std::move(name),
                         graph_,
-                        delegate(bound_obj_, f),
+                        phlex::detail::delegate(bound_obj_, f),
                         c};
     }
 

--- a/phlex/core/graph_proxy.hpp
+++ b/phlex/core/graph_proxy.hpp
@@ -20,7 +20,7 @@ namespace phlex {
   class configuration;
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
   // ==============================================================================
   // Registering user functions
 

--- a/phlex/core/index_router.cpp
+++ b/phlex/core/index_router.cpp
@@ -13,34 +13,34 @@
 #include <ranges>
 #include <stdexcept>
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   //========================================================================================
   // multilayer_slot implementation
-  namespace detail {
+  namespace internal {
     class multilayer_slot {
     public:
       multilayer_slot(tbb::flow::graph& g,
-                      identifier layer,
+                      phlex::experimental::identifier layer,
                       tbb::flow::receiver<indexed_end_token>* flush_port,
                       tbb::flow::receiver<index_message>* input_port);
 
       void put_message(data_cell_index_ptr const& index, std::size_t message_id);
       void put_end_token(data_cell_index_ptr const& index, phlex::detail::flush_gate const& fc);
 
-      bool matches_exactly(layer_path const& layer_path) const;
+      bool matches_exactly(phlex::experimental::layer_path const& layer_path) const;
       bool is_parent_of(data_cell_index_ptr const& index) const;
 
     private:
-      identifier layer_;
+      phlex::experimental::identifier layer_;
       index_set_node broadcaster_;
       flush_node flusher_;
     };
 
     multilayer_slot::multilayer_slot(tbb::flow::graph& g,
-                                     identifier layer,
+                                     phlex::experimental::identifier layer,
                                      tbb::flow::receiver<indexed_end_token>* flush_port,
                                      tbb::flow::receiver<index_message>* input_port) :
       layer_{std::move(layer)}, broadcaster_{g}, flusher_{g}
@@ -67,7 +67,7 @@ namespace phlex::experimental {
       flusher_.try_put({.index = index, .count = static_cast<int>(fg.committed_total_count())});
     }
 
-    bool multilayer_slot::matches_exactly(layer_path const& layer_path) const
+    bool multilayer_slot::matches_exactly(phlex::experimental::layer_path const& layer_path) const
     {
       return layer_path.ends_with(layer_);
     }
@@ -100,9 +100,10 @@ namespace phlex::experimental {
   {
   }
 
-  void index_router::establish_layers(std::vector<layer_path> const& layer_paths_from_driver,
-                                      std::vector<identifier> unfold_input_layer_names,
-                                      std::vector<identifier> unfold_output_layer_names)
+  void index_router::establish_layers(
+    std::vector<phlex::experimental::layer_path> const& layer_paths_from_driver,
+    std::vector<phlex::experimental::identifier> unfold_input_layer_names,
+    std::vector<phlex::experimental::identifier> unfold_output_layer_names)
   {
     auto sorted_layer_paths = layer_paths_from_driver;
     std::ranges::sort(sorted_layer_paths);
@@ -130,20 +131,20 @@ namespace phlex::experimental {
 
     // Create the index-set broadcast nodes for providers
     for (auto& [input_product, provider_port] : provider_input_ports | std::views::values) {
-      auto [it, _] =
-        index_set_nodes_.emplace(input_product.layer, std::make_shared<detail::index_set_node>(g));
+      auto [it, _] = index_set_nodes_.emplace(input_product.layer,
+                                              std::make_shared<internal::index_set_node>(g));
       make_edge(*it->second, *provider_port);
     }
 
     for (auto const& [node_name, join_ports] : multilayer_join_ports) {
       spdlog::trace("Making multilayer slots for {}", node_name);
-      detail::multilayer_slots slots;
+      internal::multilayer_slots slots;
       slots.reserve(join_ports.size());
       for (auto const& [layer, flush_port, input_port] : join_ports) {
-        auto slot = std::make_shared<detail::multilayer_slot>(g, layer, flush_port, input_port);
+        auto slot = std::make_shared<internal::multilayer_slot>(g, layer, flush_port, input_port);
         slots.push_back(slot);
       }
-      multilayer_join_slots_.emplace(identifier{node_name}, std::move(slots));
+      multilayer_join_slots_.emplace(phlex::experimental::identifier{node_name}, std::move(slots));
     }
   }
 
@@ -190,12 +191,10 @@ namespace phlex::experimental {
     return index;
   }
 
-  void index_router::drain(phlex::detail::index_flushes flushes)
-  {
-    update_flush_counts(std::move(flushes));
-  }
+  void index_router::drain(index_flushes flushes) { update_flush_counts(std::move(flushes)); }
 
-  void index_router::register_unfold_count_per_input_layer(std::map<identifier, std::size_t> counts)
+  void index_router::register_unfold_count_per_input_layer(
+    std::map<phlex::experimental::identifier, std::size_t> counts)
   {
     // Called once during finalize(), before any indices are routed, so no concurrent access.
     unfold_count_per_input_layer_ = std::move(counts);
@@ -221,20 +220,21 @@ namespace phlex::experimental {
     return is_lowest_layer_hashes_.emplace(index->layer_hash(), true).first->second;
   }
 
-  detail::index_set_node_ptr index_router::index_set_node_for(data_cell_index_ptr const& index)
+  internal::index_set_node_ptr index_router::index_set_node_for(data_cell_index_ptr const& index)
   {
     auto const layer_hash = index->layer_hash();
     if (auto it = index_set_node_cache_.find(layer_hash); it != index_set_node_cache_.end()) {
       return it->second;
     }
 
-    layer_path const layerish_path{{index->layer_name()}};
+    phlex::experimental::layer_path const layerish_path{{index->layer_name()}};
     auto broadcaster = index_set_node_for(layerish_path);
     index_set_node_cache_.insert({layer_hash, broadcaster});
     return broadcaster;
   }
 
-  auto index_router::index_set_node_for(layer_path const& layer_path) -> detail::index_set_node_ptr
+  auto index_router::index_set_node_for(phlex::experimental::layer_path const& layer_path)
+    -> internal::index_set_node_ptr
   {
     std::vector<decltype(index_set_nodes_.begin())> candidates;
     for (auto it = index_set_nodes_.begin(), e = index_set_nodes_.end(); it != e; ++it) {
@@ -259,7 +259,7 @@ namespace phlex::experimental {
     throw std::runtime_error(msg);
   }
 
-  std::pair<detail::multilayer_slots_ptr, detail::multilayer_slots_ptr>
+  std::pair<internal::multilayer_slots_ptr, internal::multilayer_slots_ptr>
   index_router::multilayer_slots_for(data_cell_index_ptr const& index)
   {
     auto const layer_hash = index->layer_hash();
@@ -280,8 +280,8 @@ namespace phlex::experimental {
     }
 
     auto const layer_path = index->layer_path();
-    detail::multilayer_slots message_slots;
-    detail::multilayer_slots end_token_slots;
+    internal::multilayer_slots message_slots;
+    internal::multilayer_slots end_token_slots;
 
     // For each multi-layer join node, determine which slots are relevant to this index.
     // Message entries: All slots from a node are added if (1) at least one slot exactly
@@ -289,7 +289,7 @@ namespace phlex::experimental {
     //                  or are parent layers of the current index.
     // End-token entries: Only slots that exactly match the current layer are added.
     for (auto& [node_name, slots] : multilayer_join_slots_) {
-      detail::multilayer_slots matching_slots;
+      internal::multilayer_slots matching_slots;
       matching_slots.reserve(slots.size());
 
       bool has_exact_match = false;
@@ -317,13 +317,13 @@ namespace phlex::experimental {
     }
 
     acc->second.message_slots =
-      std::make_shared<detail::multilayer_slots const>(std::move(message_slots));
+      std::make_shared<internal::multilayer_slots const>(std::move(message_slots));
     acc->second.end_token_slots =
-      std::make_shared<detail::multilayer_slots const>(std::move(end_token_slots));
+      std::make_shared<internal::multilayer_slots const>(std::move(end_token_slots));
     return {acc->second.message_slots, acc->second.end_token_slots};
   }
 
-  void index_router::update_flush_counts(phlex::detail::index_flushes flushes)
+  void index_router::update_flush_counts(index_flushes flushes)
   {
     for (auto const& [index, flush_counts] : flushes) {
       auto gate = gate_for(index);
@@ -334,7 +334,7 @@ namespace phlex::experimental {
     }
   }
 
-  void index_router::apply_expected_count(phlex::detail::flush_gate& gate,
+  void index_router::apply_expected_count(flush_gate& gate,
                                           data_cell_index::hash_type const child_layer_hash,
                                           std::size_t const count)
   {
@@ -360,7 +360,7 @@ namespace phlex::experimental {
     return it != is_lowest_layer_hashes_.end() ? it->second : true;
   }
 
-  phlex::detail::flush_gate_ptr index_router::gate_for(data_cell_index_ptr const& index)
+  flush_gate_ptr index_router::gate_for(data_cell_index_ptr const& index)
   {
     // Fast path: entry already exists — read under shared lock to avoid serializing threads.
     const_accessor ca;
@@ -380,7 +380,7 @@ namespace phlex::experimental {
         auto it = unfold_count_per_input_layer_.find(index->layer_name());
         return it != unfold_count_per_input_layer_.end() ? it->second : 0;
       }();
-      a->second = std::make_shared<phlex::detail::flush_gate>(index, expected_flush_count);
+      a->second = std::make_shared<flush_gate>(index, expected_flush_count);
     }
     return a->second;
   }
@@ -394,7 +394,7 @@ namespace phlex::experimental {
       // calling send_flush().  The erase claims exclusive ownership of this gate —
       // any concurrent flush_if_done call for the same index will fail to find the entry
       // and return immediately, preventing double-flush.
-      phlex::detail::flush_gate_ptr gate;
+      flush_gate_ptr gate;
       {
         accessor a;
         if (not flush_gates_.find(a, index->hash())) {

--- a/phlex/core/index_router.cpp
+++ b/phlex/core/index_router.cpp
@@ -28,7 +28,7 @@ namespace phlex::detail {
                       tbb::flow::receiver<index_message>* input_port);
 
       void put_message(data_cell_index_ptr const& index, std::size_t message_id);
-      void put_end_token(data_cell_index_ptr const& index, phlex::detail::flush_gate const& fc);
+      void put_end_token(data_cell_index_ptr const& index, flush_gate const& fc);
 
       bool matches_exactly(phlex::experimental::layer_path const& layer_path) const;
       bool is_parent_of(data_cell_index_ptr const& index) const;
@@ -59,8 +59,7 @@ namespace phlex::detail {
       broadcaster_.try_put({.index = index->parent(layer_), .msg_id = message_id});
     }
 
-    void multilayer_slot::put_end_token(data_cell_index_ptr const& index,
-                                        phlex::detail::flush_gate const& fg)
+    void multilayer_slot::put_end_token(data_cell_index_ptr const& index, flush_gate const& fg)
     {
       // We're going to have to be a little more careful about this.  The committed total count may
       // not be enough granularity for some downstream nodes.
@@ -90,7 +89,7 @@ namespace phlex::detail {
                            }},
     unfold_flush_receiver_{g,
                            tbb::flow::unlimited,
-                           [this](phlex::detail::unfold_flush input) -> tbb::flow::continue_msg {
+                           [this](unfold_flush input) -> tbb::flow::continue_msg {
                              auto&& [index, layer_hash, count] = input;
                              apply_expected_count(*gate_for(index), layer_hash, count);
                              flush_if_done(index);
@@ -148,8 +147,7 @@ namespace phlex::detail {
     }
   }
 
-  data_cell_index_ptr index_router::route(data_cell_index_ptr const& index,
-                                          phlex::detail::index_flushes flushes)
+  data_cell_index_ptr index_router::route(data_cell_index_ptr const& index, index_flushes flushes)
   {
     update_flush_counts(std::move(flushes));
     return route(index, index_is_lowest_layer(index), received_indices_.fetch_add(1));
@@ -177,7 +175,7 @@ namespace phlex::detail {
 
     gate_for(index)->set_flush_callback(
       [this, end_token_slots = std::move(end_token_slots), index, message_id](
-        phlex::detail::flush_gate const& fc) {
+        flush_gate const& fc) {
         for (auto const& slot : *end_token_slots) {
           slot->put_end_token(index, fc);
         }
@@ -251,11 +249,10 @@ namespace phlex::detail {
       return nullptr;
     }
 
-    std::string msg =
-      fmt::format("Multiple layers match specification {}:\n{}",
-                  layer_path,
-                  phlex::detail::bulleted_list(
-                    candidates | std::views::transform([](auto const& it) { return it->first; })));
+    std::string msg = fmt::format(
+      "Multiple layers match specification {}:\n{}",
+      layer_path,
+      bulleted_list(candidates | std::views::transform([](auto const& it) { return it->first; })));
     throw std::runtime_error(msg);
   }
 

--- a/phlex/core/index_router.cpp
+++ b/phlex/core/index_router.cpp
@@ -246,10 +246,11 @@ namespace phlex::experimental {
       return nullptr;
     }
 
-    std::string msg = fmt::format(
-      "Multiple layers match specification {}:\n{}",
-      layer_path,
-      bulleted_list(candidates | std::views::transform([](auto const& it) { return it->first; })));
+    std::string msg =
+      fmt::format("Multiple layers match specification {}:\n{}",
+                  layer_path,
+                  phlex::detail::bulleted_list(
+                    candidates | std::views::transform([](auto const& it) { return it->first; })));
     throw std::runtime_error(msg);
   }
 

--- a/phlex/core/index_router.cpp
+++ b/phlex/core/index_router.cpp
@@ -28,7 +28,7 @@ namespace phlex::experimental {
                       tbb::flow::receiver<index_message>* input_port);
 
       void put_message(data_cell_index_ptr const& index, std::size_t message_id);
-      void put_end_token(data_cell_index_ptr const& index, flush_gate const& fc);
+      void put_end_token(data_cell_index_ptr const& index, phlex::detail::flush_gate const& fc);
 
       bool matches_exactly(layer_path const& layer_path) const;
       bool is_parent_of(data_cell_index_ptr const& index) const;
@@ -59,11 +59,12 @@ namespace phlex::experimental {
       broadcaster_.try_put({.index = index->parent(layer_), .msg_id = message_id});
     }
 
-    void multilayer_slot::put_end_token(data_cell_index_ptr const& index, flush_gate const& fc)
+    void multilayer_slot::put_end_token(data_cell_index_ptr const& index,
+                                        phlex::detail::flush_gate const& fg)
     {
       // We're going to have to be a little more careful about this.  The committed total count may
       // not be enough granularity for some downstream nodes.
-      flusher_.try_put({.index = index, .count = static_cast<int>(fc.committed_total_count())});
+      flusher_.try_put({.index = index, .count = static_cast<int>(fg.committed_total_count())});
     }
 
     bool multilayer_slot::matches_exactly(layer_path const& layer_path) const
@@ -89,7 +90,7 @@ namespace phlex::experimental {
                            }},
     unfold_flush_receiver_{g,
                            tbb::flow::unlimited,
-                           [this](unfold_flush input) -> tbb::flow::continue_msg {
+                           [this](phlex::detail::unfold_flush input) -> tbb::flow::continue_msg {
                              auto&& [index, layer_hash, count] = input;
                              apply_expected_count(*gate_for(index), layer_hash, count);
                              flush_if_done(index);
@@ -146,7 +147,8 @@ namespace phlex::experimental {
     }
   }
 
-  data_cell_index_ptr index_router::route(data_cell_index_ptr const& index, index_flushes flushes)
+  data_cell_index_ptr index_router::route(data_cell_index_ptr const& index,
+                                          phlex::detail::index_flushes flushes)
   {
     update_flush_counts(std::move(flushes));
     return route(index, index_is_lowest_layer(index), received_indices_.fetch_add(1));
@@ -174,7 +176,7 @@ namespace phlex::experimental {
 
     gate_for(index)->set_flush_callback(
       [this, end_token_slots = std::move(end_token_slots), index, message_id](
-        flush_gate const& fc) {
+        phlex::detail::flush_gate const& fc) {
         for (auto const& slot : *end_token_slots) {
           slot->put_end_token(index, fc);
         }
@@ -188,7 +190,10 @@ namespace phlex::experimental {
     return index;
   }
 
-  void index_router::drain(index_flushes flushes) { update_flush_counts(std::move(flushes)); }
+  void index_router::drain(phlex::detail::index_flushes flushes)
+  {
+    update_flush_counts(std::move(flushes));
+  }
 
   void index_router::register_unfold_count_per_input_layer(std::map<identifier, std::size_t> counts)
   {
@@ -318,7 +323,7 @@ namespace phlex::experimental {
     return {acc->second.message_slots, acc->second.end_token_slots};
   }
 
-  void index_router::update_flush_counts(index_flushes flushes)
+  void index_router::update_flush_counts(phlex::detail::index_flushes flushes)
   {
     for (auto const& [index, flush_counts] : flushes) {
       auto gate = gate_for(index);
@@ -329,7 +334,7 @@ namespace phlex::experimental {
     }
   }
 
-  void index_router::apply_expected_count(flush_gate& gate,
+  void index_router::apply_expected_count(phlex::detail::flush_gate& gate,
                                           data_cell_index::hash_type const child_layer_hash,
                                           std::size_t const count)
   {
@@ -355,7 +360,7 @@ namespace phlex::experimental {
     return it != is_lowest_layer_hashes_.end() ? it->second : true;
   }
 
-  flush_gate_ptr index_router::gate_for(data_cell_index_ptr const& index)
+  phlex::detail::flush_gate_ptr index_router::gate_for(data_cell_index_ptr const& index)
   {
     // Fast path: entry already exists — read under shared lock to avoid serializing threads.
     const_accessor ca;
@@ -375,7 +380,7 @@ namespace phlex::experimental {
         auto it = unfold_count_per_input_layer_.find(index->layer_name());
         return it != unfold_count_per_input_layer_.end() ? it->second : 0;
       }();
-      a->second = std::make_shared<flush_gate>(index, expected_flush_count);
+      a->second = std::make_shared<phlex::detail::flush_gate>(index, expected_flush_count);
     }
     return a->second;
   }
@@ -389,7 +394,7 @@ namespace phlex::experimental {
       // calling send_flush().  The erase claims exclusive ownership of this gate —
       // any concurrent flush_if_done call for the same index will fail to find the entry
       // and return immediately, preventing double-flush.
-      flush_gate_ptr gate;
+      phlex::detail::flush_gate_ptr gate;
       {
         accessor a;
         if (not flush_gates_.find(a, index->hash())) {

--- a/phlex/core/index_router.hpp
+++ b/phlex/core/index_router.hpp
@@ -54,7 +54,8 @@ namespace phlex::experimental {
     using provider_input_ports_t = std::map<std::string, provider_input_port_t>;
 
     explicit index_router(tbb::flow::graph& g);
-    data_cell_index_ptr route(data_cell_index_ptr const& index, index_flushes flushes);
+    data_cell_index_ptr route(data_cell_index_ptr const& index,
+                              phlex::detail::index_flushes flushes);
 
     void establish_layers(std::vector<layer_path> const& layer_paths_from_driver,
                           std::vector<identifier> unfold_input_layer_names,
@@ -68,14 +69,14 @@ namespace phlex::experimental {
     void finalize(tbb::flow::graph& g,
                   provider_input_ports_t provider_input_ports,
                   std::map<std::string, named_index_ports> multilayer_join_ports);
-    void drain(index_flushes flushes);
+    void drain(phlex::detail::index_flushes flushes);
     flusher_t& flusher() { return flusher_; }
 
     tbb::flow::function_node<index_message, data_cell_index_ptr>& unfold_index_receiver()
     {
       return unfold_index_receiver_;
     }
-    tbb::flow::function_node<unfold_flush>& unfold_flush_receiver()
+    tbb::flow::function_node<phlex::detail::unfold_flush>& unfold_flush_receiver()
     {
       return unfold_flush_receiver_;
     }
@@ -95,15 +96,15 @@ namespace phlex::experimental {
     detail::index_set_node_ptr index_set_node_for(data_cell_index_ptr const& index);
     std::pair<detail::multilayer_slots_ptr, detail::multilayer_slots_ptr> multilayer_slots_for(
       data_cell_index_ptr const& index);
-    void update_flush_counts(index_flushes flushes);
-    void apply_expected_count(flush_gate& gate,
+    void update_flush_counts(phlex::detail::index_flushes flushes);
+    void apply_expected_count(phlex::detail::flush_gate& gate,
                               data_cell_index::hash_type child_layer_hash,
                               std::size_t count);
-    flush_gate_ptr gate_for(data_cell_index_ptr const& index);
+    phlex::detail::flush_gate_ptr gate_for(data_cell_index_ptr const& index);
     void flush_if_done(data_cell_index_ptr index);
 
     tbb::flow::function_node<index_message, data_cell_index_ptr> unfold_index_receiver_;
-    tbb::flow::function_node<unfold_flush> unfold_flush_receiver_;
+    tbb::flow::function_node<phlex::detail::unfold_flush> unfold_flush_receiver_;
     std::atomic<std::size_t> received_indices_{};
     flusher_t flusher_;
     tbb::concurrent_unordered_map<std::size_t, bool> is_lowest_layer_hashes_;
@@ -139,7 +140,7 @@ namespace phlex::experimental {
 
     // ==========================================================================================
     // Flush gates (data-cell index hash is the key)
-    using gates_t = tbb::concurrent_hash_map<std::size_t, flush_gate_ptr>;
+    using gates_t = tbb::concurrent_hash_map<std::size_t, phlex::detail::flush_gate_ptr>;
     using accessor = gates_t::accessor;
     using const_accessor = gates_t::const_accessor;
     gates_t flush_gates_;

--- a/phlex/core/index_router.hpp
+++ b/phlex/core/index_router.hpp
@@ -54,8 +54,7 @@ namespace phlex::detail {
     using provider_input_ports_t = std::map<std::string, provider_input_port_t>;
 
     explicit index_router(tbb::flow::graph& g);
-    data_cell_index_ptr route(data_cell_index_ptr const& index,
-                              phlex::detail::index_flushes flushes);
+    data_cell_index_ptr route(data_cell_index_ptr const& index, index_flushes flushes);
 
     void establish_layers(
       std::vector<phlex::experimental::layer_path> const& layer_paths_from_driver,
@@ -71,14 +70,14 @@ namespace phlex::detail {
     void finalize(tbb::flow::graph& g,
                   provider_input_ports_t provider_input_ports,
                   std::map<std::string, named_index_ports> multilayer_join_ports);
-    void drain(phlex::detail::index_flushes flushes);
+    void drain(index_flushes flushes);
     flusher_t& flusher() { return flusher_; }
 
     tbb::flow::function_node<index_message, data_cell_index_ptr>& unfold_index_receiver()
     {
       return unfold_index_receiver_;
     }
-    tbb::flow::function_node<phlex::detail::unfold_flush>& unfold_flush_receiver()
+    tbb::flow::function_node<unfold_flush>& unfold_flush_receiver()
     {
       return unfold_flush_receiver_;
     }
@@ -98,15 +97,15 @@ namespace phlex::detail {
     internal::index_set_node_ptr index_set_node_for(data_cell_index_ptr const& index);
     std::pair<internal::multilayer_slots_ptr, internal::multilayer_slots_ptr> multilayer_slots_for(
       data_cell_index_ptr const& index);
-    void update_flush_counts(phlex::detail::index_flushes flushes);
-    void apply_expected_count(phlex::detail::flush_gate& gate,
+    void update_flush_counts(index_flushes flushes);
+    void apply_expected_count(flush_gate& gate,
                               data_cell_index::hash_type child_layer_hash,
                               std::size_t count);
-    phlex::detail::flush_gate_ptr gate_for(data_cell_index_ptr const& index);
+    flush_gate_ptr gate_for(data_cell_index_ptr const& index);
     void flush_if_done(data_cell_index_ptr index);
 
     tbb::flow::function_node<index_message, data_cell_index_ptr> unfold_index_receiver_;
-    tbb::flow::function_node<phlex::detail::unfold_flush> unfold_flush_receiver_;
+    tbb::flow::function_node<unfold_flush> unfold_flush_receiver_;
     std::atomic<std::size_t> received_indices_{};
     flusher_t flusher_;
     tbb::concurrent_unordered_map<std::size_t, bool> is_lowest_layer_hashes_;

--- a/phlex/core/index_router.hpp
+++ b/phlex/core/index_router.hpp
@@ -19,8 +19,8 @@
 #include <string>
 #include <utility>
 
-namespace phlex::experimental {
-  namespace detail {
+namespace phlex::detail {
+  namespace internal {
     using index_set_node = tbb::flow::broadcast_node<index_message>;
     using index_set_node_ptr = std::shared_ptr<index_set_node>;
     using flush_node = tbb::flow::broadcast_node<indexed_end_token>;
@@ -57,14 +57,16 @@ namespace phlex::experimental {
     data_cell_index_ptr route(data_cell_index_ptr const& index,
                               phlex::detail::index_flushes flushes);
 
-    void establish_layers(std::vector<layer_path> const& layer_paths_from_driver,
-                          std::vector<identifier> unfold_input_layer_names,
-                          std::vector<identifier> unfold_output_layer_names);
+    void establish_layers(
+      std::vector<phlex::experimental::layer_path> const& layer_paths_from_driver,
+      std::vector<phlex::experimental::identifier> unfold_input_layer_names,
+      std::vector<phlex::experimental::identifier> unfold_output_layer_names);
 
     // Registers how many unfolds produce children from each input layer.  Must be called
     // before execution so that flush_gates are initialized with the correct expected
     // child count when they are first created.
-    void register_unfold_count_per_input_layer(std::map<identifier, std::size_t> counts);
+    void register_unfold_count_per_input_layer(
+      std::map<phlex::experimental::identifier, std::size_t> counts);
 
     void finalize(tbb::flow::graph& g,
                   provider_input_ports_t provider_input_ports,
@@ -92,9 +94,9 @@ namespace phlex::experimental {
     // correct for unfold outputs (the only source of unknown hashes) and consistent with
     // index_is_lowest_layer()'s fall-through default.
     bool is_lowest_layer_hash(std::size_t layer_hash) const;
-    detail::index_set_node_ptr index_set_node_for(layer_path const& layer);
-    detail::index_set_node_ptr index_set_node_for(data_cell_index_ptr const& index);
-    std::pair<detail::multilayer_slots_ptr, detail::multilayer_slots_ptr> multilayer_slots_for(
+    internal::index_set_node_ptr index_set_node_for(phlex::experimental::layer_path const& layer);
+    internal::index_set_node_ptr index_set_node_for(data_cell_index_ptr const& index);
+    std::pair<internal::multilayer_slots_ptr, internal::multilayer_slots_ptr> multilayer_slots_for(
       data_cell_index_ptr const& index);
     void update_flush_counts(phlex::detail::index_flushes flushes);
     void apply_expected_count(phlex::detail::flush_gate& gate,
@@ -108,28 +110,30 @@ namespace phlex::experimental {
     std::atomic<std::size_t> received_indices_{};
     flusher_t flusher_;
     tbb::concurrent_unordered_map<std::size_t, bool> is_lowest_layer_hashes_;
-    std::vector<identifier> unfold_input_layer_names_;
-    std::vector<identifier> unfold_output_layer_names_;
+    std::vector<phlex::experimental::identifier> unfold_input_layer_names_;
+    std::vector<phlex::experimental::identifier> unfold_output_layer_names_;
 
     // ==========================================================================================
     // Routing to provider nodes
     // The following maps are used to route data-cell indices to provider nodes.
     // The first map is from layer name to the corresponding index-set node.
-    tbb::concurrent_unordered_map<identifier, detail::index_set_node_ptr> index_set_nodes_;
+    tbb::concurrent_unordered_map<phlex::experimental::identifier, internal::index_set_node_ptr>
+      index_set_nodes_;
     // The second map is a cache from a layer hash to an index-set node, to avoid
     // repeated lookups for the same layer.
-    tbb::concurrent_unordered_map<std::size_t, detail::index_set_node_ptr> index_set_node_cache_;
+    tbb::concurrent_unordered_map<std::size_t, internal::index_set_node_ptr> index_set_node_cache_;
 
     // ==========================================================================================
     // Routing to multi-layer join nodes
     // Maps from join-node name to the multilayer slots for that node.
-    tbb::concurrent_unordered_map<identifier, detail::multilayer_slots> multilayer_join_slots_;
+    tbb::concurrent_unordered_map<phlex::experimental::identifier, internal::multilayer_slots>
+      multilayer_join_slots_;
 
     // This struct lets get_multilayer_slots return message and end-token slots together,
     // instead of passing concurrent_hash_map accessors as output parameters.
     struct multilayer_slot_cache_entry {
-      detail::multilayer_slots_ptr message_slots;
-      detail::multilayer_slots_ptr end_token_slots;
+      internal::multilayer_slots_ptr message_slots;
+      internal::multilayer_slots_ptr end_token_slots;
     };
     // Cache from layer hash to matched message/end-token slots for that layer.
     using multilayer_slot_cache_t =
@@ -140,14 +144,14 @@ namespace phlex::experimental {
 
     // ==========================================================================================
     // Flush gates (data-cell index hash is the key)
-    using gates_t = tbb::concurrent_hash_map<std::size_t, phlex::detail::flush_gate_ptr>;
+    using gates_t = tbb::concurrent_hash_map<std::size_t, flush_gate_ptr>;
     using accessor = gates_t::accessor;
     using const_accessor = gates_t::const_accessor;
     gates_t flush_gates_;
 
     // Number of unfolds that will send flush messages for each input layer.  Used to
     // initialize flush_gates with the correct expected child count.
-    std::map<identifier, std::size_t> unfold_count_per_input_layer_;
+    std::map<phlex::experimental::identifier, std::size_t> unfold_count_per_input_layer_;
   };
 }
 

--- a/phlex/core/input_arguments.hpp
+++ b/phlex/core/input_arguments.hpp
@@ -19,7 +19,7 @@
 namespace phlex::experimental {
   template <typename T>
   struct retriever {
-    using handle_arg_t = detail::handle_value_type<T>;
+    using handle_arg_t = phlex::detail::internal::handle_value_type<T>;
     product_selector query;
     auto retrieve(message const& msg) const
     {
@@ -27,10 +27,11 @@ namespace phlex::experimental {
       auto const& store = msg.store;
       // TODO: This needs to be replaced with a properly engineered solution
       auto all_products = std::ranges::subrange(store->begin(), store->end()) | views::keys;
-      auto products =
-        all_products |
-        views::filter([this](product_specification const& spec) { return query.match(spec); }) |
-        std::ranges::to<std::vector>();
+      auto products = all_products |
+                      views::filter([this](phlex::detail::product_specification const& spec) {
+                        return query.match(spec);
+                      }) |
+                      std::ranges::to<std::vector>();
       if (products.empty()) {
         throw std::runtime_error(fmt::format(
           "No products found matching the query {}\n Store (id {} from {}) contains:\n{}",

--- a/phlex/core/input_arguments.hpp
+++ b/phlex/core/input_arguments.hpp
@@ -37,12 +37,12 @@ namespace phlex::experimental {
           query,
           store->index()->to_string(),
           store->source().to_string(),
-          bulleted_list(all_products, /*indent=*/4)));
+          phlex::detail::bulleted_list(all_products, /*indent=*/4)));
       }
       if (products.size() > 1) {
         throw std::runtime_error(fmt::format("Multiple products found matching the query {}:\n{}",
                                              query,
-                                             bulleted_list(products, /*indent=*/4)));
+                                             phlex::detail::bulleted_list(products, /*indent=*/4)));
       }
       return store->get_handle<handle_arg_t>(products[0]);
     }

--- a/phlex/core/input_arguments.hpp
+++ b/phlex/core/input_arguments.hpp
@@ -19,7 +19,7 @@
 namespace phlex::detail {
   template <typename T>
   struct retriever {
-    using handle_arg_t = phlex::detail::internal::handle_value_type<T>;
+    using handle_arg_t = internal::handle_value_type<T>;
     product_selector query;
     auto retrieve(message const& msg) const
     {
@@ -27,23 +27,22 @@ namespace phlex::detail {
       auto const& store = msg.store;
       // TODO: This needs to be replaced with a properly engineered solution
       auto all_products = std::ranges::subrange(store->begin(), store->end()) | views::keys;
-      auto products = all_products |
-                      views::filter([this](phlex::detail::product_specification const& spec) {
-                        return query.match(spec);
-                      }) |
-                      std::ranges::to<std::vector>();
+      auto products =
+        all_products |
+        views::filter([this](product_specification const& spec) { return query.match(spec); }) |
+        std::ranges::to<std::vector>();
       if (products.empty()) {
         throw std::runtime_error(fmt::format(
           "No products found matching the query {}\n Store (id {} from {}) contains:\n{}",
           query,
           store->index()->to_string(),
           store->source().to_string(),
-          phlex::detail::bulleted_list(all_products, /*indent=*/4)));
+          bulleted_list(all_products, /*indent=*/4)));
       }
       if (products.size() > 1) {
         throw std::runtime_error(fmt::format("Multiple products found matching the query {}:\n{}",
                                              query,
-                                             phlex::detail::bulleted_list(products, /*indent=*/4)));
+                                             bulleted_list(products, /*indent=*/4)));
       }
       return store->get_handle<handle_arg_t>(products[0]);
     }

--- a/phlex/core/input_arguments.hpp
+++ b/phlex/core/input_arguments.hpp
@@ -16,7 +16,7 @@
 #include <utility>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   template <typename T>
   struct retriever {
     using handle_arg_t = phlex::detail::internal::handle_value_type<T>;

--- a/phlex/core/make_computational_edges.cpp
+++ b/phlex/core/make_computational_edges.cpp
@@ -28,10 +28,10 @@ namespace phlex::experimental {
       return nullptr;
     }
 
-    provider_bundles find_matching_implicit_providers(source_map const& sources,
-                                                      product_selector const& input_product)
+    phlex::detail::provider_bundles find_matching_implicit_providers(
+      phlex::detail::source_map const& sources, product_selector const& input_product)
     {
-      provider_bundles result;
+      phlex::detail::provider_bundles result;
       for (auto const& src : sources | std::views::values) {
         result.append_range(src->create_providers(input_product));
       }
@@ -70,7 +70,7 @@ namespace phlex::experimental {
     std::pair<index_router::provider_input_ports_t, index_router::head_ports_t>
     edges_from_implicit_providers(index_router::head_ports_t head_ports,
                                   provider_nodes& providers,
-                                  source_map const& sources,
+                                  phlex::detail::source_map const& sources,
                                   tbb::flow::graph& g)
     {
       index_router::provider_input_ports_t provider_input_ports;

--- a/phlex/core/make_computational_edges.cpp
+++ b/phlex/core/make_computational_edges.cpp
@@ -12,7 +12,7 @@
 
 using namespace std::string_literals;
 
-namespace phlex::experimental {
+namespace phlex::detail {
   namespace {
     provider_node* find_matching_provider(provider_nodes& providers,
                                           product_selector const& input_product)
@@ -28,10 +28,10 @@ namespace phlex::experimental {
       return nullptr;
     }
 
-    phlex::detail::provider_bundles find_matching_implicit_providers(
-      phlex::detail::source_map const& sources, product_selector const& input_product)
+    provider_bundles find_matching_implicit_providers(source_map const& sources,
+                                                      product_selector const& input_product)
     {
-      phlex::detail::provider_bundles result;
+      provider_bundles result;
       for (auto const& src : sources | std::views::values) {
         result.append_range(src->create_providers(input_product));
       }
@@ -70,7 +70,7 @@ namespace phlex::experimental {
     std::pair<index_router::provider_input_ports_t, index_router::head_ports_t>
     edges_from_implicit_providers(index_router::head_ports_t head_ports,
                                   provider_nodes& providers,
-                                  phlex::detail::source_map const& sources,
+                                  source_map const& sources,
                                   tbb::flow::graph& g)
     {
       index_router::provider_input_ports_t provider_input_ports;
@@ -107,13 +107,14 @@ namespace phlex::experimental {
 
           auto& bundle = bundles[0];
           auto const& spec = bundle.spec;
-          auto node = std::make_unique<provider_node>(spec.creator(),
-                                                      bundle.max_concurrency.value,
-                                                      g,
-                                                      std::move(bundle.provider_function),
-                                                      spec,
-                                                      identifier{bundle.layer},
-                                                      identifier{bundle.stage});
+          auto node =
+            std::make_unique<provider_node>(spec.creator(),
+                                            bundle.max_concurrency.value,
+                                            g,
+                                            std::move(bundle.provider_function),
+                                            spec,
+                                            phlex::experimental::identifier{bundle.layer},
+                                            phlex::experimental::identifier{bundle.stage});
           auto const provider_name = node->name().to_string();
           auto [_, inserted] =
             provider_input_ports.try_emplace(provider_name, input_product, node->input_port());

--- a/phlex/core/make_computational_edges.hpp
+++ b/phlex/core/make_computational_edges.hpp
@@ -26,7 +26,7 @@
 #include <tuple>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   PHLEX_CORE_EXPORT
   std::tuple<index_router::provider_input_ports_t, std::map<std::string, named_index_ports>>

--- a/phlex/core/message.cpp
+++ b/phlex/core/message.cpp
@@ -1,5 +1,6 @@
 #include "phlex/core/message.hpp"
 #include "phlex/model/data_cell_index.hpp"
+#include "phlex/model/product_store.hpp"
 
 #include "fmt/format.h"
 
@@ -8,7 +9,7 @@
 #include <stdexcept>
 #include <tuple>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   std::size_t message_matcher::operator()(message const& msg) const noexcept { return msg.id; }
 
@@ -16,7 +17,8 @@ namespace phlex::experimental {
   {
     assert(a.store);
     assert(b.store);
-    if (a.store->index()->depth() > b.store->index()->depth()) {
+    auto const& store = phlex::experimental::detail::more_derived(a.store, b.store);
+    if (store == a.store) {
       return a; // NOLINT(bugprone-return-const-ref-from-parameter)
     }
     return b; // NOLINT(bugprone-return-const-ref-from-parameter)

--- a/phlex/core/message.hpp
+++ b/phlex/core/message.hpp
@@ -51,7 +51,7 @@ namespace phlex::experimental {
   };
 
   template <std::size_t N>
-  using message_tuple = sized_tuple<message, N>;
+  using message_tuple = phlex::detail::sized_tuple<message, N>;
 
   template <std::size_t N>
   using messages_t = std::conditional_t<N == 1ull, message, message_tuple<N>>;

--- a/phlex/core/message.hpp
+++ b/phlex/core/message.hpp
@@ -36,7 +36,7 @@ namespace phlex::detail {
 
   struct flush_message {
     data_cell_index_ptr index;
-    phlex::detail::data_cell_counts_const_ptr counts;
+    data_cell_counts_const_ptr counts;
     std::size_t original_id{}; // FIXME: Used only by folds
   };
 
@@ -51,7 +51,7 @@ namespace phlex::detail {
   };
 
   template <std::size_t N>
-  using message_tuple = phlex::detail::sized_tuple<message, N>;
+  using message_tuple = sized_tuple<message, N>;
 
   template <std::size_t N>
   using messages_t = std::conditional_t<N == 1ull, message, message_tuple<N>>;

--- a/phlex/core/message.hpp
+++ b/phlex/core/message.hpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   struct index_message {
     data_cell_index_ptr index;
@@ -42,7 +42,7 @@ namespace phlex::experimental {
 
   struct message {
     // FIXME: Maybe consider adding an 'index' data member?
-    product_store_const_ptr store;
+    phlex::experimental::product_store_const_ptr store;
     std::size_t id{};
   };
 
@@ -57,7 +57,7 @@ namespace phlex::experimental {
   using messages_t = std::conditional_t<N == 1ull, message, message_tuple<N>>;
 
   struct named_index_port {
-    identifier layer;
+    phlex::experimental::identifier layer;
     tbb::flow::receiver<indexed_end_token>* token_port;
     tbb::flow::receiver<index_message>* index_port;
   };
@@ -70,6 +70,24 @@ namespace phlex::experimental {
   inline message const& most_derived(message const& msg)
   {
     return msg; // NOLINT(bugprone-return-const-ref-from-parameter)
+  }
+
+  // Generic most_derived for message tuples
+  template <std::size_t I, typename Tuple>
+  auto const& get_most_derived(Tuple const& tup, std::tuple_element_t<I - 1, Tuple> const& element)
+  {
+    constexpr auto num_inputs = std::tuple_size_v<Tuple>;
+    if constexpr (I == num_inputs - 1) {
+      return more_derived(element, std::get<I>(tup));
+    } else {
+      return get_most_derived<I + 1>(tup, more_derived(element, std::get<I>(tup)));
+    }
+  }
+
+  template <typename T, typename U, typename... Ts>
+  auto const& most_derived(std::tuple<T, U, Ts...> const& elements)
+  {
+    return get_most_derived<1ull>(elements, std::get<0>(elements));
   }
 
   PHLEX_CORE_EXPORT std::size_t port_index_for(product_selectors const& input_products,

--- a/phlex/core/message.hpp
+++ b/phlex/core/message.hpp
@@ -36,7 +36,7 @@ namespace phlex::experimental {
 
   struct flush_message {
     data_cell_index_ptr index;
-    data_cell_counts_const_ptr counts;
+    phlex::detail::data_cell_counts_const_ptr counts;
     std::size_t original_id{}; // FIXME: Used only by folds
   };
 

--- a/phlex/core/multilayer_join_node.hpp
+++ b/phlex/core/multilayer_join_node.hpp
@@ -63,7 +63,7 @@ namespace phlex::detail {
       // all ports are forwarded together as one tuple, ensuring that each output contains
       // exactly the messages that belong to the same data unit.
       return tbb::flow::join_node<args_t, tbb::flow::tag_matching>{
-        g, phlex::detail::type_t<message_matcher, Is>{}...};
+        g, type_t<message_matcher, Is>{}...};
     }
 
   public:

--- a/phlex/core/multilayer_join_node.hpp
+++ b/phlex/core/multilayer_join_node.hpp
@@ -3,6 +3,7 @@
 
 #include "phlex/core/detail/repeater_node.hpp"
 #include "phlex/core/message.hpp"
+#include "phlex/core/product_selector.hpp"
 #include "phlex/utilities/sized_tuple.hpp"
 
 #include "oneapi/tbb/flow_graph.h"
@@ -14,7 +15,7 @@
 #include <utility>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   template <typename Input>
   using multilayer_join_node_base_t = tbb::flow::composite_node<Input, std::tuple<Input>>;
 
@@ -68,7 +69,7 @@ namespace phlex::experimental {
   public:
     multilayer_join_node(tbb::flow::graph& g,
                          std::string const& node_name,
-                         std::vector<identifier> layer_names) :
+                         std::vector<phlex::experimental::identifier> layer_names) :
       base_t{g},
       join_{make_join(g, std::make_index_sequence<NInputs>{})},
       name_{node_name},
@@ -85,7 +86,7 @@ namespace phlex::experimental {
       if (collapsed_layers.size() > 1) {
         repeaters_.reserve(NInputs);
         for (auto const& layer : layers_) {
-          repeaters_.push_back(std::make_unique<detail::repeater_node>(g, name_, layer));
+          repeaters_.push_back(std::make_unique<internal::repeater_node>(g, name_, layer));
         }
       }
 
@@ -118,16 +119,16 @@ namespace phlex::experimental {
     }
 
   private:
-    std::vector<std::unique_ptr<detail::repeater_node>> repeaters_;
+    std::vector<std::unique_ptr<internal::repeater_node>> repeaters_;
     tbb::flow::join_node<args_t, tbb::flow::tag_matching> join_;
     // Immutable after construction; tbb::flow::join_node is already non-movable.
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::string const name_;
-    std::vector<identifier> const layers_;
+    std::vector<phlex::experimental::identifier> const layers_;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
 
-  namespace detail {
+  namespace internal {
     // Stateless placeholder used instead of multilayer_join_node when a node has only a
     // single input (no joining is required).
     struct no_join {
@@ -149,18 +150,18 @@ namespace phlex::experimental {
 
   // Resolves to multilayer_join_node<N> for N > 1 and to no_join for N == 1.
   template <std::size_t N>
-  using join_or_none_t = typename detail::pre_node<N>::type;
+  using join_or_none_t = typename internal::pre_node<N>::type;
 
   // Constructs a multilayer_join_node when N > 1, or a no_join when N == 1.
   template <std::size_t N>
   join_or_none_t<N> make_join_or_none(tbb::flow::graph& g,
                                       std::string const& node_name,
-                                      std::vector<identifier> const& layers)
+                                      std::vector<phlex::experimental::identifier> const& layers)
   {
     if constexpr (N > 1ull) {
       return multilayer_join_node<N>{g, node_name, layers};
     } else {
-      return detail::no_join{};
+      return internal::no_join{};
     }
   }
 
@@ -179,7 +180,7 @@ namespace phlex::experimental {
     throw std::runtime_error("Should never get here");
   }
 
-  namespace detail {
+  namespace internal {
     // Returns pointers to all N input ports of the join node.  Only valid for N > 1;
     // callers with a single input should use the node directly.
     template <std::size_t N>
@@ -213,7 +214,7 @@ namespace phlex::experimental {
     if constexpr (N == 1ull) {
       return {&node};
     } else {
-      return detail::input_ports<N>(join);
+      return internal::input_ports<N>(join);
     }
   }
 
@@ -229,7 +230,7 @@ namespace phlex::experimental {
     if constexpr (N == 1ull) {
       return node;
     } else {
-      return detail::receiver_for<N>(join, input_products, input_product);
+      return internal::receiver_for<N>(join, input_products, input_product);
     }
   }
 }

--- a/phlex/core/multilayer_join_node.hpp
+++ b/phlex/core/multilayer_join_node.hpp
@@ -3,6 +3,7 @@
 
 #include "phlex/core/detail/repeater_node.hpp"
 #include "phlex/core/message.hpp"
+#include "phlex/utilities/sized_tuple.hpp"
 
 #include "oneapi/tbb/flow_graph.h"
 
@@ -61,7 +62,7 @@ namespace phlex::experimental {
       // all ports are forwarded together as one tuple, ensuring that each output contains
       // exactly the messages that belong to the same data unit.
       return tbb::flow::join_node<args_t, tbb::flow::tag_matching>{
-        g, type_t<message_matcher, Is>{}...};
+        g, phlex::detail::type_t<message_matcher, Is>{}...};
     }
 
   public:

--- a/phlex/core/node_catalog.cpp
+++ b/phlex/core/node_catalog.cpp
@@ -7,7 +7,7 @@
 
 using namespace std::string_literals;
 
-namespace phlex::experimental {
+namespace phlex::detail {
   std::vector<products_consumer*> node_catalog::consumers() const
   {
     auto as_product_consumers = [](auto const& nodes) {

--- a/phlex/core/node_catalog.cpp
+++ b/phlex/core/node_catalog.cpp
@@ -57,9 +57,9 @@ namespace phlex::experimental {
     return producer_catalog{transforms, folds, unfolds};
   }
 
-  source_vector node_catalog::sources_for(std::vector<std::string> const& keys) const
+  phlex::detail::source_vector node_catalog::sources_for(std::vector<std::string> const& keys) const
   {
-    source_vector result;
+    phlex::detail::source_vector result;
     result.reserve(keys.size());
     for (auto const& key : keys) {
       if (auto src = sources.get(key)) {

--- a/phlex/core/node_catalog.cpp
+++ b/phlex/core/node_catalog.cpp
@@ -57,9 +57,9 @@ namespace phlex::detail {
     return producer_catalog{transforms, folds, unfolds};
   }
 
-  phlex::detail::source_vector node_catalog::sources_for(std::vector<std::string> const& keys) const
+  source_vector node_catalog::sources_for(std::vector<std::string> const& keys) const
   {
-    phlex::detail::source_vector result;
+    source_vector result;
     result.reserve(keys.size());
     for (auto const& key : keys) {
       if (auto src = sources.get(key)) {

--- a/phlex/core/node_catalog.hpp
+++ b/phlex/core/node_catalog.hpp
@@ -34,14 +34,14 @@ namespace phlex::experimental {
     std::vector<products_consumer*> consumers() const;
     producer_catalog producers() const;
 
-    simple_ptr_map<declared_predicate_ptr> predicates{};
-    simple_ptr_map<declared_observer_ptr> observers{};
-    simple_ptr_map<declared_output_ptr> outputs{};
-    simple_ptr_map<declared_fold_ptr> folds{};
-    simple_ptr_map<declared_unfold_ptr> unfolds{};
-    simple_ptr_map<declared_transform_ptr> transforms{};
-    simple_ptr_map<provider_node_ptr> providers{};
-    simple_ptr_map<phlex::detail::source_ptr> sources{};
+    phlex::detail::simple_ptr_map<declared_predicate_ptr> predicates{};
+    phlex::detail::simple_ptr_map<declared_observer_ptr> observers{};
+    phlex::detail::simple_ptr_map<declared_output_ptr> outputs{};
+    phlex::detail::simple_ptr_map<declared_fold_ptr> folds{};
+    phlex::detail::simple_ptr_map<declared_unfold_ptr> unfolds{};
+    phlex::detail::simple_ptr_map<declared_transform_ptr> transforms{};
+    phlex::detail::simple_ptr_map<provider_node_ptr> providers{};
+    phlex::detail::simple_ptr_map<phlex::detail::source_ptr> sources{};
 
   private:
     template <typename>

--- a/phlex/core/node_catalog.hpp
+++ b/phlex/core/node_catalog.hpp
@@ -28,7 +28,7 @@ namespace phlex::experimental {
       return registrar{ptr_map_for<Ptr>(), errors};
     }
 
-    source_vector sources_for(std::vector<std::string> const& keys) const;
+    phlex::detail::source_vector sources_for(std::vector<std::string> const& keys) const;
 
     std::size_t execution_count(std::string const& node_name) const;
     std::vector<products_consumer*> consumers() const;
@@ -41,7 +41,7 @@ namespace phlex::experimental {
     simple_ptr_map<declared_unfold_ptr> unfolds{};
     simple_ptr_map<declared_transform_ptr> transforms{};
     simple_ptr_map<provider_node_ptr> providers{};
-    simple_ptr_map<source_ptr> sources{};
+    simple_ptr_map<phlex::detail::source_ptr> sources{};
 
   private:
     template <typename>
@@ -65,7 +65,7 @@ namespace phlex::experimental {
         return transforms;
       } else if constexpr (std::is_same_v<Ptr, provider_node_ptr>) {
         return providers;
-      } else if constexpr (std::is_same_v<Ptr, source_ptr>) {
+      } else if constexpr (std::is_same_v<Ptr, phlex::detail::source_ptr>) {
         return sources;
       } else {
         static_assert(unknown_ptr_type_v<Ptr>, "Unsupported node pointer type");

--- a/phlex/core/node_catalog.hpp
+++ b/phlex/core/node_catalog.hpp
@@ -28,20 +28,20 @@ namespace phlex::detail {
       return registrar{ptr_map_for<Ptr>(), errors};
     }
 
-    phlex::detail::source_vector sources_for(std::vector<std::string> const& keys) const;
+    source_vector sources_for(std::vector<std::string> const& keys) const;
 
     std::size_t execution_count(std::string const& node_name) const;
     std::vector<products_consumer*> consumers() const;
     producer_catalog producers() const;
 
-    phlex::detail::simple_ptr_map<declared_predicate_ptr> predicates{};
-    phlex::detail::simple_ptr_map<declared_observer_ptr> observers{};
-    phlex::detail::simple_ptr_map<declared_output_ptr> outputs{};
-    phlex::detail::simple_ptr_map<declared_fold_ptr> folds{};
-    phlex::detail::simple_ptr_map<declared_unfold_ptr> unfolds{};
-    phlex::detail::simple_ptr_map<declared_transform_ptr> transforms{};
-    phlex::detail::simple_ptr_map<provider_node_ptr> providers{};
-    phlex::detail::simple_ptr_map<phlex::detail::source_ptr> sources{};
+    simple_ptr_map<declared_predicate_ptr> predicates{};
+    simple_ptr_map<declared_observer_ptr> observers{};
+    simple_ptr_map<declared_output_ptr> outputs{};
+    simple_ptr_map<declared_fold_ptr> folds{};
+    simple_ptr_map<declared_unfold_ptr> unfolds{};
+    simple_ptr_map<declared_transform_ptr> transforms{};
+    simple_ptr_map<provider_node_ptr> providers{};
+    simple_ptr_map<source_ptr> sources{};
 
   private:
     template <typename>
@@ -65,7 +65,7 @@ namespace phlex::detail {
         return transforms;
       } else if constexpr (std::is_same_v<Ptr, provider_node_ptr>) {
         return providers;
-      } else if constexpr (std::is_same_v<Ptr, phlex::detail::source_ptr>) {
+      } else if constexpr (std::is_same_v<Ptr, source_ptr>) {
         return sources;
       } else {
         static_assert(unknown_ptr_type_v<Ptr>, "Unsupported node pointer type");

--- a/phlex/core/node_catalog.hpp
+++ b/phlex/core/node_catalog.hpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   struct PHLEX_CORE_EXPORT node_catalog {
     template <typename Ptr>
     auto registrar_for(std::vector<std::string>& errors)

--- a/phlex/core/producer_catalog.cpp
+++ b/phlex/core/producer_catalog.cpp
@@ -78,8 +78,8 @@ namespace phlex::detail {
     if (candidates.size() > 1ull) {
       std::string msg = fmt::format("More than one candidate matches the query {}: \n{}\n",
                                     query.to_string(),
-                                    phlex::detail::bulleted_list(std::views::keys(candidates),
-                                                                 /*indent=*/1));
+                                    bulleted_list(std::views::keys(candidates),
+                                                  /*indent=*/1));
       throw std::runtime_error(msg);
     }
 

--- a/phlex/core/producer_catalog.cpp
+++ b/phlex/core/producer_catalog.cpp
@@ -78,7 +78,8 @@ namespace phlex::experimental {
     if (candidates.size() > 1ull) {
       std::string msg = fmt::format("More than one candidate matches the query {}: \n{}\n",
                                     query.to_string(),
-                                    bulleted_list(std::views::keys(candidates), /*indent=*/1));
+                                    phlex::detail::bulleted_list(std::views::keys(candidates),
+                                                                 /*indent=*/1));
       throw std::runtime_error(msg);
     }
 

--- a/phlex/core/producer_catalog.cpp
+++ b/phlex/core/producer_catalog.cpp
@@ -6,9 +6,9 @@
 #include "spdlog/spdlog.h"
 #include <ranges>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   producer_catalog::named_output_port const* producer_catalog::find_producer(
-    product_selector const& query, algorithm_name const& consumer_name) const
+    product_selector const& query, phlex::experimental::algorithm_name const& consumer_name) const
   {
     if (producers_.empty()) {
       spdlog::debug("No producers found. Skipping and assuming {} comes from a provider.",

--- a/phlex/core/producer_catalog.hpp
+++ b/phlex/core/producer_catalog.hpp
@@ -14,8 +14,8 @@
 #include <ranges>
 #include <string>
 
-namespace phlex::experimental {
-  using product_suffix_t = identifier;
+namespace phlex::detail {
+  using product_suffix_t = phlex::experimental::identifier;
 
   class PHLEX_CORE_EXPORT producer_catalog {
   public:
@@ -23,13 +23,14 @@ namespace phlex::experimental {
     explicit producer_catalog(Args const&... producers);
 
     struct named_output_port {
-      algorithm_name node;
+      phlex::experimental::algorithm_name node;
       tbb::flow::sender<message>* output_port;
-      phlex::detail::type_id type;
+      type_id type;
     };
 
-    named_output_port const* find_producer(product_selector const& query,
-                                           algorithm_name const& consumer_name) const;
+    named_output_port const* find_producer(
+      product_selector const& query,
+      phlex::experimental::algorithm_name const& consumer_name) const;
     auto values() const { return producers_ | std::views::values; }
 
   private:

--- a/phlex/core/producer_catalog.hpp
+++ b/phlex/core/producer_catalog.hpp
@@ -25,7 +25,7 @@ namespace phlex::experimental {
     struct named_output_port {
       algorithm_name node;
       tbb::flow::sender<message>* output_port;
-      type_id type;
+      phlex::detail::type_id type;
     };
 
     named_output_port const* find_producer(product_selector const& query,

--- a/phlex/core/product_selector.cpp
+++ b/phlex/core/product_selector.cpp
@@ -26,7 +26,7 @@ namespace phlex {
   }
 
   // Check if a product_specification satisfies this query
-  bool product_selector::match(experimental::product_specification const& spec) const
+  bool product_selector::match(detail::product_specification const& spec) const
   {
     if (!creator_match(spec.creator())) {
       return false;
@@ -43,7 +43,7 @@ namespace phlex {
   }
 
   // Check if a product_specification, layer, and stage together satisfies this query
-  bool product_selector::match(experimental::product_specification const& spec,
+  bool product_selector::match(detail::product_specification const& spec,
                                experimental::identifier const& layer,
                                experimental::identifier const& stage) const
   {
@@ -94,8 +94,8 @@ namespace phlex {
                     rhs.stage);
   }
 
-  experimental::product_specification const* resolve_in_store(
-    product_selector const& query, experimental::product_store const& store)
+  detail::product_specification const* resolve_in_store(product_selector const& query,
+                                                        experimental::product_store const& store)
   {
     for (auto const& [spec, _] : store) {
       if (query.match(spec)) {

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -109,7 +109,7 @@ namespace phlex {
     // C is a container of product_selectors
     template <typename C, typename T>
       requires std::is_same_v<typename std::remove_cvref_t<C>::value_type, product_selector> &&
-               phlex::experimental::is_tuple<T>::value
+               phlex::detail::is_tuple<T>::value
     class product_selectors_type_setter {};
     template <typename C, typename... Ts>
     class product_selectors_type_setter<C, std::tuple<Ts...>> {
@@ -134,7 +134,7 @@ namespace phlex {
 
   template <typename Tup, typename C>
     requires std::is_same_v<typename std::remove_cvref_t<C>::value_type, product_selector> &&
-             phlex::experimental::is_tuple<Tup>::value
+             phlex::detail::is_tuple<Tup>::value
   void populate_types(C& container)
   {
     detail::product_selectors_type_setter<decltype(container), Tup> populate_types{};

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -81,16 +81,16 @@ namespace phlex {
     detail::required_layer_name<experimental::identifier> layer;
     std::optional<experimental::identifier> suffix;
     std::optional<experimental::identifier> stage;
-    experimental::type_id type;
+    detail::type_id type;
 
     // Check that all products selected by /other/ would satisfy this query
     bool match(product_selector const& other) const;
 
     // Check if a product_specification satisfies this query
-    bool match(experimental::product_specification const& spec) const;
+    bool match(detail::product_specification const& spec) const;
 
     // Check if a product_specification, layer, and stage together satisfies this query
-    bool match(experimental::product_specification const& spec,
+    bool match(detail::product_specification const& spec,
                experimental::identifier const& layer,
                experimental::identifier const& stage) const;
 
@@ -109,7 +109,7 @@ namespace phlex {
     // C is a container of product_selectors
     template <typename C, typename T>
       requires std::is_same_v<typename std::remove_cvref_t<C>::value_type, product_selector> &&
-               experimental::is_tuple<T>::value
+               phlex::experimental::is_tuple<T>::value
     class product_selectors_type_setter {};
     template <typename C, typename... Ts>
     class product_selectors_type_setter<C, std::tuple<Ts...>> {
@@ -119,7 +119,7 @@ namespace phlex {
       template <typename T>
       void set_type(C& container)
       {
-        container.at(index_).type = experimental::make_type_id<T>();
+        container.at(index_).type = detail::make_type_id<T>();
         ++index_;
       }
 
@@ -134,7 +134,7 @@ namespace phlex {
 
   template <typename Tup, typename C>
     requires std::is_same_v<typename std::remove_cvref_t<C>::value_type, product_selector> &&
-             experimental::is_tuple<Tup>::value
+             phlex::experimental::is_tuple<Tup>::value
   void populate_types(C& container)
   {
     detail::product_selectors_type_setter<decltype(container), Tup> populate_types{};
@@ -143,7 +143,7 @@ namespace phlex {
 
   // This lives here rather than as a member-function of product_store because product_store is in model
   // and product_selector in core, with core depending on model.
-  PHLEX_CORE_EXPORT experimental::product_specification const* resolve_in_store(
+  PHLEX_CORE_EXPORT detail::product_specification const* resolve_in_store(
     product_selector const& query, experimental::product_store const& store);
 }
 

--- a/phlex/core/products_consumer.cpp
+++ b/phlex/core/products_consumer.cpp
@@ -12,9 +12,9 @@ namespace {
   }
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
-  products_consumer::products_consumer(algorithm_name name,
+  products_consumer::products_consumer(phlex::experimental::algorithm_name name,
                                        std::vector<std::string> predicates,
                                        product_selectors input_products) :
     consumer{std::move(name), std::move(predicates)},
@@ -33,5 +33,8 @@ namespace phlex::experimental {
   }
 
   product_selectors const& products_consumer::input() const noexcept { return input_products_; }
-  std::vector<identifier> const& products_consumer::layers() const noexcept { return layers_; }
+  std::vector<phlex::experimental::identifier> const& products_consumer::layers() const noexcept
+  {
+    return layers_;
+  }
 }

--- a/phlex/core/products_consumer.hpp
+++ b/phlex/core/products_consumer.hpp
@@ -16,10 +16,10 @@
 #include <string>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class PHLEX_CORE_EXPORT products_consumer : public consumer {
   public:
-    products_consumer(algorithm_name name,
+    products_consumer(phlex::experimental::algorithm_name name,
                       std::vector<std::string> predicates,
                       product_selectors input_products);
 
@@ -28,7 +28,7 @@ namespace phlex::experimental {
     std::size_t num_inputs() const;
 
     product_selectors const& input() const noexcept;
-    std::vector<identifier> const& layers() const noexcept;
+    std::vector<phlex::experimental::identifier> const& layers() const noexcept;
     tbb::flow::receiver<message>& port(product_selector const& input_product);
 
     virtual named_index_ports index_ports() = 0;
@@ -46,7 +46,7 @@ namespace phlex::experimental {
     virtual tbb::flow::receiver<message>& port_for(product_selector const& input_product) = 0;
 
     product_selectors input_products_;
-    std::vector<identifier> layers_;
+    std::vector<phlex::experimental::identifier> layers_;
   };
 }
 

--- a/phlex/core/provider_node.cpp
+++ b/phlex/core/provider_node.cpp
@@ -12,7 +12,7 @@ namespace phlex::experimental {
                                std::size_t concurrency,
                                tbb::flow::graph& g,
                                provider_function provider_func,
-                               product_specification output_spec,
+                               phlex::detail::product_specification output_spec,
                                identifier output_layer,
                                identifier stage) :
     name_{std::move(algo_name)},
@@ -30,7 +30,7 @@ namespace phlex::experimental {
                 // The constructor argument 1uz specifies how many slots to reserve in the
                 // underlying product container.  For providers, only one data product is
                 // produced per input index.
-                products new_products{1uz};
+                phlex::detail::products new_products{1uz};
                 new_products.add(output_, std::move(new_product));
                 auto store =
                   std::make_shared<product_store>(index, name_, std::move(new_products), stage_);
@@ -46,7 +46,10 @@ namespace phlex::experimental {
 
   algorithm_name const& provider_node::name() const noexcept { return name_; }
 
-  product_specification const& provider_node::output_product() const noexcept { return output_; }
+  phlex::detail::product_specification const& provider_node::output_product() const noexcept
+  {
+    return output_;
+  }
 
   identifier const& provider_node::layer() const noexcept { return layer_; }
 

--- a/phlex/core/provider_node.cpp
+++ b/phlex/core/provider_node.cpp
@@ -7,14 +7,14 @@
 #include <memory>
 #include <utility>
 
-namespace phlex::experimental {
-  provider_node::provider_node(algorithm_name algo_name,
+namespace phlex::detail {
+  provider_node::provider_node(phlex::experimental::algorithm_name algo_name,
                                std::size_t concurrency,
                                tbb::flow::graph& g,
                                provider_function provider_func,
-                               phlex::detail::product_specification output_spec,
-                               identifier output_layer,
-                               identifier stage) :
+                               product_specification output_spec,
+                               phlex::experimental::identifier output_layer,
+                               phlex::experimental::identifier stage) :
     name_{std::move(algo_name)},
     output_{std::move(output_spec)},
     layer_{std::move(output_layer)},
@@ -32,8 +32,8 @@ namespace phlex::experimental {
                 // produced per input index.
                 phlex::detail::products new_products{1uz};
                 new_products.add(output_, std::move(new_product));
-                auto store =
-                  std::make_shared<product_store>(index, name_, std::move(new_products), stage_);
+                auto store = std::make_shared<phlex::experimental::product_store>(
+                  index, name_, std::move(new_products), stage_);
 
                 return {.store = std::move(store), .id = msg_id};
               }}
@@ -44,15 +44,12 @@ namespace phlex::experimental {
                   layer_);
   }
 
-  algorithm_name const& provider_node::name() const noexcept { return name_; }
+  phlex::experimental::algorithm_name const& provider_node::name() const noexcept { return name_; }
 
-  phlex::detail::product_specification const& provider_node::output_product() const noexcept
-  {
-    return output_;
-  }
+  product_specification const& provider_node::output_product() const noexcept { return output_; }
 
-  identifier const& provider_node::layer() const noexcept { return layer_; }
+  phlex::experimental::identifier const& provider_node::layer() const noexcept { return layer_; }
 
-  identifier const& provider_node::stage() const noexcept { return stage_; }
+  phlex::experimental::identifier const& provider_node::stage() const noexcept { return stage_; }
 
 }

--- a/phlex/core/provider_node.cpp
+++ b/phlex/core/provider_node.cpp
@@ -30,7 +30,7 @@ namespace phlex::detail {
                 // The constructor argument 1uz specifies how many slots to reserve in the
                 // underlying product container.  For providers, only one data product is
                 // produced per input index.
-                phlex::detail::products new_products{1uz};
+                products new_products{1uz};
                 new_products.add(output_, std::move(new_product));
                 auto store = std::make_shared<phlex::experimental::product_store>(
                   index, name_, std::move(new_products), stage_);

--- a/phlex/core/provider_node.hpp
+++ b/phlex/core/provider_node.hpp
@@ -15,35 +15,35 @@
 #include <functional>
 #include <memory>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   class PHLEX_CORE_EXPORT provider_node {
   public:
     using provider_function =
       std::function<phlex::detail::product_ptr(phlex::data_cell_index const&)>;
 
-    provider_node(algorithm_name algo_name,
+    provider_node(phlex::experimental::algorithm_name algo_name,
                   std::size_t concurrency,
                   tbb::flow::graph& g,
                   provider_function provider_func,
-                  phlex::detail::product_specification output_spec,
-                  identifier output_layer,
-                  identifier stage);
+                  product_specification output_spec,
+                  phlex::experimental::identifier output_layer,
+                  phlex::experimental::identifier stage);
 
-    algorithm_name const& name() const noexcept;
-    phlex::detail::product_specification const& output_product() const noexcept;
-    identifier const& layer() const noexcept;
-    identifier const& stage() const noexcept;
+    phlex::experimental::algorithm_name const& name() const noexcept;
+    product_specification const& output_product() const noexcept;
+    phlex::experimental::identifier const& layer() const noexcept;
+    phlex::experimental::identifier const& stage() const noexcept;
 
     tbb::flow::receiver<index_message>* input_port() { return &provider_; }
     tbb::flow::sender<message>& output_port() { return provider_; }
     std::size_t num_calls() const { return calls_.load(); }
 
   private:
-    algorithm_name name_;
+    phlex::experimental::algorithm_name name_;
     phlex::detail::product_specification output_;
-    identifier layer_;
-    identifier stage_;
+    phlex::experimental::identifier layer_;
+    phlex::experimental::identifier stage_;
     tbb::flow::function_node<index_message, message> provider_;
     std::atomic<std::size_t> calls_;
   };

--- a/phlex/core/provider_node.hpp
+++ b/phlex/core/provider_node.hpp
@@ -19,18 +19,19 @@ namespace phlex::experimental {
 
   class PHLEX_CORE_EXPORT provider_node {
   public:
-    using provider_function = std::function<product_ptr(data_cell_index const&)>;
+    using provider_function =
+      std::function<phlex::detail::product_ptr(phlex::data_cell_index const&)>;
 
     provider_node(algorithm_name algo_name,
                   std::size_t concurrency,
                   tbb::flow::graph& g,
                   provider_function provider_func,
-                  product_specification output_spec,
+                  phlex::detail::product_specification output_spec,
                   identifier output_layer,
                   identifier stage);
 
     algorithm_name const& name() const noexcept;
-    product_specification const& output_product() const noexcept;
+    phlex::detail::product_specification const& output_product() const noexcept;
     identifier const& layer() const noexcept;
     identifier const& stage() const noexcept;
 
@@ -40,7 +41,7 @@ namespace phlex::experimental {
 
   private:
     algorithm_name name_;
-    product_specification output_;
+    phlex::detail::product_specification output_;
     identifier layer_;
     identifier stage_;
     tbb::flow::function_node<index_message, message> provider_;

--- a/phlex/core/provider_node.hpp
+++ b/phlex/core/provider_node.hpp
@@ -48,7 +48,7 @@ namespace phlex::experimental {
   };
 
   using provider_node_ptr = std::unique_ptr<provider_node>;
-  using provider_nodes = simple_ptr_map<provider_node_ptr>;
+  using provider_nodes = phlex::detail::simple_ptr_map<provider_node_ptr>;
 }
 
 #endif // PHLEX_CORE_PROVIDER_NODE_HPP

--- a/phlex/core/provider_node.hpp
+++ b/phlex/core/provider_node.hpp
@@ -19,8 +19,7 @@ namespace phlex::detail {
 
   class PHLEX_CORE_EXPORT provider_node {
   public:
-    using provider_function =
-      std::function<phlex::detail::product_ptr(phlex::data_cell_index const&)>;
+    using provider_function = std::function<product_ptr(data_cell_index const&)>;
 
     provider_node(phlex::experimental::algorithm_name algo_name,
                   std::size_t concurrency,
@@ -41,7 +40,7 @@ namespace phlex::detail {
 
   private:
     phlex::experimental::algorithm_name name_;
-    phlex::detail::product_specification output_;
+    product_specification output_;
     phlex::experimental::identifier layer_;
     phlex::experimental::identifier stage_;
     tbb::flow::function_node<index_message, message> provider_;
@@ -49,7 +48,7 @@ namespace phlex::detail {
   };
 
   using provider_node_ptr = std::unique_ptr<provider_node>;
-  using provider_nodes = phlex::detail::simple_ptr_map<provider_node_ptr>;
+  using provider_nodes = simple_ptr_map<provider_node_ptr>;
 }
 
 #endif // PHLEX_CORE_PROVIDER_NODE_HPP

--- a/phlex/core/registrar.cpp
+++ b/phlex/core/registrar.cpp
@@ -2,7 +2,7 @@
 
 #include "fmt/format.h"
 
-namespace phlex::experimental::detail {
+namespace phlex::detail::internal {
   void add_to_error_messages(std::vector<std::string>& errors,
                              std::string const& entity,
                              std::string const& name)

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -67,7 +67,7 @@ namespace phlex::detail {
 
   template <typename Ptr>
   class registrar {
-    using nodes = phlex::detail::simple_ptr_map<Ptr>;
+    using nodes = simple_ptr_map<Ptr>;
     using node_creator = std::function<Ptr(std::vector<std::string>, std::vector<std::string>)>;
 
   public:

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -57,9 +57,9 @@
 #include <string>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
-  namespace detail {
+  namespace internal {
     PHLEX_CORE_EXPORT void add_to_error_messages(std::vector<std::string>& errors,
                                                  std::string const& entity,
                                                  std::string const& name);
@@ -116,7 +116,7 @@ namespace phlex::experimental {
       auto name = ptr->name().to_string();
       auto [_, inserted] = nodes_->try_emplace(name, std::move(ptr));
       if (not inserted) {
-        detail::add_to_error_messages(*errors_, "Node", name);
+        internal::add_to_error_messages(*errors_, "Node", name);
       }
     }
 

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -67,7 +67,7 @@ namespace phlex::experimental {
 
   template <typename Ptr>
   class registrar {
-    using nodes = simple_ptr_map<Ptr>;
+    using nodes = phlex::detail::simple_ptr_map<Ptr>;
     using node_creator = std::function<Ptr(std::vector<std::string>, std::vector<std::string>)>;
 
   public:

--- a/phlex/core/registration_api.cpp
+++ b/phlex/core/registration_api.cpp
@@ -1,14 +1,14 @@
 #include "phlex/core/registration_api.hpp"
 #include "phlex/core/detail/maybe_predicates.hpp"
 
-namespace phlex::experimental {
+namespace phlex::detail {
   output_api::output_api(registrar<declared_output_ptr> reg,
                          configuration const* config,
                          std::string name,
                          tbb::flow::graph& g,
-                         detail::output_function_t&& f,
+                         internal::output_function_t&& f,
                          concurrency c) :
-    name_{detail::make_algorithm_name(config, std::move(name))},
+    name_{experimental::internal::make_algorithm_name(config, std::move(name))},
     graph_{g},
     ft_{std::move(f)},
     concurrency_{c},
@@ -16,7 +16,7 @@ namespace phlex::experimental {
   {
     // Predicates from the configuration always take precedence
     if (config) {
-      reg_.set_predicates(detail::maybe_predicates(config));
+      reg_.set_predicates(internal::maybe_predicates(config));
     }
     reg_.set_creator([this](auto predicates, auto) {
       return std::make_unique<declared_output>(

--- a/phlex/core/registration_api.hpp
+++ b/phlex/core/registration_api.hpp
@@ -140,11 +140,11 @@ namespace phlex::experimental {
                         identifier stage = "CURRENT"_id)
     {
       using return_type = return_type<typename AlgorithmBits::algorithm_type>;
-      product_specification output_spec(
-        std::move(creator), std::move(suffix), make_type_id<return_type>());
+      phlex::detail::product_specification output_spec(
+        std::move(creator), std::move(suffix), phlex::detail::make_type_id<return_type>());
 
-      auto type_erased_alg = [alg = alg_.release_algorithm()](data_cell_index const& index) {
-        return product_for(std::invoke(alg, index));
+      auto type_erased_alg = [alg = alg_.release_algorithm()](phlex::data_cell_index const& index) {
+        return phlex::detail::product_for(std::invoke(alg, index));
       };
 
       registrar_.set_creator(

--- a/phlex/core/registration_api.hpp
+++ b/phlex/core/registration_api.hpp
@@ -139,7 +139,7 @@ namespace phlex::experimental {
                         identifier output_layer,
                         identifier stage = "CURRENT"_id)
     {
-      using return_type = return_type<typename AlgorithmBits::algorithm_type>;
+      using return_type = phlex::detail::return_type<typename AlgorithmBits::algorithm_type>;
       phlex::detail::product_specification output_spec(
         std::move(creator), std::move(suffix), phlex::detail::make_type_id<return_type>());
 
@@ -179,7 +179,8 @@ namespace phlex::experimental {
   template <typename AlgorithmBits, typename... InitArgs>
   class fold_api {
     using init_tuple = std::tuple<InitArgs...>;
-    using input_parameter_types = skip_first_type<typename AlgorithmBits::input_parameter_types>;
+    using input_parameter_types =
+      phlex::detail::skip_first_type<typename AlgorithmBits::input_parameter_types>;
 
     static constexpr auto num_inputs = AlgorithmBits::number_inputs;
     static constexpr auto num_outputs = 1; // For now
@@ -250,10 +251,10 @@ namespace phlex::experimental {
 
   template <typename Object, typename Predicate, typename Unfold>
   class unfold_api {
-    using input_parameter_types = constructor_parameter_types<Object>;
+    using input_parameter_types = phlex::detail::constructor_parameter_types<Object>;
 
     static constexpr auto num_inputs = std::tuple_size_v<input_parameter_types>;
-    static constexpr std::size_t num_outputs = number_output_objects<Unfold>;
+    static constexpr std::size_t num_outputs = phlex::detail::number_output_objects<Unfold>;
 
     // FIXME: Should maybe use some type of static assert, but not in a way that
     //        constrains the arguments of the Predicate and the Unfold to be the same.

--- a/phlex/core/registration_api.hpp
+++ b/phlex/core/registration_api.hpp
@@ -44,7 +44,7 @@ namespace phlex::detail {
                      node_catalog& nodes,
                      std::vector<std::string>& errors) :
       config_{config},
-      name_{experimental::internal::make_algorithm_name(config, std::move(name))},
+      name_{phlex::experimental::internal::make_algorithm_name(config, std::move(name))},
       alg_{std::move(alg)},
       concurrency_{c},
       graph_{g},
@@ -126,7 +126,7 @@ namespace phlex::detail {
                  node_catalog& nodes,
                  std::vector<std::string>& errors) :
       config_{config},
-      name_{experimental::internal::make_algorithm_name(config, std::move(name))},
+      name_{phlex::experimental::internal::make_algorithm_name(config, std::move(name))},
       alg_{std::move(alg)},
       concurrency_{c},
       graph_{g},
@@ -139,12 +139,12 @@ namespace phlex::detail {
                         phlex::experimental::identifier output_layer,
                         phlex::experimental::identifier stage = "CURRENT"_id)
     {
-      using return_type = phlex::detail::return_type<typename AlgorithmBits::algorithm_type>;
-      phlex::detail::product_specification output_spec(
-        std::move(creator), std::move(suffix), phlex::detail::make_type_id<return_type>());
+      using return_type_t = return_type<typename AlgorithmBits::algorithm_type>;
+      product_specification output_spec(
+        std::move(creator), std::move(suffix), make_type_id<return_type_t>());
 
-      auto type_erased_alg = [alg = alg_.release_algorithm()](phlex::data_cell_index const& index) {
-        return phlex::detail::product_for(std::invoke(alg, index));
+      auto type_erased_alg = [alg = alg_.release_algorithm()](data_cell_index const& index) {
+        return product_for(std::invoke(alg, index));
       };
 
       registrar_.set_creator(
@@ -179,8 +179,7 @@ namespace phlex::detail {
   template <typename AlgorithmBits, typename... InitArgs>
   class fold_api {
     using init_tuple = std::tuple<InitArgs...>;
-    using input_parameter_types =
-      phlex::detail::skip_first_type<typename AlgorithmBits::input_parameter_types>;
+    using input_parameter_types = skip_first_type<typename AlgorithmBits::input_parameter_types>;
 
     static constexpr auto num_inputs = AlgorithmBits::number_inputs;
     static constexpr auto num_outputs = 1; // For now
@@ -196,7 +195,7 @@ namespace phlex::detail {
              std::string partition,
              InitArgs&&... init_args) :
       config_{config},
-      name_{experimental::internal::make_algorithm_name(config, std::move(name))},
+      name_{phlex::experimental::internal::make_algorithm_name(config, std::move(name))},
       alg_{std::move(alg)},
       concurrency_{c},
       graph_{g},
@@ -251,10 +250,10 @@ namespace phlex::detail {
 
   template <typename Object, typename Predicate, typename Unfold>
   class unfold_api {
-    using input_parameter_types = phlex::detail::constructor_parameter_types<Object>;
+    using input_parameter_types = constructor_parameter_types<Object>;
 
     static constexpr auto num_inputs = std::tuple_size_v<input_parameter_types>;
-    static constexpr std::size_t num_outputs = phlex::detail::number_output_objects<Unfold>;
+    static constexpr std::size_t num_outputs = number_output_objects<Unfold>;
 
     // FIXME: Should maybe use some type of static assert, but not in a way that
     //        constrains the arguments of the Predicate and the Unfold to be the same.

--- a/phlex/core/registration_api.hpp
+++ b/phlex/core/registration_api.hpp
@@ -21,7 +21,7 @@ namespace phlex {
   class configuration;
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   // ====================================================================================
   // Registration API
@@ -44,7 +44,7 @@ namespace phlex::experimental {
                      node_catalog& nodes,
                      std::vector<std::string>& errors) :
       config_{config},
-      name_{detail::make_algorithm_name(config, std::move(name))},
+      name_{experimental::internal::make_algorithm_name(config, std::move(name))},
       alg_{std::move(alg)},
       concurrency_{c},
       graph_{g},
@@ -91,7 +91,7 @@ namespace phlex::experimental {
 
   private:
     configuration const* config_;
-    algorithm_name name_;
+    phlex::experimental::algorithm_name name_;
     AlgorithmBits alg_;
     concurrency concurrency_;
     // Non-owning reference to the TBB graph; this class is a short-lived registration builder.
@@ -126,7 +126,7 @@ namespace phlex::experimental {
                  node_catalog& nodes,
                  std::vector<std::string>& errors) :
       config_{config},
-      name_{detail::make_algorithm_name(config, std::move(name))},
+      name_{experimental::internal::make_algorithm_name(config, std::move(name))},
       alg_{std::move(alg)},
       concurrency_{c},
       graph_{g},
@@ -134,10 +134,10 @@ namespace phlex::experimental {
     {
     }
 
-    auto output_product(algorithm_name creator,
-                        identifier suffix,
-                        identifier output_layer,
-                        identifier stage = "CURRENT"_id)
+    auto output_product(phlex::experimental::algorithm_name creator,
+                        phlex::experimental::identifier suffix,
+                        phlex::experimental::identifier output_layer,
+                        phlex::experimental::identifier stage = "CURRENT"_id)
     {
       using return_type = phlex::detail::return_type<typename AlgorithmBits::algorithm_type>;
       phlex::detail::product_specification output_spec(
@@ -165,7 +165,7 @@ namespace phlex::experimental {
 
   private:
     configuration const* config_;
-    algorithm_name name_;
+    phlex::experimental::algorithm_name name_;
     AlgorithmBits alg_;
     concurrency concurrency_;
     // Non-owning reference to the TBB graph; this class is a short-lived registration builder.
@@ -196,7 +196,7 @@ namespace phlex::experimental {
              std::string partition,
              InitArgs&&... init_args) :
       config_{config},
-      name_{detail::make_algorithm_name(config, std::move(name))},
+      name_{experimental::internal::make_algorithm_name(config, std::move(name))},
       alg_{std::move(alg)},
       concurrency_{c},
       graph_{g},
@@ -236,7 +236,7 @@ namespace phlex::experimental {
 
   private:
     configuration const* config_;
-    algorithm_name name_;
+    phlex::experimental::algorithm_name name_;
     AlgorithmBits alg_;
     concurrency concurrency_;
     // Non-owning reference to the TBB graph; this class is a short-lived registration builder.
@@ -274,7 +274,7 @@ namespace phlex::experimental {
                std::string destination_data_layer) :
       config_{config},
       registrar_{nodes.registrar_for<declared_unfold_ptr>(errors)},
-      name_{detail::make_algorithm_name(config, std::move(name))},
+      name_{phlex::experimental::internal::make_algorithm_name(config, std::move(name))},
       concurrency_{c.value},
       graph_{g},
       predicate_{std::move(predicate)},
@@ -314,7 +314,7 @@ namespace phlex::experimental {
   private:
     configuration const* config_;
     registrar<declared_unfold_ptr> registrar_;
-    algorithm_name name_;
+    phlex::experimental::algorithm_name name_;
     std::size_t concurrency_;
     // Non-owning reference to the TBB graph; this class is a short-lived registration builder.
     tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
@@ -332,7 +332,7 @@ namespace phlex::experimental {
                configuration const* config,
                std::string name,
                tbb::flow::graph& g,
-               detail::output_function_t&& f,
+               internal::output_function_t&& f,
                concurrency c);
 
     void experimental_when(std::vector<std::string> predicates);
@@ -343,10 +343,10 @@ namespace phlex::experimental {
     }
 
   private:
-    algorithm_name name_;
+    phlex::experimental::algorithm_name name_;
     // Non-owning reference to the TBB graph; this class is a short-lived registration builder.
     tbb::flow::graph& graph_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
-    detail::output_function_t ft_;
+    internal::output_function_t ft_;
     concurrency concurrency_;
     registrar<declared_output_ptr> reg_;
   };

--- a/phlex/core/source.hpp
+++ b/phlex/core/source.hpp
@@ -16,17 +16,17 @@
 #include <memory>
 #include <string>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   // ==============================================================================
 
   // Function type for type-erased data-product types (used by implicit providers)
-  using provider_function_t = product_ptr(data_cell_index const&);
+  using provider_function_t = experimental::product_ptr(data_cell_index const&);
 
   struct PHLEX_CORE_EXPORT provider_bundle {
     std::function<provider_function_t> provider_function;
     concurrency max_concurrency;
-    product_specification spec;
+    experimental::product_specification spec;
     std::string layer;
     std::string stage;
   };
@@ -42,8 +42,12 @@ namespace phlex::experimental {
   };
 
   using source_ptr = std::unique_ptr<source>;
-  using source_map = simple_ptr_map<source_ptr>;
+  using source_map = experimental::simple_ptr_map<source_ptr>;
   using source_vector = std::vector<source const*>;
+}
+
+namespace phlex {
+  using source = detail::source;
 }
 
 #endif // PHLEX_CORE_SOURCE_HPP

--- a/phlex/core/source.hpp
+++ b/phlex/core/source.hpp
@@ -21,12 +21,12 @@ namespace phlex::detail {
   // ==============================================================================
 
   // Function type for type-erased data-product types (used by implicit providers)
-  using provider_function_t = experimental::product_ptr(data_cell_index const&);
+  using provider_function_t = product_ptr(data_cell_index const&);
 
   struct PHLEX_CORE_EXPORT provider_bundle {
     std::function<provider_function_t> provider_function;
     concurrency max_concurrency;
-    experimental::product_specification spec;
+    product_specification spec;
     std::string layer;
     std::string stage;
   };
@@ -42,7 +42,7 @@ namespace phlex::detail {
   };
 
   using source_ptr = std::unique_ptr<source>;
-  using source_map = phlex::detail::simple_ptr_map<source_ptr>;
+  using source_map = simple_ptr_map<source_ptr>;
   using source_vector = std::vector<source const*>;
 }
 

--- a/phlex/core/source.hpp
+++ b/phlex/core/source.hpp
@@ -42,7 +42,7 @@ namespace phlex::detail {
   };
 
   using source_ptr = std::unique_ptr<source>;
-  using source_map = experimental::simple_ptr_map<source_ptr>;
+  using source_map = phlex::detail::simple_ptr_map<source_ptr>;
   using source_vector = std::vector<source const*>;
 }
 

--- a/phlex/core/store_counters.cpp
+++ b/phlex/core/store_counters.cpp
@@ -9,7 +9,7 @@
 
 namespace phlex::detail {
 
-  void store_counter::set_flush_value(phlex::detail::data_cell_counts_const_ptr counts,
+  void store_counter::set_flush_value(data_cell_counts_const_ptr counts,
                                       std::size_t const original_message_id)
   {
     if (not counts) {

--- a/phlex/core/store_counters.cpp
+++ b/phlex/core/store_counters.cpp
@@ -9,7 +9,7 @@
 
 namespace phlex::experimental {
 
-  void store_counter::set_flush_value(data_cell_counts_const_ptr counts,
+  void store_counter::set_flush_value(phlex::detail::data_cell_counts_const_ptr counts,
                                       std::size_t const original_message_id)
   {
     if (not counts) {

--- a/phlex/core/store_counters.cpp
+++ b/phlex/core/store_counters.cpp
@@ -7,7 +7,7 @@
 
 #include <cassert>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   void store_counter::set_flush_value(phlex::detail::data_cell_counts_const_ptr counts,
                                       std::size_t const original_message_id)

--- a/phlex/core/store_counters.hpp
+++ b/phlex/core/store_counters.hpp
@@ -14,7 +14,7 @@
 #include <memory>
 #include <version>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class PHLEX_CORE_EXPORT store_counter {
   public:
     void set_flush_value(phlex::detail::data_cell_counts_const_ptr counts,

--- a/phlex/core/store_counters.hpp
+++ b/phlex/core/store_counters.hpp
@@ -17,8 +17,7 @@
 namespace phlex::detail {
   class PHLEX_CORE_EXPORT store_counter {
   public:
-    void set_flush_value(phlex::detail::data_cell_counts_const_ptr counts,
-                         std::size_t original_message_id);
+    void set_flush_value(data_cell_counts_const_ptr counts, std::size_t original_message_id);
     void increment(data_cell_index::hash_type layer_hash);
     bool is_complete();
     unsigned int original_message_id() const noexcept;
@@ -29,9 +28,9 @@ namespace phlex::detail {
 
     counts_t counts_{};
 #ifdef __cpp_lib_atomic_shared_ptr
-    std::atomic<phlex::detail::data_cell_counts_const_ptr> flush_counts_{nullptr};
+    std::atomic<data_cell_counts_const_ptr> flush_counts_{nullptr};
 #else
-    phlex::detail::data_cell_counts_const_ptr flush_counts_{nullptr};
+    data_cell_counts_const_ptr flush_counts_{nullptr};
 #endif
     unsigned int original_message_id_{}; // Necessary for matching inputs to downstream join nodes.
     std::atomic<bool> ready_to_flush_{true};

--- a/phlex/core/store_counters.hpp
+++ b/phlex/core/store_counters.hpp
@@ -17,7 +17,8 @@
 namespace phlex::experimental {
   class PHLEX_CORE_EXPORT store_counter {
   public:
-    void set_flush_value(data_cell_counts_const_ptr counts, std::size_t original_message_id);
+    void set_flush_value(phlex::detail::data_cell_counts_const_ptr counts,
+                         std::size_t original_message_id);
     void increment(data_cell_index::hash_type layer_hash);
     bool is_complete();
     unsigned int original_message_id() const noexcept;
@@ -28,9 +29,9 @@ namespace phlex::experimental {
 
     counts_t counts_{};
 #ifdef __cpp_lib_atomic_shared_ptr
-    std::atomic<data_cell_counts_const_ptr> flush_counts_{nullptr};
+    std::atomic<phlex::detail::data_cell_counts_const_ptr> flush_counts_{nullptr};
 #else
-    data_cell_counts_const_ptr flush_counts_{nullptr};
+    phlex::detail::data_cell_counts_const_ptr flush_counts_{nullptr};
 #endif
     unsigned int original_message_id_{}; // Necessary for matching inputs to downstream join nodes.
     std::atomic<bool> ready_to_flush_{true};

--- a/phlex/core/upstream_predicates.hpp
+++ b/phlex/core/upstream_predicates.hpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   template <typename Ptr, std::size_t NumberOutputProducts>
   class upstream_predicates {
   public:
@@ -20,7 +20,7 @@ namespace phlex::experimental {
       if (!config) {
         return;
       }
-      registrar_.set_predicates(detail::maybe_predicates(config));
+      registrar_.set_predicates(internal::maybe_predicates(config));
     }
 
     auto& experimental_when(std::vector<std::string> predicates)

--- a/phlex/detail/plugin_macros.hpp
+++ b/phlex/detail/plugin_macros.hpp
@@ -54,7 +54,7 @@
 
 #define PHLEX_DETAIL_REGISTER_SOURCE_PLUGIN(token_type, func_name, dll_alias, ...)                 \
   static PHLEX_DETAIL_SELECT_SOURCE_SIGNATURE(token_type, func_name, __VA_ARGS__);                 \
-  extern "C" void dll_alias(phlex::experimental::source_bundle __phlex_bundle,                     \
+  extern "C" void dll_alias(phlex::detail::source_bundle __phlex_bundle,                           \
                             phlex::configuration const& __phlex_config)                            \
   {                                                                                                \
     func_name(token_type<phlex::detail::void_tag>{__phlex_bundle}, __phlex_config);                \
@@ -64,12 +64,11 @@
 // ================================================================================================
 // Driver registration plugin macros
 #define PHLEX_DETAIL_CREATE_DRIVER_1ARG(func_name, d)                                              \
-  phlex::experimental::driver_bundle func_name(phlex::experimental::driver_proxy d,                \
-                                               phlex::configuration const&)
+  phlex::detail::driver_bundle func_name(phlex::detail::driver_proxy d, phlex::configuration const&)
 
 #define PHLEX_DETAIL_CREATE_DRIVER_2ARGS(func_name, d, cfg)                                        \
-  phlex::experimental::driver_bundle func_name(phlex::experimental::driver_proxy d,                \
-                                               phlex::configuration const& cfg)
+  phlex::detail::driver_bundle func_name(phlex::detail::driver_proxy d,                            \
+                                         phlex::configuration const& cfg)
 
 #define PHLEX_DETAIL_SELECT_DRIVER_SIGNATURE(func_name, ...)                                       \
   BOOST_PP_IF(BOOST_PP_EQUAL(PHLEX_DETAIL_NARGS(__VA_ARGS__), 1),                                  \
@@ -83,9 +82,9 @@
 // linkage), and then open the user's implementation definition for the body that follows.
 #define PHLEX_DETAIL_REGISTER_DRIVER_PLUGIN(func_name, dll_alias, ...)                             \
   static PHLEX_DETAIL_SELECT_DRIVER_SIGNATURE(func_name, __VA_ARGS__);                             \
-  extern "C" void dll_alias(phlex::experimental::driver_proxy __phlex_proxy,                       \
+  extern "C" void dll_alias(phlex::detail::driver_proxy __phlex_proxy,                             \
                             phlex::configuration const& __phlex_config,                            \
-                            phlex::experimental::driver_bundle* __phlex_out)                       \
+                            phlex::detail::driver_bundle* __phlex_out)                             \
   {                                                                                                \
     *__phlex_out = func_name(__phlex_proxy, __phlex_config);                                       \
   }                                                                                                \

--- a/phlex/detail/plugin_macros.hpp
+++ b/phlex/detail/plugin_macros.hpp
@@ -13,10 +13,10 @@
 #define PHLEX_DETAIL_NARGS(...) BOOST_PP_DEC(BOOST_PP_VARIADIC_SIZE(__VA_OPT__(, ) __VA_ARGS__))
 
 #define PHLEX_DETAIL_CREATE_1ARG(token_type, func_name, m)                                         \
-  void func_name(token_type<phlex::experimental::void_tag> m, phlex::configuration const&)
+  void func_name(token_type<phlex::detail::void_tag> m, phlex::configuration const&)
 
 #define PHLEX_DETAIL_CREATE_2ARGS(token_type, func_name, m, cfg)                                   \
-  void func_name(token_type<phlex::experimental::void_tag> m, phlex::configuration const& cfg)
+  void func_name(token_type<phlex::detail::void_tag> m, phlex::configuration const& cfg)
 
 #define PHLEX_DETAIL_SELECT_SIGNATURE(token_type, func_name, ...)                                  \
   BOOST_PP_IF(BOOST_PP_EQUAL(PHLEX_DETAIL_NARGS(__VA_ARGS__), 1),                                  \
@@ -41,10 +41,10 @@
 //      and calls the user's implementation.
 //   3. Open the user's implementation definition for the body that follows the macro.
 #define PHLEX_DETAIL_CREATE_SOURCE_1ARG(token_type, func_name, m)                                  \
-  void func_name(token_type<phlex::experimental::void_tag> m, phlex::configuration const&)
+  void func_name(token_type<phlex::detail::void_tag> m, phlex::configuration const&)
 
 #define PHLEX_DETAIL_CREATE_SOURCE_2ARGS(token_type, func_name, m, cfg)                            \
-  void func_name(token_type<phlex::experimental::void_tag> m, phlex::configuration const& cfg)
+  void func_name(token_type<phlex::detail::void_tag> m, phlex::configuration const& cfg)
 
 #define PHLEX_DETAIL_SELECT_SOURCE_SIGNATURE(token_type, func_name, ...)                           \
   BOOST_PP_IF(BOOST_PP_EQUAL(PHLEX_DETAIL_NARGS(__VA_ARGS__), 1),                                  \
@@ -57,7 +57,7 @@
   extern "C" void dll_alias(phlex::experimental::source_bundle __phlex_bundle,                     \
                             phlex::configuration const& __phlex_config)                            \
   {                                                                                                \
-    func_name(token_type<phlex::experimental::void_tag>{__phlex_bundle}, __phlex_config);          \
+    func_name(token_type<phlex::detail::void_tag>{__phlex_bundle}, __phlex_config);                \
   }                                                                                                \
   PHLEX_DETAIL_SELECT_SOURCE_SIGNATURE(token_type, func_name, __VA_ARGS__)
 

--- a/phlex/driver.hpp
+++ b/phlex/driver.hpp
@@ -29,7 +29,7 @@ namespace phlex::experimental {
   struct driver_bundle;
 
   namespace detail {
-    using next_index_t = std::function<void(framework_driver&)>;
+    using next_index_t = std::function<void(phlex::detail::framework_driver&)>;
     // Shim type for the extern "C" entry-point: out-parameter avoids returning a C++ type
     // across a C-linkage boundary.
     using driver_shim_t = void(driver_proxy, configuration const&, driver_bundle*);
@@ -115,10 +115,11 @@ namespace phlex::experimental {
     driver_bundle driver(fixed_hierarchy hierarchy,
                          is_driver_like_with_cursor auto driver_function) const
     {
-      return make_driver_bundle(
-        std::move(hierarchy),
-        std::move(driver_function),
-        [](fixed_hierarchy const& h, framework_driver& d) { return h.yield_job(d); });
+      return make_driver_bundle(std::move(hierarchy),
+                                std::move(driver_function),
+                                [](fixed_hierarchy const& h, phlex::detail::framework_driver& d) {
+                                  return h.yield_job(d);
+                                });
     }
 
     /// @brief Creates a driver_bundle from a hierarchy and a user-supplied driver function.
@@ -132,7 +133,7 @@ namespace phlex::experimental {
       return make_driver_bundle(
         std::move(hierarchy),
         std::move(driver_function),
-        [](fixed_hierarchy const& h, framework_driver& d) { return h.yielder(d); });
+        [](fixed_hierarchy const& h, phlex::detail::framework_driver& d) { return h.yielder(d); });
     }
 
     template <typename DriverBuilder>
@@ -148,7 +149,7 @@ namespace phlex::experimental {
 
       using first_argument_type = std::remove_cvref_t<decltype(driver_function)>;
       auto first_arg_factory = [hierarchy = hierarchy](fixed_hierarchy const& h,
-                                                       framework_driver& d) {
+                                                       phlex::detail::framework_driver& d) {
         if constexpr (std::is_same_v<first_argument_type, data_cell_cursor>) {
           return h.yield_job(d);
         } else {
@@ -185,7 +186,8 @@ namespace phlex::experimental {
       return {[f = std::move(driver_function),
                h = std::move(h),
                srcs = std::move(sources_),
-               first_arg_factory = std::move(first_arg_factory)](framework_driver& d) mutable {
+               first_arg_factory =
+                 std::move(first_arg_factory)](phlex::detail::framework_driver& d) mutable {
                 detail::invoke_driver_with_sources<source_parameters_t>(
                   f, first_arg_factory(h, d), srcs);
               },

--- a/phlex/driver.hpp
+++ b/phlex/driver.hpp
@@ -24,12 +24,12 @@
 #include <utility>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class driver_proxy;
   struct driver_bundle;
 
-  namespace detail {
-    using next_index_t = std::function<void(phlex::detail::framework_driver&)>;
+  namespace internal {
+    using next_index_t = std::function<void(framework_driver&)>;
     // Shim type for the extern "C" entry-point: out-parameter avoids returning a C++ type
     // across a C-linkage boundary.
     using driver_shim_t = void(driver_proxy, configuration const&, driver_bundle*);
@@ -62,12 +62,12 @@ namespace phlex::experimental {
           as_driver_source<boost::mp11::mp_at_c<SourceParameters, Is>>(sources[Is], Is)...);
       }(std::make_index_sequence<boost::mp11::mp_size<SourceParameters>::value>{});
     }
-  };
+  }
 
   /// @brief Bundles the driver function and data hierarchy for the framework.
   struct driver_bundle {
-    detail::next_index_t driver; ///< Driver function that advances data cells.
-    fixed_hierarchy hierarchy;   ///< Data hierarchy traversed by the driver.
+    internal::next_index_t driver; ///< Driver function that advances data cells.
+    fixed_hierarchy hierarchy;     ///< Data hierarchy traversed by the driver.
   };
 
   template <typename T>
@@ -75,16 +75,13 @@ namespace phlex::experimental {
 
   template <typename F, typename FirstArg>
   concept is_driver_like_with_sources =
-    phlex::detail::check_parameters<F, FirstArg>::value &&
-    boost::mp11::mp_all_of<
-      phlex::detail::skip_first_type<phlex::detail::function_parameter_types<F>>,
-      is_derived_from_source>::value;
+    check_parameters<F, FirstArg>::value &&
+    boost::mp11::mp_all_of<skip_first_type<function_parameter_types<F>>,
+                           is_derived_from_source>::value;
 
   template <typename Tuple>
-  using source_parameter_types = phlex::detail::skip_first_type<Tuple>;
-}
+  using source_parameter_types = skip_first_type<Tuple>;
 
-namespace phlex::experimental {
   template <typename F>
   concept is_driver_like_with_cursor = is_driver_like_with_sources<F, data_cell_cursor>;
 
@@ -117,11 +114,10 @@ namespace phlex::experimental {
     driver_bundle driver(fixed_hierarchy hierarchy,
                          is_driver_like_with_cursor auto driver_function) const
     {
-      return make_driver_bundle(std::move(hierarchy),
-                                std::move(driver_function),
-                                [](fixed_hierarchy const& h, phlex::detail::framework_driver& d) {
-                                  return h.yield_job(d);
-                                });
+      return make_driver_bundle(
+        std::move(hierarchy),
+        std::move(driver_function),
+        [](fixed_hierarchy const& h, framework_driver& d) { return h.yield_job(d); });
     }
 
     /// @brief Creates a driver_bundle from a hierarchy and a user-supplied driver function.
@@ -135,7 +131,7 @@ namespace phlex::experimental {
       return make_driver_bundle(
         std::move(hierarchy),
         std::move(driver_function),
-        [](fixed_hierarchy const& h, phlex::detail::framework_driver& d) { return h.yielder(d); });
+        [](fixed_hierarchy const& h, framework_driver& d) { return h.yielder(d); });
     }
 
     template <typename DriverBuilder>
@@ -151,7 +147,7 @@ namespace phlex::experimental {
 
       using first_argument_type = std::remove_cvref_t<decltype(driver_function)>;
       auto first_arg_factory = [hierarchy = hierarchy](fixed_hierarchy const& h,
-                                                       phlex::detail::framework_driver& d) {
+                                                       framework_driver& d) {
         if constexpr (std::is_same_v<first_argument_type, data_cell_cursor>) {
           return h.yield_job(d);
         } else {
@@ -180,7 +176,7 @@ namespace phlex::experimental {
     {
       using driver_function_t = std::remove_cvref_t<DriverFunction>;
       using source_parameters_t =
-        source_parameter_types<phlex::detail::function_parameter_types<driver_function_t>>;
+        source_parameter_types<function_parameter_types<driver_function_t>>;
 
       verify_source_parameter_count<source_parameters_t>();
 
@@ -188,9 +184,8 @@ namespace phlex::experimental {
       return {[f = std::move(driver_function),
                h = std::move(h),
                srcs = std::move(sources_),
-               first_arg_factory =
-                 std::move(first_arg_factory)](phlex::detail::framework_driver& d) mutable {
-                detail::invoke_driver_with_sources<source_parameters_t>(
+               first_arg_factory = std::move(first_arg_factory)](framework_driver& d) mutable {
+                internal::invoke_driver_with_sources<source_parameters_t>(
                   f, first_arg_factory(h, d), srcs);
               },
               std::move(hierarchy)};

--- a/phlex/driver.hpp
+++ b/phlex/driver.hpp
@@ -59,8 +59,8 @@ namespace phlex::experimental {
     {
       [&]<std::size_t... Is>(std::index_sequence<Is...>) {
         f(std::forward<FirstArg>(first_arg),
-          as_driver_source<mp11::mp_at_c<SourceParameters, Is>>(sources[Is], Is)...);
-      }(std::make_index_sequence<mp11::mp_size<SourceParameters>::value>{});
+          as_driver_source<boost::mp11::mp_at_c<SourceParameters, Is>>(sources[Is], Is)...);
+      }(std::make_index_sequence<boost::mp11::mp_size<SourceParameters>::value>{});
     }
   };
 
@@ -75,11 +75,13 @@ namespace phlex::experimental {
 
   template <typename F, typename FirstArg>
   concept is_driver_like_with_sources =
-    check_parameters<F, FirstArg>::value &&
-    mp11::mp_all_of<skip_first_type<function_parameter_types<F>>, is_derived_from_source>::value;
+    phlex::detail::check_parameters<F, FirstArg>::value &&
+    boost::mp11::mp_all_of<
+      phlex::detail::skip_first_type<phlex::detail::function_parameter_types<F>>,
+      is_derived_from_source>::value;
 
   template <typename Tuple>
-  using source_parameter_types = skip_first_type<Tuple>;
+  using source_parameter_types = phlex::detail::skip_first_type<Tuple>;
 }
 
 namespace phlex::experimental {
@@ -165,7 +167,7 @@ namespace phlex::experimental {
     template <typename SourceParameters>
     void verify_source_parameter_count() const
     {
-      if (mp11::mp_size<SourceParameters>::value != sources_.size()) {
+      if (boost::mp11::mp_size<SourceParameters>::value != sources_.size()) {
         throw std::invalid_argument("Number of source parameters of driver function does not match "
                                     "the number of sources specified in the configuration.");
       }
@@ -178,7 +180,7 @@ namespace phlex::experimental {
     {
       using driver_function_t = std::remove_cvref_t<DriverFunction>;
       using source_parameters_t =
-        source_parameter_types<function_parameter_types<driver_function_t>>;
+        source_parameter_types<phlex::detail::function_parameter_types<driver_function_t>>;
 
       verify_source_parameter_count<source_parameters_t>();
 

--- a/phlex/metaprogramming/delegate.hpp
+++ b/phlex/metaprogramming/delegate.hpp
@@ -6,7 +6,7 @@
 #include <functional>
 #include <memory>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   template <typename FT>
   auto delegate(std::shared_ptr<void_tag>, FT f) // Used for lambda closures
   {

--- a/phlex/metaprogramming/detail/ctor_reflect_types.hpp
+++ b/phlex/metaprogramming/detail/ctor_reflect_types.hpp
@@ -105,7 +105,7 @@ namespace phlex::detail {
     return fields_number_ctor<T, Ns..., sizeof...(Ns)>(0);
   }
 
-  // This is a helper to turn a ctor into a tuple type.  Usage is: phlex::detail::as_tuple<data_t>
+  // This is a helper to turn a ctor into a tuple type.  Usage is: as_tuple<data_t>
   template <typename T, typename U>
   struct loophole_tuple;
 

--- a/phlex/metaprogramming/detail/ctor_reflect_types.hpp
+++ b/phlex/metaprogramming/detail/ctor_reflect_types.hpp
@@ -27,7 +27,7 @@
 // * https://www.youtube.com/watch?v=UlNUNxLtBI0
 //   Better C++14 reflections - Antony Polukhin - Meeting C++ 2018
 
-namespace refl {
+namespace phlex::detail {
 
   // tag<T, N> generates friend declarations and helps with overload resolution.  There
   // are two types: one with the auto return type, which is the way we read types later.
@@ -105,7 +105,7 @@ namespace refl {
     return fields_number_ctor<T, Ns..., sizeof...(Ns)>(0);
   }
 
-  // This is a helper to turn a ctor into a tuple type.  Usage is: refl::as_tuple<data_t>
+  // This is a helper to turn a ctor into a tuple type.  Usage is: phlex::detail::as_tuple<data_t>
   template <typename T, typename U>
   struct loophole_tuple;
 
@@ -118,7 +118,7 @@ namespace refl {
   using as_tuple =
     typename loophole_tuple<T, std::make_integer_sequence<int, fields_number_ctor<T>(0)>>::type;
 
-} // namespace refl
+} // namespace phlex::detail
 
 // ===========================================================================
 // End Alexandr code

--- a/phlex/metaprogramming/type_deduction.hpp
+++ b/phlex/metaprogramming/type_deduction.hpp
@@ -12,7 +12,7 @@
 #include <tuple>
 #include <type_traits>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   namespace ct = boost::callable_traits;
   namespace mp11 = boost::mp11;
   template <typename T>
@@ -29,7 +29,7 @@ namespace phlex::experimental {
   using function_parameter_type = std::tuple_element_t<I, function_parameter_types<T>>;
 
   template <typename T>
-  using constructor_parameter_types = typename refl::as_tuple<T>;
+  using constructor_parameter_types = as_tuple<T>;
 
   template <typename T>
   constexpr std::size_t number_parameters = mp11::mp_size<function_parameter_types<T>>::value;

--- a/phlex/model/data_cell_counts.cpp
+++ b/phlex/model/data_cell_counts.cpp
@@ -1,6 +1,6 @@
 #include "phlex/model/data_cell_counts.hpp"
 
-namespace phlex::experimental {
+namespace phlex::detail {
   void data_cell_counts::emplace(std::size_t layer_hash, std::size_t value)
   {
     map_.emplace(layer_hash, value);

--- a/phlex/model/data_cell_counts.hpp
+++ b/phlex/model/data_cell_counts.hpp
@@ -9,7 +9,7 @@
 #include <cstddef>
 #include <memory>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class PHLEX_MODEL_EXPORT data_cell_counts {
   public:
     void emplace(std::size_t layer_hash, std::size_t value);

--- a/phlex/model/data_cell_index.cpp
+++ b/phlex/model/data_cell_index.cpp
@@ -41,9 +41,9 @@ namespace phlex {
     parent_{std::move(parent)},
     number_{i},
     layer_name_{std::move(layer_name)},
-    layer_hash_{experimental::hash(parent_->layer_hash_, layer_name_.hash())},
+    layer_hash_{phlex::detail::hash(parent_->layer_hash_, layer_name_.hash())},
     depth_{parent_->depth_ + 1},
-    hash_{experimental::hash(parent_->hash_, number_, layer_hash_)}
+    hash_{phlex::detail::hash(parent_->hash_, number_, layer_hash_)}
   {
     // FIXME: Should it be an error to create an ID with an empty name?
   }

--- a/phlex/model/data_cell_tracker.cpp
+++ b/phlex/model/data_cell_tracker.cpp
@@ -9,13 +9,13 @@
 namespace {
   auto make_data_cell_counts(phlex::data_cell_index_ptr const& index)
   {
-    auto result = std::make_shared<phlex::experimental::data_cell_counts>();
+    auto result = std::make_shared<phlex::detail::data_cell_counts>();
     result->emplace(index->layer_hash(), 1);
     return result;
   }
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
   data_cell_tracker::~data_cell_tracker()
   {
     if (pending_flushes_.empty()) {

--- a/phlex/model/data_cell_tracker.hpp
+++ b/phlex/model/data_cell_tracker.hpp
@@ -8,7 +8,7 @@
 
 #include <map>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class PHLEX_MODEL_EXPORT data_cell_tracker {
   public:
     data_cell_tracker() = default;

--- a/phlex/model/data_layer_hierarchy.cpp
+++ b/phlex/model/data_layer_hierarchy.cpp
@@ -55,14 +55,13 @@ namespace phlex::experimental {
     }
 
     if (candidates.size() > 1ull) {
-      std::string msg =
-        fmt::format("The following data layers match the specification {}:\n\n{}"
-                    "\n\nPlease specify the full layer path to disambiguate between them.",
-                    layer,
-                    bulleted_list(candidates | std::views::transform([](auto const* entry) {
-                                    return entry->layer_path;
-                                  }),
-                                  /*indent=*/0));
+      std::string msg = fmt::format(
+        "The following data layers match the specification {}:\n\n{}"
+        "\n\nPlease specify the full layer path to disambiguate between them.",
+        layer,
+        phlex::detail::bulleted_list(
+          candidates | std::views::transform([](auto const* entry) { return entry->layer_path; }),
+          /*indent=*/0));
       throw std::runtime_error(msg);
     }
 

--- a/phlex/model/data_layer_hierarchy.cpp
+++ b/phlex/model/data_layer_hierarchy.cpp
@@ -15,7 +15,7 @@ namespace {
   }
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   data_layer_hierarchy::~data_layer_hierarchy() { print(); }
 
@@ -37,7 +37,8 @@ namespace phlex::experimental {
     ++it->second->count;
   }
 
-  std::size_t data_layer_hierarchy::count_for(layer_path const& layer, bool const missing_ok) const
+  std::size_t data_layer_hierarchy::count_for(phlex::experimental::layer_path const& layer,
+                                              bool const missing_ok) const
   {
     // The assumption is that specified layer is a portion of a layer path
     // sufficient to uniquely identify a layer

--- a/phlex/model/data_layer_hierarchy.cpp
+++ b/phlex/model/data_layer_hierarchy.cpp
@@ -56,13 +56,14 @@ namespace phlex::detail {
     }
 
     if (candidates.size() > 1ull) {
-      std::string msg = fmt::format(
-        "The following data layers match the specification {}:\n\n{}"
-        "\n\nPlease specify the full layer path to disambiguate between them.",
-        layer,
-        phlex::detail::bulleted_list(
-          candidates | std::views::transform([](auto const* entry) { return entry->layer_path; }),
-          /*indent=*/0));
+      std::string msg =
+        fmt::format("The following data layers match the specification {}:\n\n{}"
+                    "\n\nPlease specify the full layer path to disambiguate between them.",
+                    layer,
+                    bulleted_list(candidates | std::views::transform([](auto const* entry) {
+                                    return entry->layer_path;
+                                  }),
+                                  /*indent=*/0));
       throw std::runtime_error(msg);
     }
 

--- a/phlex/model/data_layer_hierarchy.hpp
+++ b/phlex/model/data_layer_hierarchy.hpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   class PHLEX_MODEL_EXPORT data_layer_hierarchy {
   public:
@@ -26,7 +26,8 @@ namespace phlex::experimental {
     data_layer_hierarchy& operator=(data_layer_hierarchy&&) = delete;
 
     void increment_count(data_cell_index_ptr const& id);
-    std::size_t count_for(layer_path const& layer, bool missing_ok = false) const;
+    std::size_t count_for(phlex::experimental::layer_path const& layer,
+                          bool missing_ok = false) const;
 
     void print() const;
 
@@ -40,13 +41,15 @@ namespace phlex::experimental {
                                std::string indent = {}) const;
 
     struct layer_entry {
-      layer_entry(identifier n, layer_path path, std::size_t par_hash) :
+      layer_entry(phlex::experimental::identifier n,
+                  phlex::experimental::layer_path path,
+                  std::size_t par_hash) :
         name{std::move(n)}, layer_path{std::move(path)}, parent_hash{par_hash}
       {
       }
 
-      identifier name;
-      experimental::layer_path layer_path;
+      phlex::experimental::identifier name;
+      phlex::experimental::layer_path layer_path;
       std::size_t parent_hash;
       std::atomic<std::size_t> count{};
     };

--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -38,7 +38,6 @@ namespace {
   // Each path must be non-empty and may only contain "job" as the first element.
   std::set<std::size_t> build_hashes(std::vector<layer_path> const& layer_paths)
   {
-    using namespace phlex::experimental;
     using namespace phlex::experimental::literals;
     std::set<std::size_t> hashes{"job"_idq.hash};
     for (layer_path const& path : layer_paths) {
@@ -51,14 +50,13 @@ namespace {
   std::vector<layer_path> convert_vector_vector_string(
     std::vector<std::vector<std::string>>&& layer_path_strings)
   {
-    using namespace phlex::experimental;
     std::vector<layer_path> layer_paths;
     layer_paths.reserve(layer_path_strings.size());
     for (auto& lp : layer_path_strings) {
-      auto lp_as_ids =
-        lp | std::views::as_rvalue |
-        std::views::transform([](std::string&& str) { return identifier(std::move(str)); }) |
-        std::ranges::to<std::vector>();
+      auto lp_as_ids = lp | std::views::as_rvalue | std::views::transform([](std::string&& str) {
+                         return phlex::experimental::identifier(std::move(str));
+                       }) |
+                       std::ranges::to<std::vector>();
       layer_paths.emplace_back(std::move(lp_as_ids));
     }
     return unique_paths(std::move(layer_paths));
@@ -70,7 +68,7 @@ namespace phlex {
   // data_cell_cursor implementation
   data_cell_cursor::data_cell_cursor(data_cell_index_ptr index,
                                      fixed_hierarchy const& h,
-                                     experimental::framework_driver& d) :
+                                     detail::framework_driver& d) :
     index_{std::move(index)}, hierarchy_{h}, driver_{d}
   {
   }
@@ -88,8 +86,7 @@ namespace phlex {
 
   // ================================================================================
   // data_cell_yielder implementation
-  data_cell_yielder::data_cell_yielder(fixed_hierarchy const& h,
-                                       experimental::framework_driver& d) :
+  data_cell_yielder::data_cell_yielder(fixed_hierarchy const& h, detail::framework_driver& d) :
     hierarchy_{h}, driver_{d}
   {
   }
@@ -134,14 +131,14 @@ namespace phlex {
       fmt::format("Layer {} is not part of the fixed hierarchy.", index->layer_path()));
   }
 
-  data_cell_cursor fixed_hierarchy::yield_job(experimental::framework_driver& d) const
+  data_cell_cursor fixed_hierarchy::yield_job(detail::framework_driver& d) const
   {
     auto job = data_cell_index::job();
     d.yield(job);
     return data_cell_cursor{job, *this, d};
   }
 
-  data_cell_yielder fixed_hierarchy::yielder(experimental::framework_driver& d) const
+  data_cell_yielder fixed_hierarchy::yielder(detail::framework_driver& d) const
   {
     return data_cell_yielder{*this, d};
   }

--- a/phlex/model/fixed_hierarchy.hpp
+++ b/phlex/model/fixed_hierarchy.hpp
@@ -32,14 +32,14 @@ namespace phlex {
     friend class fixed_hierarchy;
     data_cell_cursor(data_cell_index_ptr index,
                      fixed_hierarchy const& h,
-                     experimental::framework_driver& d);
+                     detail::framework_driver& d);
 
     data_cell_index_ptr index_;
     // Non-owning references to the enclosing hierarchy and driver; data_cell_cursor is a
     // short-lived view and does not manage their lifetimes.
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     fixed_hierarchy const& hierarchy_;
-    experimental::framework_driver& driver_;
+    detail::framework_driver& driver_;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
 
@@ -57,11 +57,11 @@ namespace phlex {
 
   private:
     friend class fixed_hierarchy;
-    data_cell_yielder(fixed_hierarchy const& h, experimental::framework_driver& d);
+    data_cell_yielder(fixed_hierarchy const& h, detail::framework_driver& d);
 
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     fixed_hierarchy const& hierarchy_;
-    experimental::framework_driver& driver_;
+    detail::framework_driver& driver_;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
 
@@ -82,10 +82,10 @@ namespace phlex {
 
     // Yields the job-level data-cell index to the provided driver and returns a
     // data_cell_cursor for the job.
-    data_cell_cursor yield_job(experimental::framework_driver& d) const;
+    data_cell_cursor yield_job(detail::framework_driver& d) const;
 
     // Returns a callable data-cell yielder bound to the provided driver.
-    data_cell_yielder yielder(experimental::framework_driver& d) const;
+    data_cell_yielder yielder(detail::framework_driver& d) const;
 
     // Merges additional layer paths into the hierarchy, ignoring duplicates.
     void update(std::vector<experimental::layer_path> layer_paths);

--- a/phlex/model/flush_gate.cpp
+++ b/phlex/model/flush_gate.cpp
@@ -8,7 +8,7 @@
 #include <ranges>
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   flush_gate::flush_gate(data_cell_index_ptr index, std::size_t expected_flush_count) :
     index_{std::move(index)},
@@ -97,4 +97,4 @@ namespace phlex::experimental {
     // destroyed soon after commit() is called.
   }
 
-} // namespace phlex::experimental
+} // namespace phlex::detail

--- a/phlex/model/flush_gate.hpp
+++ b/phlex/model/flush_gate.hpp
@@ -41,7 +41,7 @@
 #include <memory>
 #include <mutex>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   class PHLEX_MODEL_EXPORT flush_gate {
     using flush_callback_t = std::function<void(flush_gate const&)>;
@@ -103,6 +103,6 @@ namespace phlex::experimental {
 
   using flush_gate_ptr = std::shared_ptr<flush_gate>;
 
-} // namespace phlex::experimental
+} // namespace phlex::detail
 
 #endif // PHLEX_MODEL_FLUSH_GATE_HPP

--- a/phlex/model/flush_messages.hpp
+++ b/phlex/model/flush_messages.hpp
@@ -9,7 +9,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   struct PHLEX_MODEL_EXPORT index_flush {
     data_cell_index_ptr index;
     // Ideally, the counts field should be a `data_cell_counts_const_ptr` to ensure immutability.

--- a/phlex/model/fwd.hpp
+++ b/phlex/model/fwd.hpp
@@ -13,6 +13,11 @@ namespace phlex {
   class fixed_hierarchy;
 }
 
+namespace phlex::detail {
+  template <typename RT>
+  class resumable_driver;
+}
+
 namespace phlex::experimental {
   class data_layer_hierarchy;
   class data_cell_counts;
@@ -23,10 +28,7 @@ namespace phlex::experimental {
   using product_store_const_ptr = std::shared_ptr<product_store const>;
   using product_store_ptr = std::shared_ptr<product_store>;
 
-  template <typename RT>
-  class resumable_driver;
-
-  using framework_driver = resumable_driver<data_cell_index_ptr>;
+  using framework_driver = phlex::detail::resumable_driver<data_cell_index_ptr>;
 }
 
 #endif // PHLEX_MODEL_FWD_HPP

--- a/phlex/model/fwd.hpp
+++ b/phlex/model/fwd.hpp
@@ -18,17 +18,21 @@ namespace phlex::detail {
   class resumable_driver;
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class data_layer_hierarchy;
   class data_cell_counts;
-  class product_store;
+  using framework_driver = resumable_driver<data_cell_index_ptr>;
 
   using data_cell_counts_const_ptr = std::shared_ptr<data_cell_counts const>;
   using data_cell_counts_ptr = std::shared_ptr<data_cell_counts>;
+
+}
+
+namespace phlex::experimental {
+  class product_store;
+
   using product_store_const_ptr = std::shared_ptr<product_store const>;
   using product_store_ptr = std::shared_ptr<product_store>;
-
-  using framework_driver = phlex::detail::resumable_driver<data_cell_index_ptr>;
 }
 
 #endif // PHLEX_MODEL_FWD_HPP

--- a/phlex/model/handle.hpp
+++ b/phlex/model/handle.hpp
@@ -11,7 +11,7 @@
 #include <variant>
 
 namespace phlex {
-  namespace experimental::detail {
+  namespace detail::internal {
     template <typename T>
     struct handle_value_type_impl {
       using type = std::remove_const_t<T>;
@@ -45,7 +45,7 @@ namespace phlex {
   template <typename T>
   class handle {
   public:
-    static_assert(std::same_as<T, experimental::detail::handle_value_type<T>>,
+    static_assert(std::same_as<T, detail::internal::handle_value_type<T>>,
                   "Cannot create a handle with a template argument that is const-qualified, a "
                   "reference type, or a pointer type.");
     using value_type = T;
@@ -60,7 +60,7 @@ namespace phlex {
     // The 'product' parameter is not 'const_reference' to avoid avoid implicit type conversions.
     explicit handle(std::same_as<T> auto const& product,
                     data_cell_index const& id,
-                    experimental::product_specification const& key,
+                    detail::product_specification const& key,
                     std::optional<experimental::identifier> stage = {}) :
       product_{&product},
       id_{&id},
@@ -121,7 +121,7 @@ namespace phlex {
     experimental::identifier creator_plugin_;
     experimental::identifier creator_algorithm_;
     experimental::identifier suffix_;
-    experimental::type_id type_;
+    detail::type_id type_;
     std::optional<experimental::identifier> stage_;
 
     // Utilities for stage name access until configuration supports these
@@ -129,12 +129,12 @@ namespace phlex {
   };
 
   template <typename T>
-  handle(T const&, data_cell_index const&, experimental::product_specification const&) -> handle<T>;
+  handle(T const&, data_cell_index const&, detail::product_specification const&) -> handle<T>;
 
   template <typename T>
   handle(T const&,
          data_cell_index const&,
-         experimental::product_specification const&,
+         detail::product_specification const&,
          std::optional<experimental::identifier>) -> handle<T>;
 }
 

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -13,11 +13,11 @@ using namespace phlex::experimental::literals;
 
 namespace phlex::experimental {
   layer_path::layer_path(std::string_view path) :
-    layer_path_{
-      std::from_range,
-      path | std::views::split('/') |
-        std::views::filter([](auto const& sr) { return not sr.empty(); }) |
-        std::views::transform([](auto const& sr) { return identifier(std::string_view(sr)); })}
+    layer_path_{std::from_range,
+                path | std::views::split('/') |
+                  std::views::filter([](auto const& sr) { return not sr.empty(); }) |
+                  std::views::transform(
+                    [](auto const& sr) { return experimental::identifier(std::string_view(sr)); })}
   {
     if (layer_path_.empty()) {
       throw std::runtime_error("Layer paths cannot be empty.");
@@ -67,7 +67,7 @@ namespace phlex::experimental {
     return other_it == rev_other_layer_path.end();
   }
 
-  bool layer_path::ends_with(identifier const& name) const noexcept
+  bool layer_path::ends_with(experimental::identifier const& name) const noexcept
   {
     return layer_path_.back() == name;
   }

--- a/phlex/model/layer_path.cpp
+++ b/phlex/model/layer_path.cpp
@@ -82,7 +82,7 @@ namespace phlex::experimental {
     // incomplete paths have an implied "job" root in this calculation
     // Need the experimental:: so it isn't confused for this function
     std::size_t seed =
-      is_complete() ? "job"_idq.hash : experimental::hash("job"_idq.hash, layer_path_[0].hash());
+      is_complete() ? "job"_idq.hash : phlex::detail::hash("job"_idq.hash, layer_path_[0].hash());
     boost::hash_range(seed, layer_path_.begin() + 1, layer_path_.end());
     return seed;
   }
@@ -92,10 +92,10 @@ namespace phlex::experimental {
     std::set<std::size_t> hashes;
     // Add the appropriate first hash
     std::size_t cumulative_hash =
-      is_complete() ? "job"_idq.hash : experimental::hash("job"_idq.hash, layer_path_[0].hash());
+      is_complete() ? "job"_idq.hash : phlex::detail::hash("job"_idq.hash, layer_path_[0].hash());
     hashes.insert(cumulative_hash);
     for (auto const& name : layer_path_ | std::views::drop(1)) {
-      cumulative_hash = experimental::hash(cumulative_hash, name.hash());
+      cumulative_hash = phlex::detail::hash(cumulative_hash, name.hash());
       hashes.insert(cumulative_hash);
     }
     return hashes;

--- a/phlex/model/product_matcher.cpp
+++ b/phlex/model/product_matcher.cpp
@@ -39,7 +39,7 @@ namespace {
   }
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
   product_matcher::product_matcher(std::string matcher_spec) :
     product_matcher{tokenize(std::move(matcher_spec))}
   {

--- a/phlex/model/product_matcher.hpp
+++ b/phlex/model/product_matcher.hpp
@@ -16,11 +16,11 @@
 #include <array>
 #include <string>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class PHLEX_MODEL_EXPORT product_matcher {
   public:
     explicit product_matcher(std::string matcher_spec);
-    bool matches(product_store_const_ptr const& store) const;
+    bool matches(experimental::product_store_const_ptr const& store) const;
     std::string const& layer_path() const noexcept { return layer_path_; }
     std::string const& module_name() const noexcept { return module_name_; }
     std::string const& node_name() const noexcept { return node_name_; }

--- a/phlex/model/product_specification.cpp
+++ b/phlex/model/product_specification.cpp
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   product_specification::product_specification() = default;
 
   product_specification::product_specification(char const* name) :
@@ -19,8 +19,8 @@ namespace phlex::experimental {
   }
   product_specification::product_specification(std::string_view name) { *this = create(name); }
 
-  product_specification::product_specification(algorithm_name creator,
-                                               identifier suffix,
+  product_specification::product_specification(experimental::algorithm_name creator,
+                                               experimental::identifier suffix,
                                                type_id type) :
     creator_{std::move(creator)}, suffix_{std::move(suffix)}, type_id_{std::move(type)}
   {
@@ -43,14 +43,14 @@ namespace phlex::experimental {
   {
     auto forward_slash = s.find('/');
     if (forward_slash != std::string_view::npos) {
-      return {algorithm_name::create(s.substr(0, forward_slash)),
-              identifier(s.substr(forward_slash + 1)),
+      return {experimental::algorithm_name::create(s.substr(0, forward_slash)),
+              experimental::identifier(s.substr(forward_slash + 1)),
               type_id{}};
     }
-    return {algorithm_name::create(""), identifier(s), type_id{}};
+    return {experimental::algorithm_name::create(""), experimental::identifier(s), type_id{}};
   }
 
-  product_specifications to_product_specifications(algorithm_name const& algo_name,
+  product_specifications to_product_specifications(experimental::algorithm_name const& algo_name,
                                                    std::vector<std::string> output_suffixes,
                                                    std::vector<type_id> output_types)
   {
@@ -70,7 +70,8 @@ namespace phlex::experimental {
     // We can use std::views::zip_transform once the AppleClang C++ STL supports it.
     return std::views::zip(output_suffixes, output_types) |
            std::views::transform([&algo_name](auto const& p) {
-             return product_specification{algo_name, identifier(std::get<0>(p)), std::get<1>(p)};
+             return product_specification{
+               algo_name, experimental::identifier(std::get<0>(p)), std::get<1>(p)};
            }) |
            std::ranges::to<product_specifications>();
   }

--- a/phlex/model/product_specification.hpp
+++ b/phlex/model/product_specification.hpp
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class PHLEX_MODEL_EXPORT product_specification {
   public:
     product_specification();
@@ -22,13 +22,15 @@ namespace phlex::experimental {
     product_specification(std::string const& name);
     product_specification(std::string_view name);
     // NOLINTEND(google-explicit-constructor)
-    product_specification(algorithm_name creator, identifier suffix, type_id type);
+    product_specification(experimental::algorithm_name creator,
+                          experimental::identifier suffix,
+                          type_id type);
 
     std::string to_string() const;
-    algorithm_name const& creator() const noexcept { return creator_; }
-    identifier const& plugin() const noexcept { return creator_.plugin(); }
-    identifier const& algorithm() const noexcept { return creator_.algorithm(); }
-    identifier const& suffix() const noexcept { return suffix_; }
+    experimental::algorithm_name const& creator() const noexcept { return creator_; }
+    experimental::identifier const& plugin() const noexcept { return creator_.plugin(); }
+    experimental::identifier const& algorithm() const noexcept { return creator_.algorithm(); }
+    experimental::identifier const& suffix() const noexcept { return suffix_; }
     type_id type() const noexcept { return type_id_; }
 
     void set_type(type_id&& type) { type_id_ = std::move(type); }
@@ -41,22 +43,22 @@ namespace phlex::experimental {
     friend struct std::hash<product_specification>;
 
   private:
-    algorithm_name creator_;
-    identifier suffix_; // Default suffix is empty string
+    experimental::algorithm_name creator_;
+    experimental::identifier suffix_; // Default suffix is empty string
     type_id type_id_{};
   };
 
   using product_specifications = std::vector<product_specification>;
 
   PHLEX_MODEL_EXPORT product_specifications
-  to_product_specifications(algorithm_name const& algo_name,
+  to_product_specifications(experimental::algorithm_name const& algo_name,
                             std::vector<std::string> output_suffixes,
                             std::vector<type_id> output_types);
 }
 
 template <>
-struct std::hash<phlex::experimental::product_specification> {
-  std::size_t operator()(phlex::experimental::product_specification const& spec) const noexcept
+struct std::hash<phlex::detail::product_specification> {
+  std::size_t operator()(phlex::detail::product_specification const& spec) const noexcept
   {
     std::size_t hash = spec.creator_.plugin().hash();
     boost::hash_combine(hash, spec.creator_.algorithm().hash());

--- a/phlex/model/product_store.cpp
+++ b/phlex/model/product_store.cpp
@@ -8,7 +8,7 @@ namespace phlex::experimental {
 
   product_store::product_store(data_cell_index_ptr id,
                                algorithm_name source,
-                               detail::products new_products,
+                               phlex::detail::products new_products,
                                std::optional<identifier> stage) :
     products_{std::move(new_products)},
     id_{std::move(id)},
@@ -28,7 +28,17 @@ namespace phlex::experimental {
   algorithm_name const& product_store::source() const noexcept { return source_; }
   data_cell_index_ptr const& product_store::index() const noexcept { return id_; }
 
-  product_store_ptr const& more_derived(product_store_ptr const& a, product_store_ptr const& b)
+  product_store_ptr const& detail::more_derived(product_store_ptr const& a,
+                                                product_store_ptr const& b)
+  {
+    if (a->index()->depth() > b->index()->depth()) {
+      return a; // NOLINT(bugprone-return-const-ref-from-parameter)
+    }
+    return b; // NOLINT(bugprone-return-const-ref-from-parameter)
+  }
+
+  product_store_const_ptr const& detail::more_derived(product_store_const_ptr const& a,
+                                                      product_store_const_ptr const& b)
   {
     if (a->index()->depth() > b->index()->depth()) {
       return a; // NOLINT(bugprone-return-const-ref-from-parameter)

--- a/phlex/model/product_store.cpp
+++ b/phlex/model/product_store.cpp
@@ -8,7 +8,7 @@ namespace phlex::experimental {
 
   product_store::product_store(data_cell_index_ptr id,
                                algorithm_name source,
-                               products new_products,
+                               detail::products new_products,
                                std::optional<identifier> stage) :
     products_{std::move(new_products)},
     id_{std::move(id)},

--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -22,7 +22,7 @@ namespace phlex::experimental {
   public:
     explicit product_store(data_cell_index_ptr id,
                            algorithm_name source = default_source(),
-                           products new_products = {},
+                           phlex::detail::products new_products = {},
                            std::optional<identifier> stage = {});
     ~product_store();
     static product_store_ptr base(algorithm_name base_name = default_source());
@@ -38,23 +38,24 @@ namespace phlex::experimental {
 
     // Product interface
     template <typename T>
-    T const& get_product(product_specification const& key) const;
+    T const& get_product(phlex::detail::product_specification const& key) const;
 
     template <typename T>
-    handle<T> get_handle(product_specification const& key) const;
+    handle<T> get_handle(phlex::detail::product_specification const& key) const;
 
     // Thread-unsafe operations
     template <typename T>
-    void add_product(product_specification const& key, T&& t);
+    void add_product(phlex::detail::product_specification const& key, T&& t);
 
     template <typename T>
-    void add_product(product_specification const& key, std::unique_ptr<product<T>>&& t);
+    void add_product(phlex::detail::product_specification const& key,
+                     std::unique_ptr<phlex::detail::product<T>>&& t);
 
     // default Source identifier
-    static algorithm_name default_source();
+    static experimental::algorithm_name default_source();
 
   private:
-    products products_{};
+    phlex::detail::products products_{};
     data_cell_index_ptr id_;
     algorithm_name
       source_; // FIXME: Should not have to copy (the source should outlive the product store)
@@ -90,25 +91,29 @@ namespace phlex::experimental {
 
   // Implementation details
   template <typename T>
-  void product_store::add_product(product_specification const& key, T&& t)
+  void product_store::add_product(phlex::detail::product_specification const& key, T&& t)
   {
-    add_product(key, std::make_unique<product<std::remove_cvref_t<T>>>(std::forward<T>(t)));
+    add_product(
+      key, std::make_unique<phlex::detail::product<std::remove_cvref_t<T>>>(std::forward<T>(t)));
   }
 
   template <typename T>
-  void product_store::add_product(product_specification const& key, std::unique_ptr<product<T>>&& t)
+  void product_store::add_product(phlex::detail::product_specification const& key,
+                                  std::unique_ptr<phlex::detail::product<T>>&& t)
   {
     products_.add(key, std::move(t));
   }
 
   template <typename T>
-  [[nodiscard]] handle<T> product_store::get_handle(product_specification const& key) const
+  [[nodiscard]] handle<T> product_store::get_handle(
+    phlex::detail::product_specification const& key) const
   {
     return handle<T>{products_.get<T>(key), *id_, key, stage_};
   }
 
   template <typename T>
-  [[nodiscard]] T const& product_store::get_product(product_specification const& key) const
+  [[nodiscard]] T const& product_store::get_product(
+    phlex::detail::product_specification const& key) const
   {
     return *get_handle<T>(key);
   }

--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -62,31 +62,41 @@ namespace phlex::experimental {
     std::optional<identifier> stage_; // No value means current stage
   };
 
-  PHLEX_MODEL_EXPORT product_store_ptr const& more_derived(product_store_ptr const& a,
-                                                           product_store_ptr const& b);
+  namespace detail {
+    PHLEX_MODEL_EXPORT product_store_ptr const& more_derived(product_store_ptr const& a,
+                                                             product_store_ptr const& b);
+    PHLEX_MODEL_EXPORT product_store_const_ptr const& more_derived(
+      product_store_const_ptr const& a, product_store_const_ptr const& b);
 
-  // Non-template overload for single product_store_ptr case
-  inline product_store_ptr const& most_derived(product_store_ptr const& store)
-  {
-    return store; // NOLINT(bugprone-return-const-ref-from-parameter)
-  }
-
-  // Generic most_derived for tuples
-  template <std::size_t I, typename Tuple>
-  auto const& get_most_derived(Tuple const& tup, std::tuple_element_t<I - 1, Tuple> const& element)
-  {
-    constexpr auto num_inputs = std::tuple_size_v<Tuple>;
-    if constexpr (I == num_inputs - 1) {
-      return more_derived(element, std::get<I>(tup));
-    } else {
-      return get_most_derived<I + 1>(tup, more_derived(element, std::get<I>(tup)));
+    // Non-template overload for single product_store_ptr case
+    inline product_store_ptr const& most_derived(product_store_ptr const& store)
+    {
+      return store; // NOLINT(bugprone-return-const-ref-from-parameter)
     }
-  }
 
-  template <typename T, typename U, typename... Ts>
-  auto const& most_derived(std::tuple<T, U, Ts...> const& elements)
-  {
-    return get_most_derived<1ull>(elements, std::get<0>(elements));
+    inline product_store_const_ptr const& most_derived(product_store_const_ptr const& store)
+    {
+      return store; // NOLINT(bugprone-return-const-ref-from-parameter)
+    }
+
+    // Generic most_derived for tuples
+    template <std::size_t I, typename Tuple>
+    auto const& get_most_derived(Tuple const& tup,
+                                 std::tuple_element_t<I - 1, Tuple> const& element)
+    {
+      constexpr auto num_inputs = std::tuple_size_v<Tuple>;
+      if constexpr (I == num_inputs - 1) {
+        return more_derived(element, std::get<I>(tup));
+      } else {
+        return get_most_derived<I + 1>(tup, more_derived(element, std::get<I>(tup)));
+      }
+    }
+
+    template <typename T, typename U, typename... Ts>
+    auto const& most_derived(std::tuple<T, U, Ts...> const& elements)
+    {
+      return get_most_derived<1ull>(elements, std::get<0>(elements));
+    }
   }
 
   // Implementation details

--- a/phlex/model/products.cpp
+++ b/phlex/model/products.cpp
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   products::products(std::size_t number_known_products)
   {
     products_.reserve(number_known_products);

--- a/phlex/model/products.hpp
+++ b/phlex/model/products.hpp
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   struct PHLEX_MODEL_EXPORT product_base {
     virtual ~product_base() = default;

--- a/phlex/model/type_id.hpp
+++ b/phlex/model/type_id.hpp
@@ -164,8 +164,8 @@ namespace phlex::detail {
       static consteval auto get_tuple(std::index_sequence<Is...>) -> auto
       {
         // Atomics are why we can't just use boost::pfr::structure_to_tuple
-        return std::tuple<phlex::experimental::remove_atomic_t<
-          std::remove_cvref_t<boost::pfr::tuple_element_t<Is, A>>>...>{};
+        return std::tuple<
+          remove_atomic_t<std::remove_cvref_t<boost::pfr::tuple_element_t<Is, A>>>...>{};
       }
 
     public:
@@ -195,8 +195,7 @@ namespace phlex::detail {
     }
 
     type_id result{};
-    using basic =
-      phlex::experimental::remove_atomic_t<std::remove_cvref_t<std::remove_pointer_t<T>>>;
+    using basic = remove_atomic_t<std::remove_cvref_t<std::remove_pointer_t<T>>>;
     if constexpr (std::is_fundamental_v<basic>) {
       result.id_ = internal::make_type_id_helper_fundamental<basic>();
     }
@@ -209,7 +208,7 @@ namespace phlex::detail {
 
     // classes (both containers and "simple" aggregates)
     else if constexpr (std::is_class_v<basic>) {
-      if constexpr (phlex::experimental::contiguous_container<basic>) {
+      if constexpr (contiguous_container<basic>) {
         result = make_type_id<typename basic::value_type>();
         result.id_ |= 0x20;
       } else if constexpr (std::is_aggregate_v<basic>) {
@@ -272,7 +271,7 @@ namespace phlex::detail {
   template <typename F>
   type_ids make_output_type_ids()
   {
-    return make_type_ids<phlex::experimental::return_type<F>>();
+    return make_type_ids<return_type<F>>();
   }
 
   inline std::size_t hash_value(type_id const& id)

--- a/phlex/model/type_id.hpp
+++ b/phlex/model/type_id.hpp
@@ -18,7 +18,7 @@
 
 // This is a type_id class to store the "product concept"
 // Using our own class means we can treat, for example, all "List"s the same
-namespace phlex::experimental {
+namespace phlex::detail {
   class type_id {
   public:
     // Least significant nibble will store the fundamental type
@@ -96,7 +96,7 @@ namespace phlex::experimental {
 
   using type_ids = std::vector<type_id>;
 
-  namespace detail {
+  namespace internal {
     template <typename T>
     consteval unsigned char make_type_id_helper_integral()
     {
@@ -164,8 +164,8 @@ namespace phlex::experimental {
       static consteval auto get_tuple(std::index_sequence<Is...>) -> auto
       {
         // Atomics are why we can't just use boost::pfr::structure_to_tuple
-        return std::tuple<
-          remove_atomic_t<std::remove_cvref_t<boost::pfr::tuple_element_t<Is, A>>>...>{};
+        return std::tuple<phlex::experimental::remove_atomic_t<
+          std::remove_cvref_t<boost::pfr::tuple_element_t<Is, A>>>...>{};
       }
 
     public:
@@ -179,7 +179,7 @@ namespace phlex::experimental {
     class is_handle : public std::false_type {};
 
     template <typename T>
-    class is_handle<handle<T>> : public std::true_type {};
+    class is_handle<phlex::handle<T>> : public std::true_type {};
   }
 
   // Forward declaration
@@ -190,14 +190,15 @@ namespace phlex::experimental {
   constexpr type_id make_type_id()
   {
     // First deal with handles
-    if constexpr (detail::is_handle<T>::value) {
+    if constexpr (internal::is_handle<T>::value) {
       return make_type_id<typename T::value_type>();
     }
 
     type_id result{};
-    using basic = remove_atomic_t<std::remove_cvref_t<std::remove_pointer_t<T>>>;
+    using basic =
+      phlex::experimental::remove_atomic_t<std::remove_cvref_t<std::remove_pointer_t<T>>>;
     if constexpr (std::is_fundamental_v<basic>) {
-      result.id_ = detail::make_type_id_helper_fundamental<basic>();
+      result.id_ = internal::make_type_id_helper_fundamental<basic>();
     }
 
     // builtin arrays
@@ -208,12 +209,12 @@ namespace phlex::experimental {
 
     // classes (both containers and "simple" aggregates)
     else if constexpr (std::is_class_v<basic>) {
-      if constexpr (contiguous_container<basic>) {
+      if constexpr (phlex::experimental::contiguous_container<basic>) {
         result = make_type_id<typename basic::value_type>();
         result.id_ |= 0x20;
       } else if constexpr (std::is_aggregate_v<basic>) {
         // This case isn't evaluable at compile time because vector uses operator new
-        using child_tuple = detail::aggregate_to_plain_tuple_t<basic>;
+        using child_tuple = internal::aggregate_to_plain_tuple_t<basic>;
         result.id_ = 0x40; // has_children
         result.children_ = make_type_ids<child_tuple>();
       } else {
@@ -238,7 +239,7 @@ namespace phlex::experimental {
     return result;
   }
 
-  namespace detail {
+  namespace internal {
     template <typename T>
     class tuple_type_ids {
     public:
@@ -262,7 +263,7 @@ namespace phlex::experimental {
   type_ids make_type_ids()
   {
     if constexpr (sizeof...(Ts) == 0) {
-      return detail::tuple_type_ids<T1>::get();
+      return internal::tuple_type_ids<T1>::get();
     } else {
       return type_ids{make_type_id<T1>(), make_type_id<Ts>()...};
     }
@@ -271,7 +272,7 @@ namespace phlex::experimental {
   template <typename F>
   type_ids make_output_type_ids()
   {
-    return make_type_ids<return_type<F>>();
+    return make_type_ids<phlex::experimental::return_type<F>>();
   }
 
   inline std::size_t hash_value(type_id const& id)
@@ -285,11 +286,11 @@ namespace phlex::experimental {
 }
 
 template <>
-struct fmt::formatter<phlex::experimental::type_id> : formatter<std::string> {
-  auto format(phlex::experimental::type_id type, format_context& ctx) const
+struct fmt::formatter<phlex::detail::type_id> : formatter<std::string> {
+  auto format(phlex::detail::type_id type, format_context& ctx) const
   {
     using namespace std::string_literals;
-    using namespace phlex::experimental;
+    using namespace phlex::detail;
     if (!type.valid()) {
       return fmt::formatter<std::string>::format("INVALID / EMPTY"s, ctx);
     }

--- a/phlex/module.hpp
+++ b/phlex/module.hpp
@@ -15,15 +15,15 @@ namespace phlex::experimental {
   /// access to fold, observe, predicate, transform, and unfold registration.
   /// Users never construct this type directly.
   template <typename T>
-  class module_graph_proxy : graph_proxy<T> {
-    using base = graph_proxy<T>;
+  class module_graph_proxy : phlex::detail::graph_proxy<T> {
+    using base = phlex::detail::graph_proxy<T>;
 
   public:
     using base::graph_proxy;
 
     template <typename U, typename... Args>
     module_graph_proxy<U> make(Args&&... args)
-      requires(not is_bound_object<T>)
+      requires(not phlex::detail::is_bound_object<T>)
     {
       return this->template bind_to<module_graph_proxy, U>(std::forward<Args>(args)...);
     }

--- a/phlex/module.hpp
+++ b/phlex/module.hpp
@@ -37,7 +37,8 @@ namespace phlex::experimental {
   };
 
   namespace detail {
-    using module_creator_t = void(module_graph_proxy<void_tag>, configuration const&);
+    using module_creator_t = void(module_graph_proxy<phlex::detail::void_tag>,
+                                  configuration const&);
   }
 }
 

--- a/phlex/module.hpp
+++ b/phlex/module.hpp
@@ -8,22 +8,22 @@
 
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   /// @brief Proxy for registering module algorithm nodes.
   ///
   /// Passed to @c PHLEX_REGISTER_ALGORITHMS plugin entry points. Provides
   /// access to fold, observe, predicate, transform, and unfold registration.
   /// Users never construct this type directly.
   template <typename T>
-  class module_graph_proxy : phlex::detail::graph_proxy<T> {
-    using base = phlex::detail::graph_proxy<T>;
+  class module_graph_proxy : graph_proxy<T> {
+    using base = graph_proxy<T>;
 
   public:
     using base::graph_proxy;
 
     template <typename U, typename... Args>
     module_graph_proxy<U> make(Args&&... args)
-      requires(not phlex::detail::is_bound_object<T>)
+      requires(not is_bound_object<T>)
     {
       return this->template bind_to<module_graph_proxy, U>(std::forward<Args>(args)...);
     }
@@ -36,14 +36,13 @@ namespace phlex::experimental {
     using base::unfold;
   };
 
-  namespace detail {
-    using module_creator_t = void(module_graph_proxy<phlex::detail::void_tag>,
-                                  configuration const&);
+  namespace internal {
+    using module_creator_t = void(module_graph_proxy<void_tag>, configuration const&);
   }
 }
 
 #define PHLEX_REGISTER_ALGORITHMS(...)                                                             \
   PHLEX_DETAIL_REGISTER_PLUGIN(                                                                    \
-    phlex::experimental::module_graph_proxy, create, create_module, __VA_ARGS__)
+    phlex::detail::module_graph_proxy, create, create_module, __VA_ARGS__)
 
 #endif // PHLEX_MODULE_HPP

--- a/phlex/source.hpp
+++ b/phlex/source.hpp
@@ -4,6 +4,7 @@
 #include "phlex/concurrency.hpp"
 #include "phlex/configuration.hpp"
 #include "phlex/core/graph_proxy.hpp"
+#include "phlex/core/source.hpp"
 #include "phlex/detail/plugin_macros.hpp"
 
 #include <utility>

--- a/phlex/source.hpp
+++ b/phlex/source.hpp
@@ -16,7 +16,7 @@ namespace phlex::experimental {
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     configuration const& config;
     tbb::flow::graph& graph;
-    node_catalog& nodes;
+    phlex::detail::node_catalog& nodes;
     std::vector<std::string>& registration_errors;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
@@ -26,8 +26,8 @@ namespace phlex::experimental {
   /// Passed to @c PHLEX_REGISTER_PROVIDERS plugin entry points. Only provide
   /// registration is accessible. Users never construct this type directly.
   template <typename T>
-  class providers_graph_proxy : graph_proxy<T> {
-    using base = graph_proxy<T>;
+  class providers_graph_proxy : phlex::detail::graph_proxy<T> {
+    using base = phlex::detail::graph_proxy<T>;
 
   public:
     providers_graph_proxy(source_bundle bundle) :
@@ -39,7 +39,7 @@ namespace phlex::experimental {
 
     template <typename U, typename... Args>
     providers_graph_proxy<U> make(Args&&... args)
-      requires(not is_bound_object<T>)
+      requires(not phlex::detail::is_bound_object<T>)
     {
       return this->template bind_to<providers_graph_proxy, U>(std::forward<Args>(args)...);
     }
@@ -53,8 +53,8 @@ namespace phlex::experimental {
   /// Passed to @c PHLEX_REGISTER_SOURCE plugin entry points. Only source
   /// registration is accessible. Users never construct this type directly.
   template <typename T>
-  class source_graph_proxy : graph_proxy<T> {
-    using base = graph_proxy<T>;
+  class source_graph_proxy : phlex::detail::graph_proxy<T> {
+    using base = phlex::detail::graph_proxy<T>;
 
   public:
     source_graph_proxy(source_bundle bundle) :

--- a/phlex/source.hpp
+++ b/phlex/source.hpp
@@ -9,14 +9,14 @@
 
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   struct source_bundle {
     // Non-owning references to framework-owned resources; source_bundle is a short-lived struct.
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     configuration const& config;
     tbb::flow::graph& graph;
-    phlex::detail::node_catalog& nodes;
+    node_catalog& nodes;
     std::vector<std::string>& registration_errors;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
   };
@@ -26,8 +26,8 @@ namespace phlex::experimental {
   /// Passed to @c PHLEX_REGISTER_PROVIDERS plugin entry points. Only provide
   /// registration is accessible. Users never construct this type directly.
   template <typename T>
-  class providers_graph_proxy : phlex::detail::graph_proxy<T> {
-    using base = phlex::detail::graph_proxy<T>;
+  class providers_graph_proxy : graph_proxy<T> {
+    using base = graph_proxy<T>;
 
   public:
     providers_graph_proxy(source_bundle bundle) :
@@ -39,7 +39,7 @@ namespace phlex::experimental {
 
     template <typename U, typename... Args>
     providers_graph_proxy<U> make(Args&&... args)
-      requires(not phlex::detail::is_bound_object<T>)
+      requires(not is_bound_object<T>)
     {
       return this->template bind_to<providers_graph_proxy, U>(std::forward<Args>(args)...);
     }
@@ -53,8 +53,8 @@ namespace phlex::experimental {
   /// Passed to @c PHLEX_REGISTER_SOURCE plugin entry points. Only source
   /// registration is accessible. Users never construct this type directly.
   template <typename T>
-  class source_graph_proxy : phlex::detail::graph_proxy<T> {
-    using base = phlex::detail::graph_proxy<T>;
+  class source_graph_proxy : graph_proxy<T> {
+    using base = graph_proxy<T>;
 
   public:
     source_graph_proxy(source_bundle bundle) :
@@ -66,17 +66,17 @@ namespace phlex::experimental {
     using base::add_source;
   };
 
-  namespace detail {
+  namespace internal {
     using source_creator_t = void(source_bundle, configuration const&);
   }
 }
 
 #define PHLEX_REGISTER_PROVIDERS(...)                                                              \
   PHLEX_DETAIL_REGISTER_SOURCE_PLUGIN(                                                             \
-    phlex::experimental::providers_graph_proxy, create, create_source, __VA_ARGS__)
+    phlex::detail::providers_graph_proxy, create, create_source, __VA_ARGS__)
 
 #define PHLEX_REGISTER_SOURCE(...)                                                                 \
   PHLEX_DETAIL_REGISTER_SOURCE_PLUGIN(                                                             \
-    phlex::experimental::source_graph_proxy, create, create_source, __VA_ARGS__)
+    phlex::detail::source_graph_proxy, create, create_source, __VA_ARGS__)
 
 #endif // PHLEX_SOURCE_HPP

--- a/phlex/utilities/bulleted_list.hpp
+++ b/phlex/utilities/bulleted_list.hpp
@@ -7,8 +7,8 @@
 #include <ranges>
 #include <string>
 
-namespace phlex::experimental {
-  namespace detail {
+namespace phlex::detail {
+  namespace internal {
     template <typename R>
     concept range_of_formattable = fmt::formattable<std::ranges::range_value_t<R>>;
 
@@ -18,7 +18,7 @@ namespace phlex::experimental {
     };
   }
 
-  template <detail::range_of_formattable R>
+  template <internal::range_of_formattable R>
   std::string bulleted_list(R const& rng, std::size_t indent = 2)
   {
     if (std::ranges::empty(rng)) {
@@ -30,8 +30,8 @@ namespace phlex::experimental {
     return fmt::format("{}{}", prefix, fmt::join(rng, prefix_with_newline));
   }
 
-  template <detail::range_of_to_stringable R>
-    requires(!detail::range_of_formattable<R>)
+  template <internal::range_of_to_stringable R>
+    requires(!internal::range_of_formattable<R>)
   std::string bulleted_list(R const& rng, std::size_t indent = 2)
   {
     if (std::ranges::empty(rng)) {

--- a/phlex/utilities/hashing.cpp
+++ b/phlex/utilities/hashing.cpp
@@ -2,7 +2,7 @@
 
 #include "boost/functional/hash.hpp"
 
-namespace phlex::experimental {
+namespace phlex::detail {
   std::hash<std::string> const string_hasher{};
 
   std::size_t hash(std::string const& str) { return string_hasher(str); }

--- a/phlex/utilities/hashing.hpp
+++ b/phlex/utilities/hashing.hpp
@@ -7,7 +7,7 @@
 #include <cstdint>
 #include <string>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   PHLEX_UTILITIES_EXPORT std::size_t hash(std::string const& str);
   PHLEX_UTILITIES_EXPORT std::size_t hash(std::size_t i) noexcept;
   PHLEX_UTILITIES_EXPORT std::size_t hash(std::size_t i, std::size_t j);

--- a/phlex/utilities/max_allowed_parallelism.hpp
+++ b/phlex/utilities/max_allowed_parallelism.hpp
@@ -5,7 +5,7 @@
 
 #include <cstddef>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class max_allowed_parallelism {
   public:
     explicit max_allowed_parallelism(std::size_t const n) :

--- a/phlex/utilities/resource_usage.cpp
+++ b/phlex/utilities/resource_usage.cpp
@@ -32,7 +32,7 @@ namespace {
   }
 }
 
-namespace phlex::experimental {
+namespace phlex::detail {
   resource_usage::resource_usage() noexcept :
     begin_wall_{steady_clock::now()}, begin_cpu_{get_rusage().elapsed_time}
   {

--- a/phlex/utilities/resource_usage.hpp
+++ b/phlex/utilities/resource_usage.hpp
@@ -10,7 +10,7 @@
 
 #include <chrono>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class PHLEX_UTILITIES_EXPORT resource_usage {
   public:
     resource_usage() noexcept;

--- a/phlex/utilities/resumable_driver.hpp
+++ b/phlex/utilities/resumable_driver.hpp
@@ -29,7 +29,7 @@
 #include <thread>
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
 
   template <typename RT>
   class resumable_driver {

--- a/phlex/utilities/simple_ptr_map.hpp
+++ b/phlex/utilities/simple_ptr_map.hpp
@@ -21,7 +21,7 @@
 #include <memory>
 #include <string>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   template <typename T>
   class simple_ptr_map;
 

--- a/phlex/utilities/sized_tuple.hpp
+++ b/phlex/utilities/sized_tuple.hpp
@@ -5,7 +5,7 @@
 #include <tuple>
 #include <utility>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   // Infrastructure to allow specification of (e.g.) sized_tuple<T, 4>, which is an alias
   // for std::tuple<T, T, T, T>
   template <typename T, std::size_t>

--- a/phlex/utilities/sleep_for.hpp
+++ b/phlex/utilities/sleep_for.hpp
@@ -4,7 +4,7 @@
 #include <chrono>
 #include <thread>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   template <typename T>
   void sleep_for(T duration)
   {

--- a/phlex/utilities/string_literal.hpp
+++ b/phlex/utilities/string_literal.hpp
@@ -5,7 +5,7 @@
 #include <array>
 #include <string_view>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   template <std::size_t N>
   struct string_literal {
     // NOLINTBEGIN(google-explicit-constructor) - Implicit conversion is intentional
@@ -15,7 +15,7 @@ namespace phlex::experimental {
     char value[N]{};
   };
 
-  namespace detail {
+  namespace internal {
     template <string_literal... Resources>
     consteval bool unique()
     {
@@ -27,7 +27,7 @@ namespace phlex::experimental {
   }
 
   template <string_literal... Resources>
-  concept are_unique = detail::unique<Resources...>();
+  concept are_unique = internal::unique<Resources...>();
 }
 
 #endif // PHLEX_UTILITIES_STRING_LITERAL_HPP

--- a/phlex/utilities/thread_counter.hpp
+++ b/phlex/utilities/thread_counter.hpp
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace phlex::experimental {
+namespace phlex::detail {
   class thread_counter {
   public:
     using counter_type = std::atomic<unsigned int>;

--- a/plugins/python/src/pymodule.cpp
+++ b/plugins/python/src/pymodule.cpp
@@ -18,6 +18,7 @@
 
 using namespace phlex::experimental;
 using namespace phlex;
+using phlex::detail::framework_graph;
 
 static bool initialize();
 

--- a/plugins/python/src/wrap.hpp
+++ b/plugins/python/src/wrap.hpp
@@ -36,7 +36,7 @@ namespace phlex::experimental {
   struct py_config_map;
 
   // Phlex' module wrapper to register algorithms
-  typedef module_graph_proxy<phlex::detail::void_tag> phlex_module_t;
+  typedef phlex::detail::module_graph_proxy<phlex::detail::void_tag> phlex_module_t;
   PyObject* wrap_module(phlex_module_t& mod); // returns new reference
   // PyType_Ready() modifies PyTypeObject in-place; the Python C API requires non-const.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -44,7 +44,7 @@ namespace phlex::experimental {
   struct py_phlex_module;
 
   // Phlex' source wrapper to register providers
-  typedef providers_graph_proxy<phlex::detail::void_tag> phlex_source_t;
+  typedef phlex::detail::providers_graph_proxy<phlex::detail::void_tag> phlex_source_t;
   PyObject* wrap_source(phlex_source_t& src); // returns new reference
   // PyType_Ready() modifies PyTypeObject in-place; the Python C API requires non-const.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/plugins/python/src/wrap.hpp
+++ b/plugins/python/src/wrap.hpp
@@ -36,7 +36,7 @@ namespace phlex::experimental {
   struct py_config_map;
 
   // Phlex' module wrapper to register algorithms
-  typedef module_graph_proxy<void_tag> phlex_module_t;
+  typedef module_graph_proxy<phlex::detail::void_tag> phlex_module_t;
   PyObject* wrap_module(phlex_module_t& mod); // returns new reference
   // PyType_Ready() modifies PyTypeObject in-place; the Python C API requires non-const.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -44,7 +44,7 @@ namespace phlex::experimental {
   struct py_phlex_module;
 
   // Phlex' source wrapper to register providers
-  typedef providers_graph_proxy<void_tag> phlex_source_t;
+  typedef providers_graph_proxy<phlex::detail::void_tag> phlex_source_t;
   PyObject* wrap_source(phlex_source_t& src); // returns new reference
   // PyType_Ready() modifies PyTypeObject in-place; the Python C API requires non-const.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/test/adjust_config.cpp
+++ b/test/adjust_config.cpp
@@ -5,7 +5,7 @@
 
 #include "boost/json.hpp"
 
-using namespace phlex::experimental::detail;
+using namespace phlex::detail::internal;
 
 TEST_CASE("Adjust empty config", "[config]")
 {

--- a/test/allowed_families.cpp
+++ b/test/allowed_families.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Testing families", "[data model]")
   gen->add_layer("subrun", {"run", 1});
   gen->add_layer("event", {"subrun", 1});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   // Wire up providers for each level

--- a/test/cached_execution.cpp
+++ b/test/cached_execution.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Cached function calls", "[data model]")
   gen->add_layer("subrun", {"run", n_subruns});
   gen->add_layer("event", {"subrun", n_events});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   // Register providers

--- a/test/class_registration.cpp
+++ b/test/class_registration.cpp
@@ -66,7 +66,7 @@ TEST_CASE("Call non-framework functions", "[programming model]")
     product_selector{.creator = "input", .layer = "job", .suffix = "name"}};
   std::array const product_suffixes{"onumber"s, "otemperature"s, "oname"s};
 
-  auto g = experimental::framework_graph::with_default_driver();
+  auto g = phlex::detail::framework_graph::with_default_driver();
 
   // Register providers for the input products
   g.provide("provide_number", provide_number, concurrency::unlimited)

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -1,7 +1,7 @@
 #include "phlex/core/concepts.hpp"
 #include "phlex/core/framework_graph.hpp"
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 
 namespace {
   int transform [[maybe_unused]] (double&) { return 1; };

--- a/test/core_misc_test.cpp
+++ b/test/core_misc_test.cpp
@@ -62,10 +62,9 @@ TEST_CASE("algorithm_name tests", "[model]")
 
 TEST_CASE("consumer tests", "[core]")
 {
-  using namespace phlex::experimental;
   using namespace phlex::experimental::literals;
-  algorithm_name an = algorithm_name::create("p:a");
-  consumer c(an, {"pred1"});
+  auto an = phlex::experimental::algorithm_name::create("p:a");
+  phlex::detail::consumer c(an, {"pred1"});
 
   CHECK(c.name().to_string() == "p:a");
   CHECK(c.plugin() == "p"_idq);
@@ -75,7 +74,7 @@ TEST_CASE("consumer tests", "[core]")
 
 TEST_CASE("verify_name tests", "[core]")
 {
-  using namespace phlex::experimental::detail;
+  using namespace phlex::detail::internal;
 
   SECTION("non-empty name does nothing") { CHECK_NOTHROW(verify_name("valid_name", nullptr)); }
 
@@ -99,7 +98,7 @@ TEST_CASE("verify_name tests", "[core]")
 
 TEST_CASE("add_to_error_messages tests", "[core]")
 {
-  using namespace phlex::experimental::detail;
+  using namespace phlex::detail::internal;
 
   std::vector<std::string> errors;
   add_to_error_messages(errors, "Node", "duplicate_node");

--- a/test/core_misc_test.cpp
+++ b/test/core_misc_test.cpp
@@ -13,6 +13,7 @@
 
 TEST_CASE("algorithm_name tests", "[model]")
 {
+  using namespace phlex::detail;
   using namespace phlex::experimental;
 
   SECTION("Default constructor")

--- a/test/data_cell_tracker_test.cpp
+++ b/test/data_cell_tracker_test.cpp
@@ -7,7 +7,7 @@
 #include "spdlog/spdlog.h"
 
 using namespace phlex;
-using namespace phlex::experimental;
+using namespace phlex::detail;
 
 namespace {
   void use_ostream_logger(std::ostringstream& oss)

--- a/test/data_layer_hierarchy_test.cpp
+++ b/test/data_layer_hierarchy_test.cpp
@@ -3,7 +3,7 @@
 
 #include "catch2/catch_test_macros.hpp"
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 using phlex::data_cell_index;
 
 TEST_CASE("Data layer hierarchy with ambiguous layer names", "[data model]")

--- a/test/demo-giantdata/unfold_transform_fold.cpp
+++ b/test/demo-giantdata/unfold_transform_fold.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Unfold-transform-fold pipeline", "[concurrency][unfold][fold]")
   gen->add_layer("subrun", {"run", n_subruns});
   gen->add_layer("spill", {"subrun", n_spills});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   g.provide("provide_wgen",

--- a/test/filter.cpp
+++ b/test/filter.cpp
@@ -104,7 +104,7 @@ TEST_CASE("Two predicates", "[filtering]")
 {
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", 10, 1});
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
   g.provide("provide_num", give_me_nums, concurrency::unlimited)
     .output_product("input", "num", "event");
@@ -131,7 +131,7 @@ TEST_CASE("Two predicates in series", "[filtering]")
 {
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", 10, 1});
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
   g.provide("provide_num", give_me_nums, concurrency::unlimited)
     .output_product("input", "num", "event");
@@ -154,7 +154,7 @@ TEST_CASE("Two predicates in parallel", "[filtering]")
 {
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", 10, 1});
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
   g.provide("provide_num", give_me_nums, concurrency::unlimited)
     .output_product("input", "num", "event");
@@ -185,7 +185,7 @@ TEST_CASE("Three predicates in parallel", "[filtering]")
 
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", 10, 1});
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
   g.provide("provide_num", give_me_nums, concurrency::unlimited)
     .output_product("input", "num", "event");
@@ -212,7 +212,7 @@ TEST_CASE("Two predicates in parallel (each with multiple arguments)", "[filteri
 {
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", 10, 1});
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
   g.provide("provide_num", give_me_nums, concurrency::unlimited)
     .output_product("input", "num", "event");

--- a/test/filter_impl.cpp
+++ b/test/filter_impl.cpp
@@ -3,7 +3,7 @@
 
 #include "catch2/catch_test_macros.hpp"
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 
 TEST_CASE("Filter values", "[filtering]")
 {
@@ -45,6 +45,7 @@ TEST_CASE("Filter decision", "[filtering]")
 
 TEST_CASE("Filter data map", "[filtering]")
 {
+  using namespace phlex::experimental;
   using phlex::product_selector;
   std::vector const data_products_to_cache{
     product_selector{.creator = "input", .layer = "spill", .suffix = "a"},
@@ -69,6 +70,8 @@ TEST_CASE("Filter data map", "[filtering]")
 
 TEST_CASE("Data map for output only", "[filtering]")
 {
+  using namespace phlex::experimental;
+
   // Exercises data_map(for_output_t) which uses the output-only product query
   data_map data{data_map::for_output};
 

--- a/test/flush_gate_test.cpp
+++ b/test/flush_gate_test.cpp
@@ -29,7 +29,7 @@
 #include <ranges>
 
 using namespace phlex;
-using namespace phlex::experimental;
+using namespace phlex::detail;
 using namespace phlex::experimental::literals;
 
 namespace {

--- a/test/fold.cpp
+++ b/test/fold.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Different data layers of fold", "[graph]")
   gen->add_layer("run", {"job", index_limit});
   gen->add_layer("event", {"run", number_limit});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   g.provide("provide_number", provide_number, concurrency::unlimited)
@@ -108,7 +108,7 @@ TEST_CASE("Fold output without send consumed downstream", "[graph]")
   gen->add_layer("run", {"job", index_limit});
   gen->add_layer("event", {"run", number_limit});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   g.provide("provide_number", provide_number, concurrency::unlimited)

--- a/test/fold_duplicate_layer_name_test.cpp
+++ b/test/fold_duplicate_layer_name_test.cpp
@@ -62,7 +62,7 @@ TEST_CASE("Fold different layer paths with same trailing name", "[graph]")
   gen->add_layer("event", {"run", number_limit});
   gen->add_layer("event", {"job", top_level_event_limit});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   // Register provider

--- a/test/form/form_basics_test.cpp
+++ b/test/form/form_basics_test.cpp
@@ -258,7 +258,7 @@ TEST_CASE("FORM source registry prefers exact type matches", "[form]")
 
   form::experimental::register_form_vector_product_type<LocalProduct>(local_name);
 
-  auto const local_type = phlex::experimental::make_type_id<std::vector<LocalProduct>>();
+  auto const local_type = phlex::detail::make_type_id<std::vector<LocalProduct>>();
   auto const* resolved_name = form::experimental::find_form_product_type_name(local_type);
 
   REQUIRE(resolved_name != nullptr);
@@ -272,7 +272,7 @@ TEST_CASE("FORM source registry prefers exact type matches", "[form]")
 
 TEST_CASE("FORM source registry keeps builtin mappings", "[form]")
 {
-  auto const bool_type = phlex::experimental::make_type_id<std::vector<bool>>();
+  auto const bool_type = phlex::detail::make_type_id<std::vector<bool>>();
   auto const* resolved_name = form::experimental::find_form_product_type_name(bool_type);
 
   REQUIRE(resolved_name != nullptr);
@@ -322,7 +322,7 @@ TEST_CASE("FORM source registry: unregistered type returns nullptr", "[form]")
   // find_form_product_type_name returns nullptr for a type never registered.
   // Exercises the null-return path form_source::create_providers checks at L76-77.
   struct NeverRegistered {};
-  auto const unknown_type = phlex::experimental::make_type_id<NeverRegistered>();
+  auto const unknown_type = phlex::detail::make_type_id<NeverRegistered>();
   CHECK(form::experimental::find_form_product_type_name(unknown_type) == nullptr);
 }
 
@@ -335,17 +335,19 @@ TEST_CASE("FORM source registry: unknown name returns nullptr entry", "[form]")
 
 TEST_CASE("FORM source registry: registration error paths", "[form]")
 {
-  using phlex::experimental::make_type_id;
+  using phlex::detail::make_type_id;
 
   SECTION("empty product type name throws")
   {
-    CHECK_THROWS_AS(form::experimental::register_form_product_type(
-                      "",
-                      make_type_id<int>(),
-                      typeid(int),
-                      [](void const*, std::string const&, std::string const&)
-                        -> phlex::experimental::product_ptr { return nullptr; }),
-                    std::runtime_error);
+    CHECK_THROWS_AS(
+      form::experimental::register_form_product_type(
+        "",
+        make_type_id<int>(),
+        typeid(int),
+        [](void const*, std::string const&, std::string const&) -> phlex::detail::product_ptr {
+          return nullptr;
+        }),
+      std::runtime_error);
   }
 
   SECTION("null conversion function throws")

--- a/test/framework_graph.cpp
+++ b/test/framework_graph.cpp
@@ -48,14 +48,14 @@ namespace {
 
 TEST_CASE("Catch STL exceptions", "[graph]")
 {
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(driver_bundle{[](framework_driver&) { throw std::runtime_error("STL error"); }, {}});
   CHECK_THROWS_AS(g.execute(), std::exception);
 }
 
 TEST_CASE("Catch other exceptions", "[graph]")
 {
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(driver_bundle{[](framework_driver&) { throw 2.5; }, {}});
   CHECK_THROWS_AS(g.execute(), double);
 }
@@ -65,7 +65,7 @@ TEST_CASE("Make progress with one thread", "[graph]")
   auto gen = experimental::layer_generator::make();
   gen->add_layer("spill", {"job", 1000});
 
-  auto g = experimental::framework_graph::without_driver(1);
+  auto g = phlex::detail::framework_graph::without_driver(1);
   g.add_driver(gen);
   g.provide(
      "provide_number",
@@ -87,7 +87,7 @@ TEST_CASE("Stop driver when workflow throws exception", "[graph]")
   auto gen = experimental::layer_generator::make();
   gen->add_layer("spill", {"job", 1000});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
   g.provide(
      "throw_exception",
@@ -125,7 +125,7 @@ TEST_CASE("Throw when predicate specified by consumer does not exist", "[graph]"
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", 1, 1});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
   g.provide(
      "provide_num",
@@ -146,7 +146,7 @@ TEST_CASE("Throw when predicate specified by consumer does not exist", "[graph]"
 
 TEST_CASE("Throw for invalid deferred driver setup", "[graph]")
 {
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
 
   SECTION("Throw when source specified for driver does not exist")
   {
@@ -171,7 +171,7 @@ TEST_CASE("Throw for invalid deferred driver setup", "[graph]")
 
 TEST_CASE("Use default driver", "[graph]")
 {
-  auto g = experimental::framework_graph::with_default_driver();
+  auto g = phlex::detail::framework_graph::with_default_driver();
 
   SECTION("Throw when attempting to add a driver in default mode")
   {
@@ -201,7 +201,7 @@ TEST_CASE("Use default driver", "[graph]")
 
 TEST_CASE("Throw on duplicate node registration", "[graph]")
 {
-  auto g = experimental::framework_graph::with_default_driver();
+  auto g = phlex::detail::framework_graph::with_default_driver();
 
   g.observe(
      "duplicate_name", [](unsigned int const) {}, concurrency::unlimited)
@@ -220,7 +220,7 @@ TEST_CASE("Allow late driver configuration", "[graph]")
   auto gen = experimental::layer_generator::make();
   gen->add_layer("spill", {"job", 3});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
 
   g.provide(
      "provide_number",
@@ -273,7 +273,7 @@ TEST_CASE("driver_proxy creates bundle from driver builder", "[graph]")
 
 TEST_CASE("Driver function receives registered source", "[graph]")
 {
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_source<test_source>("src");
 
   test_source const* received_src{nullptr};
@@ -290,7 +290,7 @@ TEST_CASE("Driver function throws on source type mismatch", "[graph]")
 {
   // Register other_source but declare test_source const& in the driver function.
   // The source downcast inside invoke_driver_with_sources throws with context.
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_source<other_source>("src");
 
   auto bundle = g.driver_proxy({"src"}).driver(fixed_hierarchy{},
@@ -307,7 +307,7 @@ TEST_CASE("Driver function throws on source type mismatch", "[graph]")
 
 TEST_CASE("Throw when configuring driver twice", "[graph]")
 {
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
 
   auto gen = experimental::layer_generator::make();
   CHECK_NOTHROW(g.add_driver(gen));

--- a/test/framework_graph.cpp
+++ b/test/framework_graph.cpp
@@ -16,8 +16,8 @@
 #include <vector>
 
 using namespace phlex;
+using phlex::detail::framework_driver;
 using phlex::experimental::driver_bundle;
-using phlex::experimental::framework_driver;
 
 namespace {
   struct test_source final : phlex::source {

--- a/test/framework_graph.cpp
+++ b/test/framework_graph.cpp
@@ -20,16 +20,16 @@ using phlex::experimental::driver_bundle;
 using phlex::experimental::framework_driver;
 
 namespace {
-  struct test_source final : phlex::experimental::source {
-    phlex::experimental::provider_bundles create_providers(product_selector const&) override
+  struct test_source final : phlex::source {
+    phlex::detail::provider_bundles create_providers(product_selector const&) override
     {
       return {};
     }
     index_generator indices() override { co_return; }
   };
 
-  struct other_source final : phlex::experimental::source {
-    phlex::experimental::provider_bundles create_providers(product_selector const&) override
+  struct other_source final : phlex::source {
+    phlex::detail::provider_bundles create_providers(product_selector const&) override
     {
       return {};
     }
@@ -240,7 +240,7 @@ TEST_CASE("Allow late driver configuration", "[graph]")
 
 TEST_CASE("driver_proxy validates sources and generator", "[graph]")
 {
-  std::vector<experimental::source const*> sources{};
+  std::vector<phlex::source const*> sources{};
   auto src = std::make_unique<test_source>();
   sources.push_back(src.get());
   experimental::driver_proxy proxy{sources};

--- a/test/framework_graph.cpp
+++ b/test/framework_graph.cpp
@@ -16,8 +16,8 @@
 #include <vector>
 
 using namespace phlex;
+using phlex::detail::driver_bundle;
 using phlex::detail::framework_driver;
-using phlex::experimental::driver_bundle;
 
 namespace {
   struct test_source final : phlex::source {
@@ -243,7 +243,7 @@ TEST_CASE("driver_proxy validates sources and generator", "[graph]")
   std::vector<phlex::source const*> sources{};
   auto src = std::make_unique<test_source>();
   sources.push_back(src.get());
-  experimental::driver_proxy proxy{sources};
+  detail::driver_proxy proxy{sources};
 
   SECTION("Throw when source parameter count mismatches")
   {
@@ -265,7 +265,7 @@ TEST_CASE("driver_proxy validates sources and generator", "[graph]")
 
 TEST_CASE("driver_proxy creates bundle from driver builder", "[graph]")
 {
-  experimental::driver_proxy proxy{{}};
+  detail::driver_proxy proxy{{}};
   auto const bundle = proxy.driver(std::make_shared<test_driver_builder>());
 
   CHECK(static_cast<bool>(bundle.driver));

--- a/test/function_registration.cpp
+++ b/test/function_registration.cpp
@@ -62,7 +62,7 @@ TEST_CASE("Call non-framework functions", "[programming model]")
   std::array const product_suffixes = {"onumber"s, "otemperature"s, "oname"s};
   std::array const result{"result"s};
 
-  auto g = experimental::framework_graph::with_default_driver();
+  auto g = phlex::detail::framework_graph::with_default_driver();
 
   // Register providers
   g.provide("provide_number", provide_number, concurrency::unlimited)

--- a/test/hierarchical_nodes.cpp
+++ b/test/hierarchical_nodes.cpp
@@ -51,7 +51,7 @@ namespace {
 
   data_for_rms send(threadsafe_data_for_rms const& data)
   {
-    return {phlex::experimental::send(data.total), phlex::experimental::send(data.number)};
+    return {experimental::send(data.total), experimental::send(data.number)};
   }
 
   void add(threadsafe_data_for_rms& redata, unsigned squared_number)
@@ -82,7 +82,7 @@ TEST_CASE("Hierarchical nodes", "[graph]")
   gen->add_layer("run", {"job", index_limit});
   gen->add_layer("event", {"run", number_limit});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   g.provide("provide_time",

--- a/test/layer_generator.cpp
+++ b/test/layer_generator.cpp
@@ -5,6 +5,7 @@
 #include "catch2/matchers/catch_matchers_string.hpp"
 
 using namespace phlex::experimental;
+using phlex::detail::framework_graph;
 using namespace Catch::Matchers;
 
 TEST_CASE("Only job layer", "[layer-generation]")

--- a/test/max-parallelism/provide_parallelism.cpp
+++ b/test/max-parallelism/provide_parallelism.cpp
@@ -12,6 +12,7 @@ namespace {
       phlex::product_selector const& selector) override
     {
       using namespace phlex::experimental;
+      using namespace phlex::detail;
       phlex::detail::provider_bundles bundles;
       std::string const layer = "job";
       std::string const stage = "CURRENT";

--- a/test/max-parallelism/provide_parallelism.cpp
+++ b/test/max-parallelism/provide_parallelism.cpp
@@ -1,4 +1,3 @@
-#include "phlex/core/source.hpp"
 #include "phlex/source.hpp"
 #include "phlex/utilities/max_allowed_parallelism.hpp"
 
@@ -7,27 +6,27 @@
 #include <utility>
 
 namespace {
-  class max_parallelism_source : public phlex::experimental::source {
+  class max_parallelism_source : public phlex::source {
   public:
-    phlex::experimental::provider_bundles create_providers(
+    phlex::detail::provider_bundles create_providers(
       phlex::product_selector const& selector) override
     {
       using namespace phlex::experimental;
-      provider_bundles bundles;
+      phlex::detail::provider_bundles bundles;
       std::string const layer = "job";
       std::string const stage = "CURRENT";
       product_specification spec{"input", "max_parallelism", make_type_id<std::size_t>()};
 
       if (selector.match(spec, identifier{layer}, identifier{stage})) {
-        bundles.push_back(provider_bundle{.provider_function =
-                                            [](phlex::data_cell_index const&) {
-                                              return product_for(
-                                                max_allowed_parallelism::active_value());
-                                            },
-                                          .max_concurrency = phlex::concurrency::unlimited,
-                                          .spec = std::move(spec),
-                                          .layer = layer,
-                                          .stage = stage});
+        bundles.push_back(phlex::detail::provider_bundle{
+          .provider_function =
+            [](phlex::data_cell_index const&) {
+              return product_for(max_allowed_parallelism::active_value());
+            },
+          .max_concurrency = phlex::concurrency::unlimited,
+          .spec = std::move(spec),
+          .layer = layer,
+          .stage = stage});
       }
       return bundles;
     }

--- a/test/memory-checks/many_events.cpp
+++ b/test/memory-checks/many_events.cpp
@@ -17,7 +17,7 @@ try {
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", max_events, 1u});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   g.provide("provide_number", [](data_cell_index const& id) -> unsigned { return id.number(); })

--- a/test/mock-workflow/ion_and_scint.cpp
+++ b/test/mock-workflow/ion_and_scint.cpp
@@ -6,6 +6,6 @@ using namespace phlex::experimental::test;
 
 PHLEX_REGISTER_ALGORITHMS(m, config)
 {
-  define_algorithm<sim::SimEnergyDeposits,
-                   phlex::experimental::sized_tuple<sim::SimEnergyDeposits, 2>>(m, config);
+  define_algorithm<sim::SimEnergyDeposits, phlex::detail::sized_tuple<sim::SimEnergyDeposits, 2>>(
+    m, config);
 }

--- a/test/mock-workflow/largeant.cpp
+++ b/test/mock-workflow/largeant.cpp
@@ -11,7 +11,7 @@ PHLEX_REGISTER_ALGORITHMS(m, config)
 {
   using assns =
     phlex::experimental::association<simb::MCParticle, simb::MCTruth, sim::GeneratedParticleInfo>;
-  using input = phlex::experimental::sized_tuple<simb::MCTruths, 6>;
+  using input = phlex::detail::sized_tuple<simb::MCTruths, 6>;
   using output = std::tuple<sim::ParticleAncestryMap,
                             assns,
                             sim::SimEnergyDeposits,

--- a/test/multiple_function_registration.cpp
+++ b/test/multiple_function_registration.cpp
@@ -41,7 +41,7 @@ namespace {
 
 TEST_CASE("Call multiple functions", "[programming model]")
 {
-  auto g = experimental::framework_graph::with_default_driver();
+  auto g = phlex::detail::framework_graph::with_default_driver();
 
   g.provide("provide_numbers",
             [](data_cell_index const&) -> std::vector<unsigned> { return {0, 1, 2, 3, 4}; })

--- a/test/output_products.cpp
+++ b/test/output_products.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Output data products", "[graph]")
   auto gen = experimental::layer_generator::make();
   gen->add_layer("spill", {"job", 1u});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   g.provide("provide_number", [](data_cell_index const&) -> int { return 17; })

--- a/test/product_handle.cpp
+++ b/test/product_handle.cpp
@@ -10,7 +10,7 @@
 
 using namespace phlex;
 using namespace phlex::experimental::literals;
-using spec_t = experimental::product_specification;
+using spec_t = detail::product_specification;
 using opt_id_t = std::optional<experimental::identifier>;
 
 namespace {
@@ -21,7 +21,7 @@ namespace {
 
 TEST_CASE("Handle type conversions (compile-time checks)", "[data model]")
 {
-  using experimental::detail::handle_value_type;
+  using detail::internal::handle_value_type;
   static_assert(std::same_as<handle_value_type<int>, int>);
   static_assert(std::same_as<handle_value_type<int const>, int>);
   static_assert(std::same_as<handle_value_type<int const&>, int>);

--- a/test/product_matcher.cpp
+++ b/test/product_matcher.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <regex>
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 
 namespace {
 

--- a/test/product_selecting.cpp
+++ b/test/product_selecting.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Querying products in different ways", "[graph]")
   constexpr int num_events = 25;
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {.parent_layer_name = "job", .total_per_parent_data_cell = num_events});
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   // Register providers

--- a/test/product_store.cpp
+++ b/test/product_store.cpp
@@ -40,6 +40,8 @@ TEST_CASE("Product store insertion", "[data model]")
 
 TEST_CASE("Product store derivation", "[data model]")
 {
+  using namespace phlex::experimental::detail;
+
   SECTION("Only one store")
   {
     auto store = product_store::base();

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -1,6 +1,6 @@
 #include "phlex/core/framework_graph.hpp"
-#include "phlex/core/source.hpp"
 #include "phlex/model/data_cell_index.hpp"
+#include "phlex/source.hpp"
 #include "plugins/layer_generator.hpp"
 
 #include "catch2/catch_test_macros.hpp"
@@ -35,32 +35,34 @@ namespace {
   }
 
   // Vertices source for implicit provider test
-  class vertices_source : public experimental::source {
+  class vertices_source : public phlex::source {
   public:
-    experimental::provider_bundles create_providers(product_selector const& selector) override
+    phlex::detail::provider_bundles create_providers(product_selector const& selector) override
     {
       using namespace experimental;
-      provider_bundles bundles;
+      phlex::detail::provider_bundles bundles;
       std::string const layer = "spill";
       std::string const stage = "previous_process";
       product_specification spec{
         "vertices_maker", "happy_vertices", make_type_id<toy::VertexCollection>()};
 
       if (selector.match(spec, identifier{layer}, identifier{stage})) {
-        bundles.push_back(provider_bundle{.provider_function = give_me_vertices_erased,
-                                          .max_concurrency = concurrency::unlimited,
-                                          .spec = std::move(spec),
-                                          .layer = layer,
-                                          .stage = stage});
+        bundles.push_back(
+          phlex::detail::provider_bundle{.provider_function = give_me_vertices_erased,
+                                         .max_concurrency = concurrency::unlimited,
+                                         .spec = std::move(spec),
+                                         .layer = layer,
+                                         .stage = stage});
       }
 
       product_specification int_spec{"vertices_maker", "num_happy_vertices", make_type_id<int>()};
       if (selector.match(int_spec, identifier{layer}, identifier{stage})) {
-        bundles.push_back(provider_bundle{.provider_function = give_me_vertices_erased,
-                                          .max_concurrency = concurrency::unlimited,
-                                          .spec = std::move(int_spec),
-                                          .layer = layer,
-                                          .stage = stage});
+        bundles.push_back(
+          phlex::detail::provider_bundle{.provider_function = give_me_vertices_erased,
+                                         .max_concurrency = concurrency::unlimited,
+                                         .spec = std::move(int_spec),
+                                         .layer = layer,
+                                         .stage = stage});
       }
       return bundles;
     }

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -27,10 +27,10 @@ namespace {
   }
 
   // Type-erased provider function
-  experimental::product_ptr give_me_vertices_erased(data_cell_index const& id)
+  detail::product_ptr give_me_vertices_erased(data_cell_index const& id)
   {
     spdlog::info("give_me_vertices_erased: {}", id.number());
-    return std::make_unique<experimental::product<toy::VertexCollection>>(
+    return std::make_unique<detail::product<toy::VertexCollection>>(
       toy::make_collection(id.number()));
   }
 
@@ -40,7 +40,8 @@ namespace {
     phlex::detail::provider_bundles create_providers(product_selector const& selector) override
     {
       using namespace experimental;
-      phlex::detail::provider_bundles bundles;
+      using namespace phlex::detail;
+      provider_bundles bundles;
       std::string const layer = "spill";
       std::string const stage = "previous_process";
       product_specification spec{

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -80,7 +80,7 @@ TEST_CASE("Explicit providers")
   auto gen = experimental::layer_generator::make();
   gen->add_layer("spill", {"job", num_spills, 1u});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   g.provide("my_name_here", give_me_vertices, concurrency::unlimited)
@@ -109,7 +109,7 @@ TEST_CASE("Implicit providers")
   auto gen = experimental::layer_generator::make();
   gen->add_layer("spill", {"job", num_spills, 1u});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
   g.add_source<vertices_source>("vertices_source");
 
@@ -132,7 +132,7 @@ TEST_CASE("Implicit providers")
 
 TEST_CASE("Throw when two sources with the same name are registered")
 {
-  auto g = experimental::framework_graph::with_default_driver();
+  auto g = phlex::detail::framework_graph::with_default_driver();
   g.add_source<vertices_source>("vertices_source");
   g.add_source<vertices_source>("vertices_source");
 
@@ -142,7 +142,7 @@ TEST_CASE("Throw when two sources with the same name are registered")
 
 TEST_CASE("Throw when no provider found for required product")
 {
-  auto g = experimental::framework_graph::with_default_driver();
+  auto g = phlex::detail::framework_graph::with_default_driver();
 
   // Register an observer that needs a product from a creator that does not exist in the graph.
   // Since there is no matching provider, make_computational_edges should throw listing all
@@ -158,7 +158,7 @@ TEST_CASE("Throw when no provider found for required product")
 
 TEST_CASE("Throw when two implicit providers are found for the same product")
 {
-  auto g = experimental::framework_graph::with_default_driver();
+  auto g = phlex::detail::framework_graph::with_default_driver();
 
   // Register two sources that can provide the same product
   g.add_source<vertices_source>("vertices_source_1");
@@ -180,7 +180,7 @@ TEST_CASE("Throw when implicit provider insertion fails")
   auto gen = experimental::layer_generator::make();
   gen->add_layer("spill", {"job", 1u});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(std::move(gen));
   g.add_source<vertices_source>("duplicate_vertices_source");
 

--- a/test/repeater_node_test.cpp
+++ b/test/repeater_node_test.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 using namespace oneapi;
-using namespace phlex::experimental;
+using namespace phlex::detail;
+using phlex::experimental::product_store;
 
 namespace {
   auto make_run_index(int run_number)
@@ -90,7 +91,7 @@ namespace {
 
   private:
     tbb::flow::graph g_;
-    detail::repeater_node repeater_;
+    internal::repeater_node repeater_;
     message_collector consumer_;
   };
 }
@@ -295,7 +296,7 @@ TEST_CASE("Test warning message if there are cached messages", "[multithreading]
   // new scope, we create the repeater_nopde as a unique_ptr and then reset it at the end of
   // the test, which will invoke the destructor.
   tbb::flow::graph g;
-  auto repeater = std::make_unique<detail::repeater_node>(
+  auto repeater = std::make_unique<internal::repeater_node>(
     g, "test_repeater_warning_on_cached_messages", "run"_id);
 
   SECTION("Cached data product")

--- a/test/replicated.cpp
+++ b/test/replicated.cpp
@@ -8,7 +8,7 @@
 #include <atomic>
 #include <vector>
 
-using phlex::experimental::thread_counter;
+using phlex::detail::thread_counter;
 using namespace oneapi::tbb;
 
 namespace {

--- a/test/string_literal.cpp
+++ b/test/string_literal.cpp
@@ -2,7 +2,7 @@
 
 #include <string_view>
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 using namespace std::string_view_literals;
 
 int main()

--- a/test/tbb-preview/resource_limiting_test.cpp
+++ b/test/tbb-preview/resource_limiting_test.cpp
@@ -11,7 +11,7 @@
 #include <string_view>
 #include <tuple>
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 using namespace oneapi::tbb;
 
 namespace {

--- a/test/type_deduction.cpp
+++ b/test/type_deduction.cpp
@@ -1,6 +1,6 @@
 #include "phlex/metaprogramming/type_deduction.hpp"
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 
 namespace {
   int transform [[maybe_unused]] (double&) { return 1; };

--- a/test/type_distinction.cpp
+++ b/test/type_distinction.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Distinguish products with same name and different types", "[programmi
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", 10, 1});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   // Register providers

--- a/test/type_id.cpp
+++ b/test/type_id.cpp
@@ -9,7 +9,7 @@
 #include <functional>
 #include <vector>
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 
 struct A {
   int a;

--- a/test/unfold.cpp
+++ b/test/unfold.cpp
@@ -94,7 +94,7 @@ TEST_CASE("Splitting the processing", "[graph]")
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", index_limit});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   g.provide("provide_max_number", provide_max_number, concurrency::unlimited)
@@ -162,7 +162,7 @@ TEST_CASE("Multi-layer transform with one input from an unfold", "[graph]")
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", index_limit});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
 
   g.provide("provide_max_number", provide_max_number, concurrency::unlimited)

--- a/test/utilities/sized_tuple.cpp
+++ b/test/utilities/sized_tuple.cpp
@@ -4,7 +4,7 @@
 #include <tuple>
 
 using namespace std;
-using namespace phlex::experimental;
+using namespace phlex::detail;
 
 int main()
 {

--- a/test/utilities/sleep_for.cpp
+++ b/test/utilities/sleep_for.cpp
@@ -9,20 +9,20 @@ using namespace std::chrono;
 TEST_CASE("Sleeping (1 s)", "[utilities]")
 {
   auto start = steady_clock::now();
-  phlex::experimental::sleep_for(1s);
+  phlex::detail::sleep_for(1s);
   CHECK(steady_clock::now() - start >= 1s);
 }
 
 TEST_CASE("Spinning (1 s)", "[utilities]")
 {
   auto start = steady_clock::now();
-  phlex::experimental::spin_for(1s);
+  phlex::detail::spin_for(1s);
   CHECK(steady_clock::now() - start >= 1s);
 }
 
 TEST_CASE("Spinning (1000 ms)", "[utilities]")
 {
   auto start = steady_clock::now();
-  phlex::experimental::spin_for(1'000ms);
+  phlex::detail::spin_for(1'000ms);
   CHECK(steady_clock::now() - start >= 1'000ms);
 }

--- a/test/utilities/thread_counter.cpp
+++ b/test/utilities/thread_counter.cpp
@@ -4,7 +4,7 @@
 #include "catch2/catch_all.hpp"
 #include "oneapi/tbb/flow_graph.h"
 
-using namespace phlex::experimental;
+using namespace phlex::detail;
 using namespace oneapi::tbb;
 
 TEST_CASE("Thread counter exception", "[multithreading]")

--- a/test/vector_of_abstract_types.cpp
+++ b/test/vector_of_abstract_types.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Test vector of abstract types")
   auto gen = experimental::layer_generator::make();
   gen->add_layer("event", {"job", 1u, 1u});
 
-  auto g = experimental::framework_graph::without_driver();
+  auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
   g.provide("provide_thing", [](data_cell_index const&) { return make_derived_as_abstract(); })
     .output_product("dummy", "thing", "event");

--- a/test/yielding_driver.cpp
+++ b/test/yielding_driver.cpp
@@ -31,7 +31,7 @@ namespace {
     }
   }
 
-  void cells_to_process(experimental::resumable_driver<data_cell_index_ptr>& d)
+  void cells_to_process(detail::resumable_driver<data_cell_index_ptr>& d)
   {
     for (auto const& index : make_indices(2, 2, 3)) {
       d.yield(index);
@@ -41,7 +41,7 @@ namespace {
 
 TEST_CASE("Resumable driver with TBB flow graph", "[resumable_driver]")
 {
-  experimental::resumable_driver<data_cell_index_ptr> drive{cells_to_process};
+  detail::resumable_driver<data_cell_index_ptr> drive{cells_to_process};
   std::vector<std::string> received_indices;
 
   tbb::flow::graph g{};


### PR DESCRIPTION
Resolves #632.

## Types in the top-level `phlex` namespace

These are types that are intended as part of the public API:

- `concurrency`
- `configuration`
- `data_cell_cursor`
- `data_cell_index`
- `data_cell_index_ptr`
- `data_cell_yielder`
- `fixed_hierarchy`
- `handle`
- `index_generator`
- `product_selector`
- `product_selectors`
- `source`

## Types in the `phlex::experimental` namespace

These are types that may become part of the public API but are either "new", "unstable", or it is not yet clear whether they should become public-facing.

- `algorithm_name`
- `identifier`
- `identifier_query`
- `layer_path`
- `product_store`
- `product_store_const_ptr`
- `product_store_ptr`

All other types are considered "implementation-defined" and should not be used by users.