### PR TITLE
Sync `main` with `v0.3.2`

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -357,7 +357,8 @@ jobs:
 
       - name: Prepare PR comment data
         if: >-
-          github.event_name == 'pull_request' && steps.check_codeql.outputs.comment_path != ''
+          github.event_name == 'pull_request' && (steps.check_codeql.outputs.new_vs_base == 'true' ||
+          steps.check_codeql.outputs.fixed_vs_base == 'true') && steps.check_codeql.outputs.comment_path != ''
         env:
           COMMENT_PATH: ${{ steps.check_codeql.outputs.comment_path }}
         run: |
@@ -367,7 +368,8 @@ jobs:
 
       - name: Upload PR comment data
         if: >-
-          github.event_name == 'pull_request' && steps.check_codeql.outputs.comment_path != ''
+          github.event_name == 'pull_request' && (steps.check_codeql.outputs.new_vs_base == 'true' ||
+          steps.check_codeql.outputs.fixed_vs_base == 'true') && steps.check_codeql.outputs.comment_path != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codeql-pr-data

--- a/.github/workflows/markdown-fix.yaml
+++ b/.github/workflows/markdown-fix.yaml
@@ -100,7 +100,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
 

--- a/.github/workflows/yaml-fix.yaml
+++ b/.github/workflows/yaml-fix.yaml
@@ -101,7 +101,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20.x"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ find_package(cetmodules 4.01.01 REQUIRED)
 
 # ##############################################################################
 # Main project declaration
