### PR TITLE
Post CodeQL comment only when PR creates a new alert or resolves an existing one

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -357,8 +357,8 @@ jobs:
 
       - name: Prepare PR comment data
         if: >-
-          github.event_name == 'pull_request' && (steps.check_codeql.outputs.new_alerts == 'true' ||
-          steps.check_codeql.outputs.fixed_alerts == 'true') && steps.check_codeql.outputs.comment_path != ''
+          github.event_name == 'pull_request' && (steps.check_codeql.outputs.new_vs_base == 'true' ||
+          steps.check_codeql.outputs.fixed_vs_base == 'true') && steps.check_codeql.outputs.comment_path != ''
         env:
           COMMENT_PATH: ${{ steps.check_codeql.outputs.comment_path }}
         run: |
@@ -368,8 +368,8 @@ jobs:
 
       - name: Upload PR comment data
         if: >-
-          github.event_name == 'pull_request' && (steps.check_codeql.outputs.new_alerts == 'true' ||
-          steps.check_codeql.outputs.fixed_alerts == 'true') && steps.check_codeql.outputs.comment_path != ''
+          github.event_name == 'pull_request' && (steps.check_codeql.outputs.new_vs_base == 'true' ||
+          steps.check_codeql.outputs.fixed_vs_base == 'true') && steps.check_codeql.outputs.comment_path != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codeql-pr-data

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -357,7 +357,8 @@ jobs:
 
       - name: Prepare PR comment data
         if: >-
-          github.event_name == 'pull_request' && steps.check_codeql.outputs.comment_path != ''
+          github.event_name == 'pull_request' && steps.check_codeql.outputs.new_alerts == 'true' &&
+          steps.check_codeql.outputs.comment_path != ''
         env:
           COMMENT_PATH: ${{ steps.check_codeql.outputs.comment_path }}
         run: |
@@ -367,7 +368,8 @@ jobs:
 
       - name: Upload PR comment data
         if: >-
-          github.event_name == 'pull_request' && steps.check_codeql.outputs.comment_path != ''
+          github.event_name == 'pull_request' && steps.check_codeql.outputs.new_alerts == 'true' &&
+          steps.check_codeql.outputs.comment_path != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codeql-pr-data

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -357,8 +357,8 @@ jobs:
 
       - name: Prepare PR comment data
         if: >-
-          github.event_name == 'pull_request' && steps.check_codeql.outputs.new_alerts == 'true' &&
-          steps.check_codeql.outputs.comment_path != ''
+          github.event_name == 'pull_request' && (steps.check_codeql.outputs.new_alerts == 'true' ||
+          steps.check_codeql.outputs.fixed_alerts == 'true') && steps.check_codeql.outputs.comment_path != ''
         env:
           COMMENT_PATH: ${{ steps.check_codeql.outputs.comment_path }}
         run: |
@@ -368,8 +368,8 @@ jobs:
 
       - name: Upload PR comment data
         if: >-
-          github.event_name == 'pull_request' && steps.check_codeql.outputs.new_alerts == 'true' &&
-          steps.check_codeql.outputs.comment_path != ''
+          github.event_name == 'pull_request' && (steps.check_codeql.outputs.new_alerts == 'true' ||
+          steps.check_codeql.outputs.fixed_alerts == 'true') && steps.check_codeql.outputs.comment_path != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codeql-pr-data

--- a/scripts/check_codeql_alerts.py
+++ b/scripts/check_codeql_alerts.py
@@ -869,6 +869,8 @@ def set_outputs(
     new_alerts: collections.abc.Sequence[Alert],
     fixed_alerts: collections.abc.Sequence[Alert],
     comment_path: Path | None,
+    new_vs_base: collections.abc.Sequence[Alert] | None = None,
+    fixed_vs_base: collections.abc.Sequence[Alert] | None = None,
 ) -> None:
     """Sets the GitHub action outputs.
 
@@ -876,6 +878,8 @@ def set_outputs(
         new_alerts: A list of new alerts.
         fixed_alerts: A list of fixed alerts.
         comment_path: The path to the comment file.
+        new_vs_base: Alerts newly introduced since PR base, if available.
+        fixed_vs_base: Alerts fixed since PR base, if available.
     """
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:
@@ -885,6 +889,10 @@ def set_outputs(
         handle.write(f"alert_count={len(new_alerts)}\n")
         handle.write(f"fixed_alerts={'true' if fixed_alerts else 'false'}\n")
         handle.write(f"fixed_count={len(fixed_alerts)}\n")
+        handle.write(f"new_vs_base={'true' if new_vs_base else 'false'}\n")
+        handle.write(f"new_vs_base_count={len(new_vs_base or [])}\n")
+        handle.write(f"fixed_vs_base={'true' if fixed_vs_base else 'false'}\n")
+        handle.write(f"fixed_vs_base_count={len(fixed_vs_base or [])}\n")
         if comment_path:
             handle.write(f"comment_path={comment_path}\n")
         else:
@@ -1290,12 +1298,20 @@ def main(argv: collections.abc.Sequence[str] | None = None) -> int:
             max_results=args.max_results,
             threshold=min_level,
         )
