### PR TITLE
Some improvements as identified by AI

### DIFF
--- a/phlex/core/declared_transform.hpp
+++ b/phlex/core/declared_transform.hpp
@@ -81,7 +81,7 @@ namespace phlex::detail {
       transform_{
         g,
         concurrency,
-        [this, ft = alg.release_algorithm()](messages_t<num_inputs> const& messages, auto& output) {
+        [this, ft = alg.release_algorithm()](messages_t<num_inputs> const& messages) -> message {
           using namespace phlex::experimental::detail;
           auto const& msg = most_derived(messages);
           auto const& [store, message_id] = std::tie(msg.store, msg.id);
@@ -95,7 +95,7 @@ namespace phlex::detail {
           auto new_store = std::make_shared<phlex::experimental::product_store>(
             store->index(), name(), std::move(new_products));
 
-          std::get<0>(output).try_put({.store = std::move(new_store), .id = message_id});
+          return {.store = std::move(new_store), .id = message_id};
         }}
     {
       if constexpr (num_inputs > 1ull) {
@@ -114,10 +114,7 @@ namespace phlex::detail {
       return input_ports<num_inputs>(join_, transform_);
     }
 
-    tbb::flow::sender<message>& output_port() override
-    {
-      return tbb::flow::output_port<0>(transform_);
-    }
+    tbb::flow::sender<message>& output_port() override { return transform_; }
     product_specifications const& output() const override { return output_; }
 
     template <std::size_t... Is>
@@ -146,7 +143,7 @@ namespace phlex::detail {
     input_retriever_types<input_parameter_types> input_{input_arguments<input_parameter_types>()};
     product_specifications output_;
     join_or_none_t<num_inputs> join_;
-    tbb::flow::multifunction_node<messages_t<num_inputs>, message_tuple<1u>> transform_;
+    tbb::flow::function_node<messages_t<num_inputs>, message> transform_;
     std::atomic<std::size_t> calls_;
     tbb::concurrent_unordered_map<std::size_t, std::atomic<std::size_t>> product_count_;
   };

--- a/phlex/model/products.cpp
+++ b/phlex/model/products.cpp
@@ -19,7 +19,8 @@ namespace phlex::detail {
 
   product_base const* products::find_product(product_specification const& spec) const
   {
-    auto it = std::ranges::find(products_, spec, [](auto const& p) { return p.first; });
+    auto it =
+      std::ranges::find(products_, spec, [](auto const& p) -> auto const& { return p.first; });
     if (it == products_.end()) {
       throw std::runtime_error(
         fmt::format("No product exists with the specification '{}'.", spec.to_string()));


### PR DESCRIPTION
This PR includes two changes:

1. Switching the `phlex::detail::transform_node` implementation from using a `tbb::flow::multifunction_node` object to a `tbb::flow::function_node` object, which is simpler to understand.
2. Make sure that the `std::ranges::find(...)` projection lambda returns a reference and not a copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Replaced `tbb::flow::multifunction_node` with `function_node` in `phlex::detail::transform_node`.
  - Updated transform handling to return a single message directly and simplified output-port wiring.
  - Changed the `std::ranges::find` projection lambda to return the pair key by `const` reference instead of copying it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->