-project(phlex VERSION 0.3.1 LANGUAGES CXX)
+project(phlex VERSION 0.3.2 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ find_package(cetmodules 4.01.01 REQUIRED)
 
 # ##############################################################################
 # Main project declaration
-project(phlex VERSION 0.2.0 LANGUAGES CXX)
+project(phlex VERSION 0.3.0 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ find_package(cetmodules 4.01.01 REQUIRED)
 
 # ##############################################################################
 # Main project declaration
-project(phlex VERSION 0.3.0 LANGUAGES CXX)
+project(phlex VERSION 0.3.1 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -103,7 +103,7 @@ To guide the creation of the environment, download the environment configuration
 ```bash
 spack env create my-phlex-environment
 spack env activate my-phlex-environment
-spack add phlex@0.3.0 %%gcc@15
+spack add phlex@0.3.1 %%gcc@15
 spack concretize
 ```
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -103,7 +103,7 @@ To guide the creation of the environment, download the environment configuration
 ```bash
 spack env create my-phlex-environment
 spack env activate my-phlex-environment
-spack add phlex@0.3.1 %%gcc@15
+spack add phlex@0.3.2 %%gcc@15
 spack concretize
 ```
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -103,7 +103,7 @@ To guide the creation of the environment, download the environment configuration
 ```bash
 spack env create my-phlex-environment
 spack env activate my-phlex-environment
-spack add phlex %gcc@15
+spack add phlex@0.3.0 %%gcc@15
 spack concretize
 ```
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 project = "Phlex"
 copyright = "2025-2026, The Phlex Developers"
 author = "The Phlex Developers"
-release = "0.3.1"
+release = "0.3.2"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 project = "Phlex"
 copyright = "2025-2026, The Phlex Developers"
 author = "The Phlex Developers"
-release = "0.3.0"
+release = "0.3.1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 project = "Phlex"
 copyright = "2025-2026, The Phlex Developers"
 author = "The Phlex Developers"
-release = "0.2.0"
+release = "0.3.0"
 
 # -- General configuration ---------------------------------------------------
 

--- a/form/form/form_source_type_registry.hpp
+++ b/form/form/form_source_type_registry.hpp
@@ -44,7 +44,9 @@ namespace form::experimental {
         throw std::runtime_error("FORM Error: Failed to retrieve product [" + product_name +
                                  "] for " + index_str);
       }
-      return phlex::detail::product_for(*static_cast<product_type_t const*>(data));
+
+      auto ptr = std::unique_ptr<product_type_t const>(static_cast<product_type_t const*>(data));
+      return phlex::detail::product_for(*ptr);
     };
 
     register_form_product_type(std::move(product_type),

--- a/phlex/CMakeLists.txt
+++ b/phlex/CMakeLists.txt
@@ -34,7 +34,7 @@ cet_make_library(
   phlex::configuration
 )
 
-install(FILES concurrency.hpp module.hpp source.hpp DESTINATION include/phlex)
+install(FILES concurrency.hpp driver.hpp module.hpp source.hpp DESTINATION include/phlex)
 install(FILES detail/plugin_macros.hpp DESTINATION include/phlex/detail)
 
 cet_make_library(

--- a/phlex/core/make_computational_edges.cpp
+++ b/phlex/core/make_computational_edges.cpp
@@ -201,8 +201,6 @@ namespace phlex::detail {
       return {};
     }
 
-    edges_to_outputs(nodes.providers, producers, nodes.outputs);
-
     auto [explicit_provider_input_ports, unconsumed_head_ports] =
       edges_from_explicit_providers(std::move(head_ports), nodes.providers);
 
@@ -219,6 +217,9 @@ namespace phlex::detail {
       }
       throw std::runtime_error(error_msg);
     }
+
+    // Make edges to outputs after both implicit and explicit providers have been registered.
+    edges_to_outputs(nodes.providers, producers, nodes.outputs);
 
     // Combine implicit and explicit provider input ports.
     auto provider_input_ports = std::move(explicit_provider_input_ports);

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -28,8 +28,7 @@ namespace phlex {
       template <typename U>
         requires std::constructible_from<T, U>
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
-      creator_name(U&& rhs) : // NOLINT(cppcoreguidelines-missing-std-forward)
-        content_(std::forward_like<T>(rhs))
+      creator_name(U&& rhs) : content_(std::forward<U>(rhs))
       {
         if (content_.value().empty()) {
           throw std::runtime_error("Cannot specify product with empty creator name.");
@@ -59,8 +58,7 @@ namespace phlex {
       template <typename U>
         requires std::constructible_from<T, U>
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
-      required_layer_name(U&& rhs) : // NOLINT(cppcoreguidelines-missing-std-forward)
-        content_(std::forward_like<T>(rhs))
+      required_layer_name(U&& rhs) : content_(std::forward<U>(rhs))
       {
         if (content_.empty()) {
           throw std::runtime_error("Cannot specify the empty string as a data layer.");

--- a/scripts/check_codeql_alerts.py
+++ b/scripts/check_codeql_alerts.py
@@ -869,6 +869,8 @@ def set_outputs(
     new_alerts: collections.abc.Sequence[Alert],
     fixed_alerts: collections.abc.Sequence[Alert],
     comment_path: Path | None,
+    new_vs_base: collections.abc.Sequence[Alert] | None = None,
+    fixed_vs_base: collections.abc.Sequence[Alert] | None = None,
 ) -> None:
     """Sets the GitHub action outputs.
 
@@ -876,6 +878,8 @@ def set_outputs(
         new_alerts: A list of new alerts.
         fixed_alerts: A list of fixed alerts.
         comment_path: The path to the comment file.
+        new_vs_base: Alerts newly introduced since PR base, if available.
+        fixed_vs_base: Alerts fixed since PR base, if available.
     """
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:
@@ -885,6 +889,10 @@ def set_outputs(
         handle.write(f"alert_count={len(new_alerts)}\n")
         handle.write(f"fixed_alerts={'true' if fixed_alerts else 'false'}\n")
         handle.write(f"fixed_count={len(fixed_alerts)}\n")
+        handle.write(f"new_vs_base={'true' if new_vs_base else 'false'}\n")
+        handle.write(f"new_vs_base_count={len(new_vs_base or [])}\n")
+        handle.write(f"fixed_vs_base={'true' if fixed_vs_base else 'false'}\n")
+        handle.write(f"fixed_vs_base_count={len(fixed_vs_base or [])}\n")
         if comment_path:
             handle.write(f"comment_path={comment_path}\n")
         else:
@@ -901,16 +909,14 @@ def _compare_alerts_via_api(
     owner: str, repo: str, ref: str, *, min_level: str = "warning"
 ) -> APIAlertComparison:
     """Compare alerts between a ref and the main branch using the GitHub API."""
-    # Fetch alerts for the PR merge ref (fixed) and for the repo default state (open)
-    pr_alerts_raw = list(_paginate_alerts_api(owner, repo, state="open", ref=ref))
-    _debug(f"Fetched {len(pr_alerts_raw)} alerts for ref={ref}")
-    main_alerts_raw = list(_paginate_alerts_api(owner, repo, state="open", ref=None))
-    _debug(f"Fetched {len(main_alerts_raw)} alerts for repo (main)")
-
-    # Also fetch alerts at the PR base (branch point) when possible
+    # Fetch PR metadata first so we can use the head SHA when querying PR alerts.
+    # The Code Scanning API does not support synthetic merge refs such as
+    # refs/pull/N/merge; using that ref returns zero results.  The head SHA is
+    # the correct stable identifier for the alerts recorded against the PR.
     base_ref: str | None = None
     prev_commit_ref: str | None = None
     base_sha: str | None = None
+    head_sha: str | None = None
     base_alerts_raw: list[dict] = []
     prev_alerts_raw: list[dict] = []
     if ref.startswith("refs/pull/"):
@@ -919,6 +925,7 @@ def _compare_alerts_via_api(
             pr_info = _api_request("GET", f"/repos/{owner}/{repo}/pulls/{pr_num}")
             base_ref = pr_info.get("base", {}).get("ref")
             base_sha = pr_info.get("base", {}).get("sha")
+            head_sha = pr_info.get("head", {}).get("sha")
             # Determine previous commit on PR if available
             commits = _api_request("GET", f"/repos/{owner}/{repo}/pulls/{pr_num}/commits") or []
             if isinstance(commits, list) and len(commits) >= 2:
@@ -929,25 +936,33 @@ def _compare_alerts_via_api(
             base_ref = None
             prev_commit_ref = None
 
-        if base_ref or base_sha:
-            try:
-                # prefer base SHA if available
-                base_target = base_sha or base_ref
-                base_alerts_raw = list(
-                    _paginate_alerts_api(owner, repo, state="open", ref=base_target)
-                )
-                _debug(f"Fetched {len(base_alerts_raw)} alerts for base {base_target}")
-            except GitHubAPIError as exc:
-                _debug(f"Failed to fetch base alerts ({base_target}): {exc}")
+    # Use the head SHA to query open alerts for the PR; fall back to the
+    # original ref only when head_sha could not be determined.
+    pr_ref = head_sha or ref
+    pr_alerts_raw = list(_paginate_alerts_api(owner, repo, state="open", ref=pr_ref))
+    _debug(f"Fetched {len(pr_alerts_raw)} alerts for ref={pr_ref}")
+    main_alerts_raw = list(_paginate_alerts_api(owner, repo, state="open", ref=None))
+    _debug(f"Fetched {len(main_alerts_raw)} alerts for repo (main)")
 
-        if prev_commit_ref:
-            try:
-                prev_alerts_raw = list(
-                    _paginate_alerts_api(owner, repo, state="open", ref=prev_commit_ref)
-                )
-                _debug(f"Fetched {len(prev_alerts_raw)} alerts for prev commit {prev_commit_ref}")
-            except GitHubAPIError as exc:
-                _debug(f"Failed to fetch previous-commit alerts ({prev_commit_ref}): {exc}")
+    if base_ref or base_sha:
+        try:
+            # prefer base SHA if available
+            base_target = base_sha or base_ref
+            base_alerts_raw = list(
+                _paginate_alerts_api(owner, repo, state="open", ref=base_target)
+            )
+            _debug(f"Fetched {len(base_alerts_raw)} alerts for base {base_target}")
+        except GitHubAPIError as exc:
+            _debug(f"Failed to fetch base alerts ({base_target}): {exc}")
+
+    if prev_commit_ref:
+        try:
+            prev_alerts_raw = list(
+                _paginate_alerts_api(owner, repo, state="open", ref=prev_commit_ref)
+            )
+            _debug(f"Fetched {len(prev_alerts_raw)} alerts for prev commit {prev_commit_ref}")
+        except GitHubAPIError as exc:
+            _debug(f"Failed to fetch previous-commit alerts ({prev_commit_ref}): {exc}")
 
     def alert_key(a: Alert) -> tuple[str, str]:
         # Prefer alert number as it is the stable, per-alert unique identifier in
@@ -1290,12 +1305,20 @@ def main(argv: collections.abc.Sequence[str] | None = None) -> int:
             max_results=args.max_results,
             threshold=min_level,
         )
-        set_outputs(new_alerts=new_alerts, fixed_alerts=fixed_alerts, comment_path=comment_path)
+        set_outputs(
+            new_alerts=new_alerts,
+            fixed_alerts=fixed_alerts,
+            comment_path=comment_path,
+            new_vs_base=(api_comp.new_vs_base if api_comp else []),
+            fixed_vs_base=(api_comp.fixed_vs_base if api_comp else []),
+        )
         print(comment_body)
         return 0
 
     print("No new or resolved CodeQL alerts past the configured threshold.")
-    set_outputs(new_alerts=[], fixed_alerts=[], comment_path=None)
+    set_outputs(
+        new_alerts=[], fixed_alerts=[], comment_path=None, new_vs_base=[], fixed_vs_base=[]
+    )
     return 0
 
 

--- a/scripts/test/test_check_codeql_alerts.py
+++ b/scripts/test/test_check_codeql_alerts.py
@@ -922,15 +922,21 @@ class TestCompareAlertsViaApi:
 
         return MagicMock(side_effect=_paginate)
 
+    HEAD_SHA = "deadbeef" * 5  # 40-char hex head SHA used by all PR tests
+
     def _pr_info(self, base_ref: str = "main", base_sha: str = "abc1234") -> dict:
-        return {"base": {"ref": base_ref, "sha": base_sha}}
+        return {
+            "base": {"ref": base_ref, "sha": base_sha},
+            "head": {"sha": self.HEAD_SHA},
+        }
 
     @patch("check_codeql_alerts._api_request")
     @patch("check_codeql_alerts._paginate_alerts_api")
     def test_new_alert_detected(self, mock_pag: MagicMock, mock_req: MagicMock) -> None:
         """New alert detected."""
         pr_alert = _make_api_alert(number=1, analysis_key="ak:1")
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [pr_alert], None: []})
+        # PR alerts are fetched by head SHA, not the merge ref
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [pr_alert], None: []})
         mock_req.side_effect = [
             self._pr_info(),  # pulls/{n}
             [{"sha": "prev000"}],  # pulls/{n}/commits (only 1 commit → no prev)
@@ -944,7 +950,7 @@ class TestCompareAlertsViaApi:
     def test_fixed_alert_detected(self, mock_pag: MagicMock, mock_req: MagicMock) -> None:
         """Fixed alert detected."""
         main_alert = _make_api_alert(number=2, analysis_key="ak:2")
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [], None: [main_alert]})
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [], None: [main_alert]})
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge")
         assert len(result.fixed_alerts) == 1
@@ -955,7 +961,7 @@ class TestCompareAlertsViaApi:
     def test_matched_alert(self, mock_pag: MagicMock, mock_req: MagicMock) -> None:
         """Matched alert."""
         alert = _make_api_alert(number=3, analysis_key="ak:3")
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [alert], None: [alert]})
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [alert], None: [alert]})
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge")
         assert len(result.new_alerts) == 0
