### PR TITLE
chore(deps): update LLVM to 22.1.8 in CI spack environment

### DIFF
--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -16,7 +16,7 @@ spack:
     - py-pytest-cov # Needed for Python coverage reports
     - py-pyyaml # Needed by run-clang-tidy --export-fixes to merge per-TU fix files
     - |
-      llvm@20.1.8 +zstd +llvm_dylib +link_llvm_dylib ~lldb targets=x86
+      llvm@22.1.8 +zstd +llvm_dylib +link_llvm_dylib ~lldb targets=x86
 
   view:
     default:
@@ -43,6 +43,7 @@ spack:
     llvm:
       require:
         - "target=x86_64_v3"
+        - "%c,cxx=gcc@15"
 
     phlex:
       require:


### PR DESCRIPTION
- Update llvm dependency from 20.1.8 to 22.1.8 in ci/spack.yaml
- Add version constraint for llvm: require GCC 15 as compiler and x86_64_v3 target

This aligns the CI environment with the project's requirement for GCC 15+ for
C++23 support and ensures consistent toolchain versions across development and
CI pipelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **CI / Build system**
  - Updated the Spack CI environment from LLVM 20.1.8 to LLVM 22.1.8.
  - Constrained LLVM builds to use GCC 15, aligning CI with the project’s GCC 15+ C++23 toolchain requirement.
  - Preserved the existing LLVM feature configuration and target settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->