### PR TITLE
Make RNTuple Read All File Entries

### DIFF
--- a/form/form/form_source_type_registry.hpp
+++ b/form/form/form_source_type_registry.hpp
@@ -44,7 +44,8 @@ namespace form::experimental {
         throw std::runtime_error("FORM Error: Failed to retrieve product [" + product_name +
                                  "] for " + index_str);
       }
-      return phlex::detail::product_for(*static_cast<product_type_t const*>(data));
+      std::unique_ptr<product_type_t const> dataWithType(static_cast<product_type_t const*>(data));
+      return phlex::detail::product_for(std::move(*dataWithType));
     };
 
     register_form_product_type(std::move(product_type),

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -97,8 +97,9 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
   if (m_branch == nullptr) {
     throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::read no branch found");
   }
-  if (id >= m_tree->GetEntries())
+  if (id >= m_tree->GetEntries()) {
     return false;
+  }
 
   gsl::owner<void*> branchBuffer = nullptr;
   auto dictInfo = TDictionary::GetDictionary(type);

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -97,7 +97,7 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
   if (m_branch == nullptr) {
     throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::read no branch found");
   }
-  if (id > m_tree->GetEntries())
+  if (id >= m_tree->GetEntries())
     return false;
 
   gsl::owner<void*> branchBuffer = nullptr;

--- a/form/storage/storage_reader.cpp
+++ b/form/storage/storage_reader.cpp
@@ -159,7 +159,7 @@ namespace {
   std::optional<int> sequential_row_from_index_id(std::string const& id)
   {
     if (id == "[]") {
-      return 1;
+      return 0;
     }
 
     if (id.size() < 2 || id.front() != '[' || id.back() != ']') {
@@ -179,7 +179,7 @@ namespace {
 
     try {
       auto const number = std::stoi(body.substr(colon + 1));
-      return number + 1;
+      return number;
     } catch (...) {
       return std::nullopt;
     }
@@ -223,7 +223,7 @@ int StorageReader::getIndex(Token const& token,
       cont->second->setFile(file->second);
     }
     auto const& type = typeid(std::string);
-    int entry = 1;
+    int entry = 0;
     void const* rawData = nullptr;
     while (cont->second->read(entry, &rawData, type)) {
       std::unique_ptr<std::string const> data(static_cast<std::string const*>(rawData));
@@ -326,7 +326,7 @@ std::vector<std::string> StorageReader::listIndices(
     }
 
     auto const& type = typeid(std::string);
-    int entry = 1;
+    int entry = 0;
     void const* rawData = nullptr;
     while (cont->second->read(entry, &rawData, type)) {
       std::unique_ptr<std::string const> data(static_cast<std::string const*>(rawData));

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -397,9 +397,6 @@ TEST_CASE("StorageReader getIndex: malformed ids and compatibility fallbacks", "
   CHECK_THROWS_AS(
     reader.getIndex(index_token, "[EVENT=99999999999999999999999999999999]", settings),
     std::runtime_error);
-  //We still accept commas in an index string for now.  But we may want to restore this logic one day soon.
-  /*CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT=00000001,SEG=00000002]", settings),
-                  std::runtime_error);*/
   CHECK_THROWS_AS(reader.getIndex(index_token, "[=00000001]", settings), std::runtime_error);
   CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT]", settings), std::runtime_error);
   CHECK_THROWS_AS(reader.getIndex(index_token, "[    ]", settings), std::runtime_error);

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -397,8 +397,9 @@ TEST_CASE("StorageReader getIndex: malformed ids and compatibility fallbacks", "
   CHECK_THROWS_AS(
     reader.getIndex(index_token, "[EVENT=99999999999999999999999999999999]", settings),
     std::runtime_error);
-  CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT=00000001,SEG=00000002]", settings),
-                  std::runtime_error);
+  //We still accept commas in an index string for now.  But we may want to restore this logic one day soon.
+  /*CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT=00000001,SEG=00000002]", settings),
+                  std::runtime_error);*/
   CHECK_THROWS_AS(reader.getIndex(index_token, "[=00000001]", settings), std::runtime_error);
   CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT]", settings), std::runtime_error);
   CHECK_THROWS_AS(reader.getIndex(index_token, "[    ]", settings), std::runtime_error);
@@ -490,11 +491,7 @@ TEST_CASE("StorageReader prime/listIndices/readContainer: attribute and error br
   tech_setting_config container_attr_settings;
   container_attr_settings.container_settings[technology][creator + "/index"] = {{"split", "0"}};
 
-  if (form::technology::GetMinor(technology) == form::technology::ROOT_RNTUPLE_MINOR) {
-    CHECK_THROWS_AS(reader.listIndices(index_token, container_attr_settings), std::runtime_error);
-  } else {
-    CHECK_NOTHROW(reader.listIndices(index_token, container_attr_settings));
-  }
+  CHECK_NOTHROW(reader.listIndices(index_token, container_attr_settings));
   CHECK_NOTHROW(reader.readContainer(Token{file_name, creator + "/prod", technology, 0},
                                      &raw,
                                      typeid(std::vector<int>),

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -389,7 +389,7 @@ TEST_CASE("StorageReader getIndex: malformed ids and compatibility fallbacks", "
   Token const index_token{file_name, index_container, technology};
   tech_setting_config const settings{};
 
-  CHECK(reader.getIndex(index_token, "[]", settings) == 1);
+  CHECK(reader.getIndex(index_token, "[]", settings) == 0);
   CHECK(reader.getIndex(index_token, "plain-text-id", settings) == 0);
 
   CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT,SEG=00000001]", settings),


### PR DESCRIPTION
FORM's RNTuple backend needs a little help to read the last entry in a FORM file.  The Storage layer was using 1-based indexing to refer to entries.  This PR transitions the Storage layer to 0-based indexing which allows the RNTuple backend to read all entries in an input file.  FORM's TTree backend is also updated to work with 0-based indexing.  Moving from 1-based indexing to 0-based indexing also requires updates to one of our tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Updated FORM storage indexing from 1-based to 0-based across `StorageReader`.
  - Corrected TTree bounds checking so the final valid entry is accepted while `GetEntries()` is rejected.
  - Fixed a memory leak in the FORM source.
  - Removed an obsolete comment related to a deleted index-string test.

- **Tests**
  - Updated storage expectations for zero-based index parsing and enumeration.
  - Added coverage for reading the final RNTuple entry.
  - Simplified backend-independent `listIndices` checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->