### PR TITLE
ci: add mypy to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
       - id: check-vcs-permalinks
       - id: check-executables-have-shebangs
       - id: mixed-line-ending
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        types_or: [python, pyi]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.22
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,17 +13,23 @@ repos:
       - id: check-executables-have-shebangs
       - id: mixed-line-ending
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v2.3.0
     hooks:
       - id: mypy
+        language_version: python3.12
         types_or: [python, pyi]
+        args: [--enable-incomplete-feature=NewGenericSyntax]
+        additional_dependencies:
+          - types-PyYAML
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.22
     hooks:
       - id: ruff-format
         types_or: [python, pyi]
+        language_version: python3.12
       - id: ruff
         types_or: [python, pyi]
+        language_version: python3.12
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 182152eb8c5ce1cf5299b956b04392c86bd8a126 # frozen: v20.1.8
     hooks:


### PR DESCRIPTION
Add the mypy static type checker to the pre-commit configuration to
improve Python type safety and catch potential bugs before commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code quality**
  - Added the pinned `mypy` v1.11.2 pre-commit hook using `pre-commit/mirrors-mypy`.
  - Configured it to check both Python (`.py`) and type stub (`.pyi`) files before commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->