### PR TITLE
Only create `phlex::handle<T>` objects when the user's algorithm signature demands it

### DIFF
--- a/phlex/core/input_arguments.hpp
+++ b/phlex/core/input_arguments.hpp
@@ -13,15 +13,16 @@
 #include <ranges>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 namespace phlex::detail {
   template <typename T>
   struct retriever {
-    using handle_arg_t = internal::handle_value_type<T>;
+    using product_type = std::remove_cv_t<std::remove_pointer_t<std::decay_t<T>>>;
     product_selector query;
-    auto retrieve(message const& msg) const
+    decltype(auto) retrieve(message const& msg) const
     {
       namespace views = std::ranges::views;
       auto const& store = msg.store;
@@ -44,7 +45,14 @@ namespace phlex::detail {
                                              query,
                                              bulleted_list(products, /*indent=*/4)));
       }
-      return store->get_handle<handle_arg_t>(products[0]);
+      if constexpr (internal::is_handle<T>) {
+        using handle_arg_t = internal::handle_value_type<T>;
+        return store->get_handle<handle_arg_t>(products[0]);
+      } else if constexpr (std::is_pointer_v<T>) {
+        return &store->get_product<product_type>(products[0]);
+      } else {
+        return store->get_product<product_type>(products[0]);
+      }
     }
   };
 

--- a/phlex/model/handle.hpp
+++ b/phlex/model/handle.hpp
@@ -85,10 +85,7 @@ namespace phlex {
 
     const_pointer operator->() const noexcept { return product_; }
     [[nodiscard]] const_reference operator*() const noexcept { return *operator->(); }
-    // NOLINTBEGIN(google-explicit-constructor) - Implicit conversion is intentional
-    operator const_reference() const noexcept { return operator*(); }
-    operator const_pointer() const noexcept { return operator->(); }
-    // NOLINTEND(google-explicit-constructor)
+
     auto const& data_cell_index() const noexcept { return *id_; }
 
     // Product specification information

--- a/phlex/model/product_store.hpp
+++ b/phlex/model/product_store.hpp
@@ -118,14 +118,14 @@ namespace phlex::experimental {
   [[nodiscard]] handle<T> product_store::get_handle(
     phlex::detail::product_specification const& key) const
   {
-    return handle<T>{products_.get<T>(key), *id_, key, stage_};
+    return handle{get_product<T>(key), *id_, key, stage_};
   }
 
   template <typename T>
   [[nodiscard]] T const& product_store::get_product(
     phlex::detail::product_specification const& key) const
   {
-    return *get_handle<T>(key);
+    return products_.get<T>(key);
   }
 }
 

--- a/phlex/model/type_id.hpp
+++ b/phlex/model/type_id.hpp
@@ -176,10 +176,13 @@ namespace phlex::detail {
     using aggregate_to_plain_tuple_t = aggregate_to_plain_tuple<A>::type;
 
     template <typename T>
-    class is_handle : public std::false_type {};
+    struct is_handle_impl : std::false_type {};
 
     template <typename T>
-    class is_handle<phlex::handle<T>> : public std::true_type {};
+    struct is_handle_impl<handle<T>> : std::true_type {};
+
+    template <typename T>
+    concept is_handle = is_handle_impl<std::remove_cvref_t<T>>::value;
   }
 
   // Forward declaration
@@ -190,7 +193,7 @@ namespace phlex::detail {
   constexpr type_id make_type_id()
   {
     // First deal with handles
-    if constexpr (internal::is_handle<T>::value) {
+    if constexpr (internal::is_handle<T>) {
       return make_type_id<typename T::value_type>();
     }
 

--- a/test/product_handle.cpp
+++ b/test/product_handle.cpp
@@ -98,19 +98,8 @@ TEST_CASE("Handle comparisons", "[data model]")
   CHECK(h17 != h17sr);                                     // Therefore handles are not the same
 }
 
-TEST_CASE("Handle type conversions (run-time checks)", "[data model]")
+TEST_CASE("Data-product access through operator->", "[data model]")
 {
-  int const number{3};
-  spec_t spec{"number"};
-  handle const h{number, *data_cell_index::job(), spec};
-  CHECK(h.data_cell_index() == *data_cell_index::job());
-
-  int const& num_ref = h;
-  int const* num_ptr = h;
-  CHECK(static_cast<bool>(h));
-  CHECK(num_ref == number);
-  CHECK(*num_ptr == number);
-
   Composer const composer{"Elgar"};
   spec_t composer_spec{"composer"};
   CHECK(handle{composer, *data_cell_index::job(), composer_spec}->name == "Elgar");

--- a/test/product_store.cpp
+++ b/test/product_store.cpp
@@ -33,7 +33,6 @@ TEST_CASE("Product store insertion", "[data model]")
   CHECK(store->get_product<int>("number") == number);
 
   auto h = store->get_handle<std::vector<int>>("numbers");
-  REQUIRE(h);
   CHECK(*h == many_numbers);
   CHECK(store->get_product<std::vector<int>>("numbers") == many_numbers);
 }


### PR DESCRIPTION
Up until now, handles have been created for all input parameters of all algorithms.  In cases where the handle is not actually desired, the created handle is implicitly converted to the appropriate input-parameter type of the user's algorithm.  It is wasteful to always create a `phlex::handle<T>` object and then immediately convert it to something else that doesn't use the handle's metadata.  This PR removes the unconditional creation of handles and also removes the (now-unnecessary) implicit conversion operators of the `phlex::handle` class template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Input handling**
  - Create `phlex::handle<T>` objects only when the algorithm requests handles.
  - Extend input retrieval to support handles, product pointers, and product references/values.
  - Refactor handle detection used by type ID generation.

- **Handle API**
  - Remove implicit conversions from `phlex::handle<T>` to product references and pointers, requiring explicit access through `operator*` and `operator->`.

- **Product store**
  - Simplify `get_handle` and `get_product` delegation while preserving their public interfaces.

- **Tests**
  - Replace runtime handle-conversion coverage with `operator->` product access coverage.
  - Adjust product-store insertion assertions to validate retrieved product contents directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->