### PR TITLE
style(ruff): bring scripts/git-ai-commit into conformance

### DIFF
--- a/scripts/git-ai-commit
+++ b/scripts/git-ai-commit
@@ -104,10 +104,10 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-from typing import TextIO
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import TextIO
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -476,7 +476,7 @@ def _token(backend: str) -> str:
 
 
 def _clean_message(text: str) -> str:
-    """Strip model preamble and fenced code blocks from a raw API response.
+    r"""Strip model preamble and fenced code blocks from a raw API response.
 
     Some models ignore the instruction to respond with only the commit message
     and wrap their output in prose ("Here's the commit message:") and/or a
@@ -636,7 +636,10 @@ def _chat_antigravity(model: str, messages: list[dict[str, str]]) -> str:
 
     if result.returncode != 0:
         raise _APIError(
-            f"Antigravity CLI (agy) failed (exit code {result.returncode}):\n{result.stderr.strip()}",
+            (
+                "Antigravity CLI (agy) failed "
+                f"(exit code {result.returncode}):\n{result.stderr.strip()}"
+            ),
             result.returncode,
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code quality**
  - Reordered imports in `scripts/git-ai-commit` to satisfy Ruff’s import sorting.
  - Converted the `_clean_message` docstring literal to a raw triple-quoted string without changing behavior.
  - Reformatted the `agy`/antigravity backend error path so `_APIError` is constructed with the same message and `result.returncode` as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->