### PR TITLE
ci(coverage): re-enable push and pull_request triggers

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,9 +3,9 @@ name: Code Coverage
 run-name: "${{ github.actor }} running code coverage"
 
 "on":
-  #  push:
-  #    branches: [main, "release/*"]
-  #  pull_request:
+  push:
+    branches: [main, "release/*"]
+  pull_request:
   issue_comment:
     types: [created]
   workflow_dispatch:


### PR DESCRIPTION
Runs on recent commits to `main` and currently-open PRs were successful, and have been uploaded to CodeCov; the source of previous failures remains unknown at this time.