-        set_outputs(new_alerts=new_alerts, fixed_alerts=fixed_alerts, comment_path=comment_path)
+        set_outputs(
+            new_alerts=new_alerts,
+            fixed_alerts=fixed_alerts,
+            comment_path=comment_path,
+            new_vs_base=(api_comp.new_vs_base if api_comp else []),
+            fixed_vs_base=(api_comp.fixed_vs_base if api_comp else []),
+        )
         print(comment_body)
         return 0
 
     print("No new or resolved CodeQL alerts past the configured threshold.")
-    set_outputs(new_alerts=[], fixed_alerts=[], comment_path=None)
+    set_outputs(
+        new_alerts=[], fixed_alerts=[], comment_path=None, new_vs_base=[], fixed_vs_base=[]
+    )
     return 0
 
 

--- a/scripts/check_codeql_alerts.py
+++ b/scripts/check_codeql_alerts.py
@@ -909,16 +909,14 @@ def _compare_alerts_via_api(
     owner: str, repo: str, ref: str, *, min_level: str = "warning"
 ) -> APIAlertComparison:
     """Compare alerts between a ref and the main branch using the GitHub API."""
-    # Fetch alerts for the PR merge ref (fixed) and for the repo default state (open)
-    pr_alerts_raw = list(_paginate_alerts_api(owner, repo, state="open", ref=ref))
-    _debug(f"Fetched {len(pr_alerts_raw)} alerts for ref={ref}")
-    main_alerts_raw = list(_paginate_alerts_api(owner, repo, state="open", ref=None))
-    _debug(f"Fetched {len(main_alerts_raw)} alerts for repo (main)")
-
-    # Also fetch alerts at the PR base (branch point) when possible
+    # Fetch PR metadata first so we can use the head SHA when querying PR alerts.
+    # The Code Scanning API does not support synthetic merge refs such as
+    # refs/pull/N/merge; using that ref returns zero results.  The head SHA is
+    # the correct stable identifier for the alerts recorded against the PR.
     base_ref: str | None = None
     prev_commit_ref: str | None = None
     base_sha: str | None = None
+    head_sha: str | None = None
     base_alerts_raw: list[dict] = []
     prev_alerts_raw: list[dict] = []
     if ref.startswith("refs/pull/"):
