### PR TITLE
Sync `main` with `v0.3.1`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ find_package(cetmodules 4.01.01 REQUIRED)
 
 # ##############################################################################
 # Main project declaration
-project(phlex VERSION 0.3.0 LANGUAGES CXX)
+project(phlex VERSION 0.3.1 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -103,7 +103,7 @@ To guide the creation of the environment, download the environment configuration
 ```bash
 spack env create my-phlex-environment
 spack env activate my-phlex-environment
-spack add phlex@0.3.0 %%gcc@15
+spack add phlex@0.3.1 %%gcc@15
 spack concretize
 ```
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 project = "Phlex"
 copyright = "2025-2026, The Phlex Developers"
 author = "The Phlex Developers"
-release = "0.3.0"
+release = "0.3.1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/phlex/CMakeLists.txt
+++ b/phlex/CMakeLists.txt
@@ -34,7 +34,7 @@ cet_make_library(
   phlex::configuration
 )
 
-install(FILES concurrency.hpp module.hpp source.hpp DESTINATION include/phlex)
+install(FILES concurrency.hpp driver.hpp module.hpp source.hpp DESTINATION include/phlex)
 install(FILES detail/plugin_macros.hpp DESTINATION include/phlex/detail)
 
 cet_make_library(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Build system**
  - Bumped the project version from `0.3.0` to `0.3.1` in the top-level `CMakeLists.txt`.

- **Packaging / installation**
  - Updated the Spack installation instructions to use `phlex@0.3.1` instead of `phlex@0.3.0`.
  - Added `driver.hpp` to the set of public headers installed into `include/phlex`.

- **Documentation**
  - Updated Sphinx docs configuration to report release `0.3.1` instead of `0.3.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->