### PR TITLE
Sync `release/v0.3` with `main`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ find_package(cetmodules 4.01.01 REQUIRED)
 
 # ##############################################################################
 # Main project declaration
-project(phlex VERSION 0.2.0 LANGUAGES CXX)
+project(phlex VERSION 0.3.0 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -103,7 +103,7 @@ To guide the creation of the environment, download the environment configuration
 ```bash
 spack env create my-phlex-environment
 spack env activate my-phlex-environment
-spack add phlex %gcc@15
+spack add phlex@0.3.0 %%gcc@15
 spack concretize
 ```
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 project = "Phlex"
 copyright = "2025-2026, The Phlex Developers"
 author = "The Phlex Developers"
-release = "0.2.0"
+release = "0.3.0"
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Build system**
  - Bumped the CMake project version from `0.2.0` to `0.3.0`.

- **Docs**
  - Updated the installation instructions to pin `phlex@0.3.0` and use the `gcc@15` compiler selector in the Spack setup example.
  - Synced the Sphinx documentation release version from `0.2.0` to `0.3.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->