@@ -927,6 +925,7 @@ def _compare_alerts_via_api(
             pr_info = _api_request("GET", f"/repos/{owner}/{repo}/pulls/{pr_num}")
             base_ref = pr_info.get("base", {}).get("ref")
             base_sha = pr_info.get("base", {}).get("sha")
+            head_sha = pr_info.get("head", {}).get("sha")
             # Determine previous commit on PR if available
             commits = _api_request("GET", f"/repos/{owner}/{repo}/pulls/{pr_num}/commits") or []
             if isinstance(commits, list) and len(commits) >= 2:
@@ -937,25 +936,33 @@ def _compare_alerts_via_api(
             base_ref = None
             prev_commit_ref = None
 
-        if base_ref or base_sha:
-            try:
-                # prefer base SHA if available
-                base_target = base_sha or base_ref
-                base_alerts_raw = list(
-                    _paginate_alerts_api(owner, repo, state="open", ref=base_target)
-                )
-                _debug(f"Fetched {len(base_alerts_raw)} alerts for base {base_target}")
-            except GitHubAPIError as exc:
-                _debug(f"Failed to fetch base alerts ({base_target}): {exc}")
+    # Use the head SHA to query open alerts for the PR; fall back to the
+    # original ref only when head_sha could not be determined.
+    pr_ref = head_sha or ref
+    pr_alerts_raw = list(_paginate_alerts_api(owner, repo, state="open", ref=pr_ref))
+    _debug(f"Fetched {len(pr_alerts_raw)} alerts for ref={pr_ref}")
+    main_alerts_raw = list(_paginate_alerts_api(owner, repo, state="open", ref=None))
+    _debug(f"Fetched {len(main_alerts_raw)} alerts for repo (main)")
 
-        if prev_commit_ref:
-            try:
-                prev_alerts_raw = list(
-                    _paginate_alerts_api(owner, repo, state="open", ref=prev_commit_ref)
-                )
-                _debug(f"Fetched {len(prev_alerts_raw)} alerts for prev commit {prev_commit_ref}")
-            except GitHubAPIError as exc:
-                _debug(f"Failed to fetch previous-commit alerts ({prev_commit_ref}): {exc}")
+    if base_ref or base_sha:
+        try:
+            # prefer base SHA if available
+            base_target = base_sha or base_ref
+            base_alerts_raw = list(
+                _paginate_alerts_api(owner, repo, state="open", ref=base_target)
+            )
+            _debug(f"Fetched {len(base_alerts_raw)} alerts for base {base_target}")
+        except GitHubAPIError as exc:
+            _debug(f"Failed to fetch base alerts ({base_target}): {exc}")
+
+    if prev_commit_ref:
+        try:
+            prev_alerts_raw = list(
+                _paginate_alerts_api(owner, repo, state="open", ref=prev_commit_ref)
+            )
+            _debug(f"Fetched {len(prev_alerts_raw)} alerts for prev commit {prev_commit_ref}")
+        except GitHubAPIError as exc:
+            _debug(f"Failed to fetch previous-commit alerts ({prev_commit_ref}): {exc}")
 
     def alert_key(a: Alert) -> tuple[str, str]:
         # Prefer alert number as it is the stable, per-alert unique identifier in

--- a/scripts/test/test_check_codeql_alerts.py
+++ b/scripts/test/test_check_codeql_alerts.py
@@ -922,15 +922,21 @@ class TestCompareAlertsViaApi:
 
         return MagicMock(side_effect=_paginate)
 
+    HEAD_SHA = "deadbeef" * 5  # 40-char hex head SHA used by all PR tests
+
     def _pr_info(self, base_ref: str = "main", base_sha: str = "abc1234") -> dict:
-        return {"base": {"ref": base_ref, "sha": base_sha}}
+        return {
+            "base": {"ref": base_ref, "sha": base_sha},
+            "head": {"sha": self.HEAD_SHA},
+        }
 
     @patch("check_codeql_alerts._api_request")
     @patch("check_codeql_alerts._paginate_alerts_api")
     def test_new_alert_detected(self, mock_pag: MagicMock, mock_req: MagicMock) -> None:
         """New alert detected."""
         pr_alert = _make_api_alert(number=1, analysis_key="ak:1")
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [pr_alert], None: []})
+        # PR alerts are fetched by head SHA, not the merge ref
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [pr_alert], None: []})
         mock_req.side_effect = [
             self._pr_info(),  # pulls/{n}
             [{"sha": "prev000"}],  # pulls/{n}/commits (only 1 commit → no prev)
@@ -944,7 +950,7 @@ class TestCompareAlertsViaApi:
     def test_fixed_alert_detected(self, mock_pag: MagicMock, mock_req: MagicMock) -> None:
         """Fixed alert detected."""
         main_alert = _make_api_alert(number=2, analysis_key="ak:2")
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [], None: [main_alert]})
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [], None: [main_alert]})
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge")
         assert len(result.fixed_alerts) == 1
@@ -955,7 +961,7 @@ class TestCompareAlertsViaApi:
     def test_matched_alert(self, mock_pag: MagicMock, mock_req: MagicMock) -> None:
         """Matched alert."""
         alert = _make_api_alert(number=3, analysis_key="ak:3")
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [alert], None: [alert]})
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [alert], None: [alert]})
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge")
         assert len(result.new_alerts) == 0
@@ -967,7 +973,7 @@ class TestCompareAlertsViaApi:
     def test_min_level_filters_new_alerts(self, mock_pag: MagicMock, mock_req: MagicMock) -> None:
         """Min level filters new alerts."""
         note_alert = _make_api_alert(number=5, severity="note", analysis_key="ak:5")
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [note_alert], None: []})
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [note_alert], None: []})
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api(
             "owner", "repo", "refs/pull/7/merge", min_level="warning"
@@ -979,7 +985,7 @@ class TestCompareAlertsViaApi:
     def test_min_level_none_includes_notes(self, mock_pag: MagicMock, mock_req: MagicMock) -> None:
         """Min level none includes notes."""
         note_alert = _make_api_alert(number=5, severity="note", analysis_key="ak:5")
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [note_alert], None: []})
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [note_alert], None: []})
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge", min_level="none")
         assert len(result.new_alerts) == 1
