### PR TITLE
Install `driver.hpp`

### DIFF
--- a/phlex/CMakeLists.txt
+++ b/phlex/CMakeLists.txt
@@ -34,7 +34,7 @@ cet_make_library(
   phlex::configuration
 )
 
-install(FILES concurrency.hpp module.hpp source.hpp DESTINATION include/phlex)
+install(FILES concurrency.hpp driver.hpp module.hpp source.hpp DESTINATION include/phlex)
 install(FILES detail/plugin_macros.hpp DESTINATION include/phlex/detail)
 
 cet_make_library(


### PR DESCRIPTION
For v0.2.0, the `driver.hpp` file was not publicly installed because it was only used internally.  It should have been installed for v0.3.0

---

Fixes #685.