### PR TITLE
use unique_ptr for FORM product_from_data to own buffer

### DIFF
--- a/form/form/form_source_type_registry.hpp
+++ b/form/form/form_source_type_registry.hpp
@@ -44,7 +44,9 @@ namespace form::experimental {
         throw std::runtime_error("FORM Error: Failed to retrieve product [" + product_name +
                                  "] for " + index_str);
       }
-      return phlex::detail::product_for(*static_cast<product_type_t const*>(data));
+
+      auto ptr = std::unique_ptr<product_type_t const>(static_cast<product_type_t const*>(data));
+      return phlex::detail::product_for(*ptr);
     };
 
     register_form_product_type(std::move(product_type),


### PR DESCRIPTION
**Summary**: Fix ownership and lifetime handling for FORM data products when converting raw `void const*` into phlex products.

**Details:**

- Wrap the raw FORM buffer pointer in `std::unique_ptr<product_type_t const>` inside `form/form/form_source_type_registry.hpp`
- Pass the dereferenced object into `phlex::detail::product_for`
- This moves temporary ownership into a scoped unique pointer, ensuring the original FORM buffer is deleted immediately after the product copy is created
- Prevents potential use-after-free when FORM raw data outlives a single `read()` call or when multiple reads occur concurrently

**Notes:**

- a future follow-up could further improve efficiency by evolving phlex to accept moved ownership directly, eliminating the temporary copy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Updated FORM product conversion to take ownership of the raw buffer pointer with `std::unique_ptr`.
  - Passes the owned product object by reference to `phlex::detail::product_for`.
  - Ensures the buffer is released after the product copy is created, improving ownership and lifetime safety during `read()` operations, including concurrent reads.
  - Public and exported declarations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->