### PR TITLE
clang-tidy: resolve `readability-const-return-type` in virtual

### DIFF
--- a/form/storage/istorage.hpp
+++ b/form/storage/istorage.hpp
@@ -53,7 +53,7 @@ namespace form::detail::experimental {
     virtual ~IStorage_File() = default;
 
     virtual std::string const& name() = 0;
-    virtual char const mode() = 0;
+    virtual char mode() = 0;
 
     virtual void setAttribute(std::string const& name, std::string const& value) = 0;
   };

--- a/form/storage/storage_file.cpp
+++ b/form/storage/storage_file.cpp
@@ -8,7 +8,7 @@ Storage_File::Storage_File(std::string const& name, char mode) : m_name(name), m
 
 std::string const& Storage_File::name() { return m_name; }
 
-char const Storage_File::mode() { return m_mode; }
+char Storage_File::mode() { return m_mode; }
 
 void Storage_File::setAttribute(std::string const& /*name*/, std::string const& /*value*/)
 {

--- a/form/storage/storage_file.hpp
+++ b/form/storage/storage_file.hpp
@@ -14,7 +14,7 @@ namespace form::detail::experimental {
     ~Storage_File() override = default;
 
     std::string const& name() override;
-    char const mode() override;
+    char mode() override;
 
     void setAttribute(std::string const& name, std::string const& value) override;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code quality:** Resolved `readability-const-return-type` for the virtual `mode()` accessor.
- **API consistency:** Updated `IStorage_File`, `Storage_File`, and its implementation to return `char` instead of top-level `const char`.
- **Behavior:** No functional behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->