### PR TITLE
Forward instead of move in product_selector converting constructors

### DIFF
--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -28,8 +28,7 @@ namespace phlex {
       template <typename U>
         requires std::constructible_from<T, U>
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
-      creator_name(U&& rhs) : // NOLINT(cppcoreguidelines-missing-std-forward)
-        content_(std::forward_like<T>(rhs))
+      creator_name(U&& rhs) : content_(std::forward<U>(rhs))
       {
         if (content_.value().empty()) {
           throw std::runtime_error("Cannot specify product with empty creator name.");
@@ -59,8 +58,7 @@ namespace phlex {
       template <typename U>
         requires std::constructible_from<T, U>
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
-      required_layer_name(U&& rhs) : // NOLINT(cppcoreguidelines-missing-std-forward)
-        content_(std::forward_like<T>(rhs))
+      required_layer_name(U&& rhs) : content_(std::forward<U>(rhs))
       {
         if (content_.empty()) {
           throw std::runtime_error("Cannot specify the empty string as a data layer.");

--- a/test/product_selector.cpp
+++ b/test/product_selector.cpp
@@ -3,6 +3,8 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"
 
+#include <string>
+
 using namespace phlex;
 
 TEST_CASE("Empty specifications", "[data model]")
@@ -40,4 +42,29 @@ TEST_CASE("Product name with data layer", "[data model]")
   // Here for no reason other than to satisfy codecov
   CHECK(label == label);
   CHECK((label <=> label) == std::strong_ordering::equal);
+}
+
+// Regression test for issue #707: the converting constructors of creator_name and
+// required_layer_name once moved from their lvalue arguments, silently emptying them.
+// Do not remove this test on the assumption that "specifying an lvalue as an argument
+// can't possibly nullify it" -- that is exactly the bug this guards against.
+TEST_CASE("Selectors do not move from lvalue arguments", "[data model]")
+{
+  experimental::identifier const expected_creator{"creator"};
+  experimental::identifier creator{"creator"};
+  experimental::identifier layer{"event"};
+  std::string layer_string{"event"};
+
+  product_selector first{.creator = creator, .layer = layer, .suffix = "a"_id};
+  // The sources must be intact after the first use...
+  CHECK(creator == expected_creator);
+  CHECK(!layer.empty());
+  // ...so that reusing them does not throw an empty-name error.
+  product_selector second{.creator = creator, .layer = layer, .suffix = "b"_id};
+  CHECK(first.creator == second.creator);
+  CHECK(first.layer == second.layer);
+
+  product_selector from_string{.creator = creator, .layer = layer_string};
+  CHECK(layer_string == "event");
+  CHECK(from_string.layer == second.layer);
 }


### PR DESCRIPTION
The converting constructors of creator_name and required_layer_name used std::forward_like<T>(rhs) with T = experimental::identifier. Since std::forward_like takes its value category from T, a non-reference type, this cast the argument to an rvalue unconditionally, moving from lvalue identifier and std::string arguments and silently emptying them. The next selector built from the same variable then failed its emptiness check, throwing a confusing empty-creator/empty-layer error far from the responsible line.

Use std::forward<U>(rhs) instead, which copies from lvalues and moves from rvalues, and drop the NOLINT that suppressed the clang-tidy check (cppcoreguidelines-missing-std-forward) that had flagged exactly this.

Add a regression test that reuses lvalue identifier and std::string arguments across several selectors.

Fixes #707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code:** Updated `creator_name` and `required_layer_name` constructors to copy lvalues and move rvalues via `std::forward<U>`, preventing reused identifiers and layer names from being emptied.
- **Tests:** Added regression coverage confirming lvalue `experimental::identifier` and `std::string` arguments remain intact and can be reused across multiple `product_selector` instances.
- **Code quality:** Removed the corresponding clang-tidy suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->