@@ -967,7 +973,7 @@ class TestCompareAlertsViaApi:
     def test_min_level_filters_new_alerts(self, mock_pag: MagicMock, mock_req: MagicMock) -> None:
         """Min level filters new alerts."""
         note_alert = _make_api_alert(number=5, severity="note", analysis_key="ak:5")
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [note_alert], None: []})
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [note_alert], None: []})
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api(
             "owner", "repo", "refs/pull/7/merge", min_level="warning"
@@ -979,7 +985,7 @@ class TestCompareAlertsViaApi:
     def test_min_level_none_includes_notes(self, mock_pag: MagicMock, mock_req: MagicMock) -> None:
         """Min level none includes notes."""
         note_alert = _make_api_alert(number=5, severity="note", analysis_key="ak:5")
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [note_alert], None: []})
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [note_alert], None: []})
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge", min_level="none")
         assert len(result.new_alerts) == 1
@@ -993,14 +999,14 @@ class TestCompareAlertsViaApi:
         # The script uses commits[-2]["sha"], so with [older, prev] that is "older_sha".
         mock_pag.side_effect = self._mock_paginate(
             {
-                "refs/pull/7/merge": [pr_only],
+                self.HEAD_SHA: [pr_only],  # PR alerts fetched by head SHA
                 None: [],
                 "older_sha": [prev_only],  # key must match commits[-2]["sha"]
             }
         )
         mock_req.side_effect = [
             self._pr_info(),
-            [{"sha": "older_sha"}, {"sha": "head_sha"}],  # 2 commits; [-2] = "older_sha"
+            [{"sha": "older_sha"}, {"sha": self.HEAD_SHA}],  # 2 commits; [-2] = "older_sha"
         ]
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge")
         assert len(result.new_vs_prev) == 1
