### PR TITLE
ci: fix indentation in actionlint-check.yaml workflow

### DIFF
--- a/.github/workflows/actionlint-check.yaml
+++ b/.github/workflows/actionlint-check.yaml
@@ -54,21 +54,21 @@ jobs:
       pr_number: ${{ steps.setup.outputs.pr_number }}
       checkout_path: ${{ steps.setup.outputs.checkout_path }}
       has_changes: ${{ steps.setup.outputs.has_changes }}
-  steps:
-    - name: Workflow setup
-      id: setup
-      uses: Framework-R-D/action-workflow-setup@f73307dd8c13cb66c2565c9ace32571517b1cea8 # v1
-      with:
-        include-globs: |
-          .github/workflows/**/*.yml
-          .github/workflows/**/*.yaml
-          .github/actions/**/*.yml
-          .github/actions/**/*.yaml
-        head-ref: ${{ inputs.pr-head-sha }}
-        ref: ${{ inputs.ref }}
-        repo: ${{ inputs.repo }}
-        pr-base-sha: ${{ inputs.pr-base-sha }}
-        checkout-path: ${{ inputs.checkout-path }}
+    steps:
+      - name: Workflow setup
+        id: setup
+        uses: Framework-R-D/action-workflow-setup@f73307dd8c13cb66c2565c9ace32571517b1cea8 # v1
+        with:
+          include-globs: |
+            .github/workflows/**/*.yml
+            .github/workflows/**/*.yaml
+            .github/actions/**/*.yml
+            .github/actions/**/*.yaml
+          head-ref: ${{ inputs.pr-head-sha }}
+          ref: ${{ inputs.ref }}
+          repo: ${{ inputs.repo }}
+          pr-base-sha: ${{ inputs.pr-base-sha }}
+          checkout-path: ${{ inputs.checkout-path }}
 
 actionlint-check:
   needs: setup


### PR DESCRIPTION
The `steps:` section in the setup job was incorrectly indented (2-space
indent at the job level instead of 2-space indent under `jobs:`). This
fixes the YAML structure to match GitHub Actions workflow schema
requirements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **CI:** Fixed indentation of the setup job’s `steps:` section in `.github/workflows/actionlint-check.yaml` to satisfy GitHub Actions YAML schema requirements.
- **Configuration:** Preserved the existing action and all input values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->