### PR TITLE
Adjust product_selector print format

### DIFF
--- a/phlex/core/product_selector.cpp
+++ b/phlex/core/product_selector.cpp
@@ -71,23 +71,19 @@ namespace phlex {
 
   std::string product_selector::to_string() const
   {
-    // Will generate [<suffix>][::<concept>][ by <creator>[ (of <stage>)]][ in <layer>]
-    // where square brackets indicate optional sections. If stage is specified but not creator,
-    // creator will be [ANY]
+    // Will generate <<suffix>::<concept> by <creator> (of <stage>) in <layer>>
     using experimental::identifier;
     std::string_view suffix_str =
-      suffix.transform(&identifier::operator std::string_view).value_or("");
+      suffix.transform(&identifier::operator std::string_view).value_or("[ANY]");
     std::string type_str =
-      this->type.valid() ? fmt::format("::{}", this->type) : ""; // will later be concept
-    std::string layer_str = fmt::format(" in {}", identifier(layer));
-    std::string creator_str; // depends on whether /stage/ is specified
-    if (stage.has_value()) {
-      creator_str = fmt::format(" by {} of {}", creator, stage.value());
-    } else {
-      creator_str = creator ? fmt::format(" by {}", creator) : "";
-    }
+      this->type.valid() ? fmt::format("[{}]", this->type) : "[UNSET]"; // will later be concept
+    auto layer_str = std::string_view(layer);
+    std::string_view creator_str = creator ? std::string_view(*creator) : "[ANY]";
+    std::string_view stage_str =
+      stage.transform(&identifier::operator std::string_view).value_or("[ANY STAGE]");
 
-    return fmt::format("{}{}{}{}", suffix_str, type_str, creator_str, layer_str);
+    return fmt::format(
+      "<{}::{} by {} (of {}) in {}>", suffix_str, type_str, creator_str, stage_str, layer_str);
   }
 
   bool product_selector::operator==(product_selector const& rhs) const

--- a/phlex/core/product_selector.cpp
+++ b/phlex/core/product_selector.cpp
@@ -74,16 +74,20 @@ namespace phlex {
     // Will generate <<suffix>::<concept> by <creator> (of <stage>) in <layer>>
     using experimental::identifier;
     std::string_view suffix_str =
-      suffix.transform(&identifier::operator std::string_view).value_or("[ANY]");
-    std::string type_str =
-      this->type.valid() ? fmt::format("[{}]", this->type) : "[UNSET]"; // will later be concept
+      suffix.transform(&identifier::operator std::string_view).value_or("[ANY SUFFIX]");
+    std::string type_str = this->type.valid() ? fmt::format("<{}>", this->type)
+                                              : "[UNSET TYPE]"; // will later be concept
     auto layer_str = std::string_view(layer);
-    std::string_view creator_str = creator ? std::string_view(*creator) : "[ANY]";
+    std::string_view creator_str = creator ? std::string_view(*creator) : "[ANY CREATOR]";
     std::string_view stage_str =
       stage.transform(&identifier::operator std::string_view).value_or("[ANY STAGE]");
 
-    return fmt::format(
-      "<{}::{} by {} (of {}) in {}>", suffix_str, type_str, creator_str, stage_str, layer_str);
+    return fmt::format("<{} (of type {}) by {} (of {}) in {}>",
+                       suffix_str,
+                       type_str,
+                       creator_str,
+                       stage_str,
+                       layer_str);
   }
 
   bool product_selector::operator==(product_selector const& rhs) const

--- a/phlex/core/product_selector.cpp
+++ b/phlex/core/product_selector.cpp
@@ -74,15 +74,15 @@ namespace phlex {
     // Will generate <<suffix>::<concept> by <creator> (of <stage>) in <layer>>
     using experimental::identifier;
     std::string_view suffix_str =
-      suffix.transform(&identifier::operator std::string_view).value_or("[ANY SUFFIX]");
+      suffix.transform(&identifier::operator std::string_view).value_or("[ANY]");
     std::string type_str = this->type.valid() ? fmt::format("<{}>", this->type)
                                               : "[UNSET TYPE]"; // will later be concept
     auto layer_str = std::string_view(layer);
-    std::string_view creator_str = creator ? std::string_view(*creator) : "[ANY CREATOR]";
+    std::string_view creator_str = creator ? std::string_view(*creator) : "[ANY]";
     std::string_view stage_str =
-      stage.transform(&identifier::operator std::string_view).value_or("[ANY STAGE]");
+      stage.transform(&identifier::operator std::string_view).value_or("[ANY]");
 
-    return fmt::format("<{} (of type {}) by {} (of {}) in {}>",
+    return fmt::format("<suffix {} (of type {}) by creator {} (of stage {}) in layer {}>",
                        suffix_str,
                        type_str,
                        creator_str,

--- a/phlex/core/product_selector.cpp
+++ b/phlex/core/product_selector.cpp
@@ -71,10 +71,23 @@ namespace phlex {
 
   std::string product_selector::to_string() const
   {
-    if (suffix) {
-      return fmt::format("{}/{} ϵ {}", creator, *suffix, layer);
+    // Will generate [<suffix>][::<concept>][ by <creator>[ (of <stage>)]][ in <layer>]
+    // where square brackets indicate optional sections. If stage is specified but not creator,
+    // creator will be [ANY]
+    using experimental::identifier;
+    std::string_view suffix_str =
+      suffix.transform(&identifier::operator std::string_view).value_or("");
+    std::string type_str =
+      this->type.valid() ? fmt::format("::{}", this->type) : ""; // will later be concept
+    std::string layer_str = fmt::format(" in {}", identifier(layer));
+    std::string creator_str; // depends on whether /stage/ is specified
+    if (stage.has_value()) {
+      creator_str = fmt::format(" by {} of {}", creator, stage.value());
+    } else {
+      creator_str = creator ? fmt::format(" by {}", creator) : "";
     }
-    return fmt::format("{} ϵ {}", creator, layer);
+
+    return fmt::format("{}{}{}{}", suffix_str, type_str, creator_str, layer_str);
   }
 
   bool product_selector::operator==(product_selector const& rhs) const

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -69,6 +69,7 @@ namespace phlex {
 
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
       operator T const&() const noexcept { return content_; }
+      explicit operator std::string_view() const noexcept { return std::string_view(content_); }
       bool operator==(required_layer_name const&) const noexcept = default;
 
     private:

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -170,7 +170,7 @@ TEST_CASE("Throw when two implicit providers are found for the same product")
 
   CHECK_THROWS_WITH(
     g.execute(),
-    ContainsSubstring("Multiple implicit providers found for product 'happy_vertices") &&
+    ContainsSubstring("Multiple implicit providers found for product '<happy_vertices") &&
       ContainsSubstring("by vertices_maker") && ContainsSubstring("in spill") &&
       ContainsSubstring("node 'passer'"));
 }
@@ -194,7 +194,7 @@ TEST_CASE("Throw when implicit provider insertion fails")
 
   CHECK_THROWS_WITH(
     g.execute(),
-    ContainsSubstring("Failed to create implicit provider for product selector 'happy_vertices") &&
+    ContainsSubstring("Failed to create implicit provider for product selector '<happy_vertices") &&
       ContainsSubstring("by vertices_maker") &&
       ContainsSubstring(
         "Implicit providers not yet supported for creators that created multiple data products"));

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -170,9 +170,9 @@ TEST_CASE("Throw when two implicit providers are found for the same product")
 
   CHECK_THROWS_WITH(
     g.execute(),
-    ContainsSubstring(
-      "Multiple implicit providers found for product 'vertices_maker/happy_vertices") &&
-      ContainsSubstring("spill") && ContainsSubstring("passer"));
+    ContainsSubstring("Multiple implicit providers found for product 'happy_vertices") &&
+      ContainsSubstring("by vertices_maker") && ContainsSubstring("in spill") &&
+      ContainsSubstring("node 'passer'"));
 }
 
 TEST_CASE("Throw when implicit provider insertion fails")
@@ -194,8 +194,8 @@ TEST_CASE("Throw when implicit provider insertion fails")
 
   CHECK_THROWS_WITH(
     g.execute(),
-    ContainsSubstring("Failed to create implicit provider for product selector 'vertices_maker/") &&
-      ContainsSubstring("happy_vertices") &&
+    ContainsSubstring("Failed to create implicit provider for product selector 'happy_vertices") &&
+      ContainsSubstring("by vertices_maker") &&
       ContainsSubstring(
         "Implicit providers not yet supported for creators that created multiple data products"));
 }

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -170,8 +170,8 @@ TEST_CASE("Throw when two implicit providers are found for the same product")
 
   CHECK_THROWS_WITH(
     g.execute(),
-    ContainsSubstring("Multiple implicit providers found for product '<happy_vertices") &&
-      ContainsSubstring("by vertices_maker") && ContainsSubstring("in spill") &&
+    ContainsSubstring("Multiple implicit providers found for product '<suffix happy_vertices") &&
+      ContainsSubstring("by creator vertices_maker") && ContainsSubstring("in layer spill") &&
       ContainsSubstring("node 'passer'"));
 }
 
@@ -194,8 +194,9 @@ TEST_CASE("Throw when implicit provider insertion fails")
 
   CHECK_THROWS_WITH(
     g.execute(),
-    ContainsSubstring("Failed to create implicit provider for product selector '<happy_vertices") &&
-      ContainsSubstring("by vertices_maker") &&
+    ContainsSubstring(
+      "Failed to create implicit provider for product selector '<suffix happy_vertices") &&
+      ContainsSubstring("by creator vertices_maker") &&
       ContainsSubstring(
         "Implicit providers not yet supported for creators that created multiple data products"));
 }


### PR DESCRIPTION
Addresses #677.

Will generate `[<suffix>][::<concept>][ by <creator>[ (of <stage>)]][ in <layer>]`
where square brackets indicate optional sections. If stage is specified but not creator,
creator will be `[ANY]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Reworked `phlex::product_selector::to_string()` to emit the new selector format: `[<suffix>][::<concept>][ by <creator>[ (of <stage>)]][ in <layer>]`.
  - Built the string from optional components so each section is only included when present.
  - Preserved the special fallback where a stage without a creator renders the creator as `[ANY]`.
  - Removed the old `ϵ`-based formatting path.

- **Tests**
  - Updated `test/provider_test.cpp` expectations to match the revised product selector/error-message formatting in provider build/execute failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->