@@ -1016,7 +1022,7 @@ class TestCompareAlertsViaApi:
         pr_only = _make_api_alert(number=21, analysis_key="ak:21")
         mock_pag.side_effect = self._mock_paginate(
             {
-                "refs/pull/7/merge": [pr_only],
+                self.HEAD_SHA: [pr_only],  # PR alerts fetched by head SHA
                 None: [],
                 "abc1234": [base_only],  # base_sha from _pr_info
             }
@@ -1038,6 +1044,7 @@ class TestCompareAlertsViaApi:
         self, mock_pag: MagicMock, mock_req: MagicMock
     ) -> None:
         """Api error on pr info is handled."""
+        # When PR info fetch fails, head_sha is None so the merge ref is used as fallback
         mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [], None: []})
         mock_req.side_effect = M.GitHubAPIError("404 not found")
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge")
@@ -1069,7 +1076,7 @@ class TestCompareAlertsViaApi:
         """
         note_alert = _make_api_alert(number=6, severity="note", analysis_key="ak:6")
         # note_alert exists on main but not on the PR → it is "fixed"
-        mock_pag.side_effect = self._mock_paginate({"refs/pull/7/merge": [], None: [note_alert]})
+        mock_pag.side_effect = self._mock_paginate({self.HEAD_SHA: [], None: [note_alert]})
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api(
             "owner", "repo", "refs/pull/7/merge", min_level="warning"
@@ -1096,7 +1103,7 @@ class TestCompareAlertsViaApi:
         main_alert_c = _make_api_alert(number=12, analysis_key=shared_ak)
         # PR fixes all three
         mock_pag.side_effect = self._mock_paginate(
-            {"refs/pull/7/merge": [], None: [main_alert_a, main_alert_b, main_alert_c]}
+            {self.HEAD_SHA: [], None: [main_alert_a, main_alert_b, main_alert_c]}
         )
         mock_req.side_effect = [self._pr_info(), [{"sha": "prev000"}]]
         result = M._compare_alerts_via_api("owner", "repo", "refs/pull/7/merge")

--- a/test/output_products.cpp
+++ b/test/output_products.cpp
@@ -6,7 +6,9 @@
 // =======================================================================================
 
 #include "phlex/core/framework_graph.hpp"
+#include "phlex/core/source.hpp"
 #include "phlex/model/data_cell_index.hpp"
+#include "phlex/model/products.hpp"
 #include "plugins/layer_generator.hpp"
 
 #include "catch2/catch_test_macros.hpp"
@@ -32,6 +34,35 @@ namespace {
   private:
     std::set<std::string>* products_;
   };
+
+  constexpr std::string brahms() { return "Brahms"; }
+
+  detail::product_ptr give_me_a_name(data_cell_index const&)
+  {
+    return detail::product_for(brahms());
+  }
+
+  class test_source : public detail::source {
+    detail::provider_bundles create_providers(product_selector const& selector) override
+    {
+      using namespace experimental;
+      using namespace phlex::detail;
+      provider_bundles bundles;
+      std::string const layer = "spill";
+      std::string const stage = "previous_process";
+      product_specification spec{"provide_name", "", make_type_id<std::string>()};
+
+      if (selector.match(spec, identifier{layer}, identifier{stage})) {
+        bundles.push_back(phlex::detail::provider_bundle{.provider_function = give_me_a_name,
+                                                         .max_concurrency = concurrency::unlimited,
+                                                         .spec = std::move(spec),
+                                                         .layer = layer,
+                                                         .stage = stage});
+      }
+      return bundles;
+    }
+    index_generator indices() override { co_return; }
+  };
 }
 
 TEST_CASE("Output data products", "[graph]")
@@ -41,6 +72,7 @@ TEST_CASE("Output data products", "[graph]")
 
   auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
+  g.add_source<test_source>("test_source");
 
   g.provide("provide_number", [](data_cell_index const&) -> int { return 17; })
     .output_product("input", "number_from_provider", "spill");
@@ -53,6 +85,12 @@ TEST_CASE("Output data products", "[graph]")
       product_selector{.creator = "input", .layer = "spill", .suffix = "number_from_provider"})
     .output_product_suffixes("squared_number");
 
+  // Create another node that requires a data product from an implicit provider.
+  // Concurrency must be serial because the CHECK macro cannot be invoked in a parallel context.
+  g.observe(
+     "read_name", [](std::string const& name) { CHECK(name == brahms()); }, concurrency::serial)
+    .input_family(product_selector{.creator = "provide_name", .layer = "spill"});
+
   std::set<std::string> products_from_nodes;
   g.make<product_recorder>(products_from_nodes)
     .output("record_numbers", &product_recorder::record, concurrency::serial);
@@ -61,10 +99,13 @@ TEST_CASE("Output data products", "[graph]")
 
   CHECK(g.execution_count("provide_number") == 1u);
   CHECK(g.execution_count("square_number") == 1u);
-  // The "record_numbers" output node should be executed twice: once to receive the data
-  // store from the "provide_number" provider, and once to receive the data store from the
-  // "square_number" transform.
-  CHECK(g.execution_count("record_numbers") == 2u);
-  CHECK(products_from_nodes ==
-        std::set<std::string>{"input/number_from_provider", "square_number/squared_number"});
+
+  // The "record_numbers" output node should be executed three times:
+  //   - once to receive the data store from the "provide_number" explicit provider,
+  //   - once to receive the data store from the "provide_name" implicit provider,
+  //   - once to receive the data store from the "square_number" transform.
+  CHECK(g.execution_count("record_numbers") == 3u);
+  CHECK(products_from_nodes == std::set<std::string>{"input/number_from_provider",
+                                                     "provide_name/",
+                                                     "square_number/squared_number"});
 }

--- a/test/product_selector.cpp
+++ b/test/product_selector.cpp
@@ -3,6 +3,8 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"
 
+#include <string>
+
 using namespace phlex;
 
 TEST_CASE("Empty specifications", "[data model]")
@@ -40,4 +42,29 @@ TEST_CASE("Product name with data layer", "[data model]")
   // Here for no reason other than to satisfy codecov
   CHECK(label == label);
   CHECK((label <=> label) == std::strong_ordering::equal);
+}
+
+// Regression test for issue #707: the converting constructors of creator_name and
+// required_layer_name once moved from their lvalue arguments, silently emptying them.
+// Do not remove this test on the assumption that "specifying an lvalue as an argument
+// can't possibly nullify it" -- that is exactly the bug this guards against.
+TEST_CASE("Selectors do not move from lvalue arguments", "[data model]")
+{
+  experimental::identifier const expected_creator{"creator"};
+  experimental::identifier creator{"creator"};
+  experimental::identifier layer{"event"};
+  std::string layer_string{"event"};
+
+  product_selector first{.creator = creator, .layer = layer, .suffix = "a"_id};
+  // The sources must be intact after the first use...
+  CHECK(creator == expected_creator);
+  CHECK(!layer.empty());
+  // ...so that reusing them does not throw an empty-name error.
+  product_selector second{.creator = creator, .layer = layer, .suffix = "b"_id};
+  CHECK(first.creator == second.creator);
+  CHECK(first.layer == second.layer);
+
+  product_selector from_string{.creator = creator, .layer = layer_string};
+  CHECK(layer_string == "event");
+  CHECK(from_string.layer == second.layer);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Release metadata:** Bumped project and documentation versions from `0.2.0` to `0.3.2`; updated installation instructions to pin `phlex@0.3.2`.
- **CI:** Improved CodeQL PR comment gating to require changes relative to the base branch. Updated `actions/setup-node` pins to `v7.0.0`.
- **Code:** Fixed product ownership handling during form registration, corrected forwarding of selector constructor arguments, reordered computational graph output-edge creation, and installed `driver.hpp` with public headers.
- **CodeQL tooling:** Added base-branch alert comparison outputs and switched PR alert queries to use the PR head SHA, with fallback and guarded comparison lookups.
- **Tests:** Added coverage for implicit providers and ensured selector construction does not move from lvalue arguments; updated CodeQL API-comparison mocks for head-SHA behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->