### PR TITLE
Fix FORM's RNTuple backend build against ROOT 6.40

### DIFF
--- a/form/root_storage/root_rntuple_write_container.hpp
+++ b/form/root_storage/root_rntuple_write_container.hpp
@@ -5,6 +5,8 @@
 
 #include "storage/storage_write_association.hpp"
 
+#include "RVersion.h"
+
 #include <memory>
 #include <string>
 
@@ -14,14 +16,27 @@ namespace ROOT {
   class RNTupleWriter;
   class RNTupleModel;
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)
+  namespace Detail {
+    class RRawPtrWriteEntry;
+  }
+#else
   namespace Experimental {
     namespace Detail {
       class RRawPtrWriteEntry;
     }
   }
+#endif
 }
 
 namespace form::detail::experimental {
+
+  //ROOT 6.40 moved RRawPtrWriteEntry from ROOT::Experimental::Detail to ROOT::Detail.
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)
+  using RRawPtrWriteEntry = ROOT::Detail::RRawPtrWriteEntry;
+#else
+  using RRawPtrWriteEntry = ROOT::Experimental::Detail::RRawPtrWriteEntry;
+#endif
 
   class ROOT_RNTuple_Write_ContainerImp : public Storage_Write_Association {
   public:
@@ -43,7 +58,7 @@ namespace form::detail::experimental {
     //State shared by ROOT_RField_ContainerImps
     std::unique_ptr<ROOT::RNTupleWriter> m_writer;
     std::unique_ptr<ROOT::RNTupleModel> m_model;
-    std::unique_ptr<ROOT::Experimental::Detail::RRawPtrWriteEntry> m_entry;
+    std::unique_ptr<RRawPtrWriteEntry> m_entry;
   };
 }
 


### PR DESCRIPTION
ROOT 6.40 moved RRawPtrWriteEntry from ROOT::Experimental::Detail to ROOT::Detail. Select the namespace with a ROOT version check so the RNTuple storage backend (FORM_USE_RNTUPLE_STORAGE=ON) compiles against both ROOT 6.38 and 6.40.

Fixes #712.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Added ROOT version-aware handling for `RRawPtrWriteEntry`.
  - Uses `ROOT::Detail` with ROOT 6.40+ and `ROOT::Experimental::Detail` for ROOT 6.38.
  - Updated the `m_entry` member to use the compatibility alias.
- **Compatibility**
  - Enables the RNTuple storage backend to compile with ROOT 6.38 and newer, including ROOT 6.40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->