### PR TITLE
Simplify construction of implicit providers

### DIFF
--- a/form/form_source.cpp
+++ b/form/form_source.cpp
@@ -112,12 +112,12 @@ namespace {
           return this->read_product_from_form(actual_creator_, name, id.to_string(), product_type);
         };
 
-        bundles.push_back(phlex::detail::provider_bundle{
-          .provider_function = std::function<phlex::detail::provider_function_t>(provider_func),
-          .max_concurrency = phlex::concurrency::serial,
-          .spec = std::move(spec),
-          .layer = std::string(selector_layer.trans_get_string()),
-          .stage = std::string(selector_stage.trans_get_string())});
+        bundles.push_back(
+          phlex::detail::provider_bundle{.provider_function = provider_func,
+                                         .max_concurrency = phlex::concurrency::serial,
+                                         .spec = std::move(spec),
+                                         .layer = std::string(selector_layer.trans_get_string()),
+                                         .stage = std::string(selector_stage.trans_get_string())});
       }
 
       return bundles;

--- a/phlex/core/make_computational_edges.cpp
+++ b/phlex/core/make_computational_edges.cpp
@@ -106,15 +106,7 @@ namespace phlex::detail {
           }
 
           auto& bundle = bundles[0];
-          auto const& spec = bundle.spec;
-          auto node =
-            std::make_unique<provider_node>(spec.creator(),
-                                            bundle.max_concurrency.value,
-                                            g,
-                                            std::move(bundle.provider_function),
-                                            spec,
-                                            phlex::experimental::identifier{bundle.layer},
-                                            phlex::experimental::identifier{bundle.stage});
+          auto node = std::make_unique<provider_node>(g, std::move(bundle));
           auto const provider_name = node->name().to_string();
           auto [_, inserted] =
             provider_input_ports.try_emplace(provider_name, input_product, node->input_port());

--- a/phlex/core/provider_node.cpp
+++ b/phlex/core/provider_node.cpp
@@ -13,7 +13,7 @@ namespace phlex::detail {
                   bundle.max_concurrency.value,
                   g,
                   std::move(bundle.provider_function),
-                  bundle.spec, // copied to avoid potential error reading from moved-from bundle
+                  std::move(bundle.spec), // safe: brace-init arguments are evaluated left-to-right
                   phlex::experimental::identifier{bundle.layer},
                   phlex::experimental::identifier{bundle.stage}}
   {

--- a/phlex/core/provider_node.cpp
+++ b/phlex/core/provider_node.cpp
@@ -8,6 +8,17 @@
 #include <utility>
 
 namespace phlex::detail {
+  provider_node::provider_node(tbb::flow::graph& g, provider_bundle bundle) :
+    provider_node{bundle.spec.creator(),
+                  bundle.max_concurrency.value,
+                  g,
+                  std::move(bundle.provider_function),
+                  bundle.spec, // copied to avoid potential error reading from moved-from bundle
+                  phlex::experimental::identifier{bundle.layer},
+                  phlex::experimental::identifier{bundle.stage}}
+  {
+  }
+
   provider_node::provider_node(phlex::experimental::algorithm_name algo_name,
                                std::size_t concurrency,
                                tbb::flow::graph& g,

--- a/phlex/core/provider_node.hpp
+++ b/phlex/core/provider_node.hpp
@@ -3,6 +3,7 @@
 
 #include "phlex/phlex_core_export.hpp"
 
+#include "phlex/concurrency.hpp"
 #include "phlex/core/message.hpp"
 #include "phlex/model/algorithm_name.hpp"
 #include "phlex/model/data_cell_index.hpp"
@@ -14,12 +15,27 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace phlex::detail {
 
+  // Function type for type-erased data-product types (used by implicit providers)
+  using provider_function = std::function<product_ptr(data_cell_index const&)>;
+
+  struct PHLEX_CORE_EXPORT provider_bundle {
+    phlex::detail::provider_function provider_function;
+    concurrency max_concurrency;
+    product_specification spec;
+    std::string layer;
+    std::string stage;
+  };
+
+  using provider_bundles = std::vector<provider_bundle>;
+
   class PHLEX_CORE_EXPORT provider_node {
   public:
-    using provider_function = std::function<product_ptr(data_cell_index const&)>;
+    provider_node(tbb::flow::graph& g, provider_bundle bundle);
 
     provider_node(phlex::experimental::algorithm_name algo_name,
                   std::size_t concurrency,

--- a/phlex/core/source.hpp
+++ b/phlex/core/source.hpp
@@ -3,8 +3,8 @@
 
 #include "phlex/phlex_core_export.hpp"
 
-#include "phlex/concurrency.hpp"
 #include "phlex/core/product_selector.hpp"
+#include "phlex/core/provider_node.hpp"
 #include "phlex/model/algorithm_name.hpp"
 #include "phlex/model/index_generator.hpp"
 #include "phlex/model/product_specification.hpp"
@@ -18,22 +18,6 @@
 
 namespace phlex::detail {
 
-  // ==============================================================================
-
-  // Function type for type-erased data-product types (used by implicit providers)
-  using provider_function_t = product_ptr(data_cell_index const&);
-
-  struct PHLEX_CORE_EXPORT provider_bundle {
-    std::function<provider_function_t> provider_function;
-    concurrency max_concurrency;
-    product_specification spec;
-    std::string layer;
-    std::string stage;
-  };
-
-  using provider_bundles = std::vector<provider_bundle>;
-
-  // ==============================================================================
   class PHLEX_CORE_EXPORT source {
   public:
     virtual ~source() = default;


### PR DESCRIPTION
Resolves #642.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Provider construction:** Simplified implicit provider creation by introducing `provider_bundle` and constructing `provider_node` directly from the bundle.
- **API organization:** Moved `provider_function` and provider bundle types to namespace scope, and added the corresponding `provider_node` constructor.
- **Initialization cleanup:** Replaced explicit `std::function` wrapping with direct callable assignment while preserving concurrency, specification, layer, and stage values.
- **Header dependencies:** Consolidated provider-related type definitions in `provider_node.hpp` and updated `source.hpp` to consume them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->