@@ -993,14 +999,14 @@ class TestCompareAlertsViaApi:
         # The script uses commits[-2]["sha"], so with [older, prev] that is "older_sha".
         mock_pag.side_effect = self._mock_paginate(
             {
-                "refs/pull/7/merge": [pr_only],
+                self.HEAD_SHA: [pr_only],  # PR alerts fetched by head SHA
                 None: [],
                 "older_sha": [prev_only],  # key must match commits[-2]["sha"]
             }
         )
         mock_req.side_effect = [
             self._pr_info(),
-            [{"sha": "older_sha"}, {"sha": "head_sha"}],  # 2 commits; [-2] = "older_sha"
+            [{"sha": "older_sha"}, {"sha": self.HEAD_SHA}],  # 2 commits; [-2] = "older_sha"
         ]
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge")
         assert len(result.new_vs_prev) == 1
@@ -1016,7 +1022,7 @@ class TestCompareAlertsViaApi:
         pr_only = _make_api_alert(number=21, analysis_key="ak:21")
         mock_pag.side_effect = self._mock_paginate(
             {
-                "refs/pull/7/merge": [pr_only],
+                self.HEAD_SHA: [pr_only],  # PR alerts fetched by head SHA
                 None: [],
                 "abc1234": [base_only],  # base_sha from _pr_info
             }
@@ -1038,6 +1044,7 @@ class TestCompareAlertsViaApi:
         self, mock_pag: MagicMock, mock_req: MagicMock
     ) -> None:
         """Api error on pr info is handled."""
+        # When PR info fetch fails, head_sha is None so the merge ref is used as fallback
         mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [], None: []})
         mock_req.side_effect = M.GitHubAPIError("404 not found")
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge")
@@ -1069,7 +1076,7 @@ class TestCompareAlertsViaApi:
         """
         note_alert = _make_api_alert(number=6, severity="note", analysis_key="ak:6")
         # note_alert exists on main but not on the PR → it is "fixed"
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [], None: [note_alert]})
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [], None: [note_alert]})
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api(
             "owner", "repo", "refs/pull/7/merge", min_level="warning"
@@ -1096,7 +1103,7 @@ class TestCompareAlertsViaApi:
         main_alert_c = _make_api_alert(number=12, analysis_key=shared_ak)
         # PR fixes all three
         mock_pag.side_effect = self._mock_paginate(
-            {"refs/pull/7/merge": [], None: [main_alert_a, main_alert_b, main_alert_c]}
+            {self.HEAD_SHA: [], None: [main_alert_a, main_alert_b, main_alert_c]}
         )
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge")


### PR DESCRIPTION
Right now, there is a CodeQL comment for every PR even if that PR does not create or resolve any alerts (see
https://github.com/Framework-R-D/phlex/pull/710#issuecomment-4974282826). This PR fixes that by:

1. Comparing alerts against the **PR base commit** rather than against the current default branch, and
2. Only posting a comment when that comparison shows a net change (new or resolved alerts).

----

## Changes

### `scripts/check_codeql_alerts.py`

- **Fix for a latent bug in `_compare_alerts_via_api`**: the function previously queried the Code Scanning API using the synthetic `refs/pull/N/merge` ref to retrieve open alerts for the PR.  That ref is not supported by the API and returns zero results, which caused every alert present on the base branch to be misreported as "fixed by the PR".  The fix fetches PR metadata (via `GET /repos/{owner}/{repo}/pulls/{n}`) first so that the PR's **head SHA** is available, then uses that SHA — which the API does support — to query the PR's open alerts.

- **New `set_outputs` parameters `new_vs_base` / `fixed_vs_base`**: exposes the count and boolean flag for alerts that are new or fixed *relative to the PR base commit*, in addition to the existing `new_alerts` / `fixed_alerts` outputs (which compare against the repository default branch).

### `.github/workflows/codeql-analysis.yaml`

- **Guard the "Prepare PR comment data" and "Upload PR comment data" steps** behind `new_vs_base == 'true' || fixed_vs_base == 'true'`.  Previously these steps ran whenever `comment_path` was non-empty, which was true even when the PR had no alert changes relative to its base.  Now a comment is only prepared and posted when the PR actually introduces or resolves at least one alert with respect to its branch point.

### `scripts/test/test_check_codeql_alerts.py`

- Updated `TestCompareAlertsViaApi._pr_info` to include a `head` SHA so that tests reflect the real API response shape.
- Updated all `_mock_paginate` dispatch tables to key PR-side alerts on `HEAD_SHA` (the head commit SHA) rather than `"refs/pull/7/merge"`, so tests actually exercise the corrected alert-fetch path.