### PR TITLE
build: update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,14 +13,14 @@ repos:
       - id: check-executables-have-shebangs
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.19
+    rev: v0.15.22
     hooks:
       - id: ruff-format
         types_or: [python, pyi]
       - id: ruff
         types_or: [python, pyi]
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v20.1.8
+    rev: 182152eb8c5ce1cf5299b956b04392c86bd8a126 # frozen: v20.1.8
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
@@ -54,12 +54,12 @@ repos:
         # We therefore exclude them from linting, but still format them.
         exclude: ^test/max-parallelism
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.4
+    rev: v3.9.5
     hooks:
       - id: prettier
         types_or: [yaml]
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.22.1
+    rev: v0.23.0
     hooks:
       - id: markdownlint-cli2
         args: [--fix]


### PR DESCRIPTION
Update versions for the following hooks:
- ruff: v0.15.19 -> v0.15.22
- clang-format: v20.1.8 -> 182152e (frozen)
- prettier: v3.8.4 -> v3.9.5
- markdownlint-cli2: v0.22.1 -> v0.23.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code quality:** Updated pinned pre-commit hook versions for Ruff, Clang-format, Prettier, and markdownlint-cli2.
- **Reproducibility:** Pinned Clang-format to revision `182152e` while preserving its frozen-version comment.
- **Scope:** Hook IDs and argument configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->