### PR TITLE
ci(coverage): temporarily disable push and pull_request triggers

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,9 +3,9 @@ name: Code Coverage
 run-name: "${{ github.actor }} running code coverage"
 
 "on":
-  push:
-    branches: [main, "release/*"]
-  pull_request:
+  #  push:
+  #    branches: [main, "release/*"]
+  #  pull_request:
   issue_comment:
     types: [created]
   workflow_dispatch:


### PR DESCRIPTION
Disable automatic triggers to avoid CI failures caused by persistent
upstream access/404 issues.
