### PR TITLE
maintenance/workflows harden checkouts

### DIFF
--- a/.github/workflows/actionlint-check.yaml
+++ b/.github/workflows/actionlint-check.yaml
@@ -132,10 +132,12 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout trusted base repository for governance script
+      - name: Checkout repository for governance script
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          path: base-repo
+          repository: Framework-R-D/phlex
+          path: phlex
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Checkout code
@@ -152,4 +154,4 @@ jobs:
       - name: Verify gating-block consistency
         env:
           CHECKOUT_PATH: ${{ needs.setup.outputs.checkout_path }}
-        run: bash "base-repo/scripts/check-gating-block.sh" "${CHECKOUT_PATH}/.github/workflows"
+        run: bash "phlex/scripts/check-gating-block.sh" "${CHECKOUT_PATH}/.github/workflows"

--- a/.github/workflows/actionlint-check.yaml
+++ b/.github/workflows/actionlint-check.yaml
@@ -136,6 +136,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Framework-R-D/phlex
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name ==
+            'workflow_call' && inputs.pr-base-sha || github.sha }}
           path: phlex
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/actionlint-check.yaml
+++ b/.github/workflows/actionlint-check.yaml
@@ -101,7 +101,7 @@ jobs:
         continue-on-error: true
         env:
           CHECKOUT_PATH: ${{ needs.setup.outputs.checkout_path }}
-          ACTIONLINT_IMAGE_URL: "rhysd/actionlint:7ef0d156288b43c3bd5ee96bac787a28aae53275e88e4f9476a64bc0c19195c9" # v1.7.12
+          ACTIONLINT_IMAGE_URL: "rhysd/actionlint@sha256:7ef0d156288b43c3bd5ee96bac787a28aae53275e88e4f9476a64bc0c19195c9" # v1.7.12
         run: |
           docker run --rm \
             -v "$GITHUB_WORKSPACE/${CHECKOUT_PATH}:/work" \

--- a/.github/workflows/clang-format-check.yaml
+++ b/.github/workflows/clang-format-check.yaml
@@ -82,9 +82,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
-          repository: ${{ needs.setup.outputs.repo }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           persist-credentials: false
 
       - name: Announce clang-format check

--- a/.github/workflows/clang-format-fix.yaml
+++ b/.github/workflows/clang-format-fix.yaml
@@ -97,6 +97,7 @@ jobs:
           ref: ${{ needs.setup.outputs.ref }}
           repository: ${{ needs.setup.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
+          persist-credentials: false
 
       - uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
         with:

--- a/.github/workflows/clang-tidy-check.yaml
+++ b/.github/workflows/clang-tidy-check.yaml
@@ -59,9 +59,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
-          repository: ${{ needs.setup.outputs.repo }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           persist-credentials: false
 
       - name: Setup build environment

--- a/.github/workflows/clang-tidy-check.yaml
+++ b/.github/workflows/clang-tidy-check.yaml
@@ -149,6 +149,12 @@ jobs:
         shell: bash
         env:
           BASE_SHA: ${{ needs.setup.outputs.base_sha }}
+          BASE_REPO:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name ||
+            needs.setup.outputs.repo }}
+          HEAD_REPO:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           SOURCE_PATH: ${{ needs.setup.outputs.checkout_path }}
           BUILD_PATH: ${{ needs.setup.outputs.build_path }}
         run: |
@@ -159,9 +165,15 @@ jobs:
 
           # Fetch the base commit if it is not already in the shallow history.
           # actions/checkout uses --depth 1, so BASE_SHA may be absent locally.
+          FETCH_REMOTE="origin"
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ "${BASE_REPO}" != "${HEAD_REPO}" ]; then
+            FETCH_REMOTE="base-origin"
+            git remote add "$FETCH_REMOTE" "https://github.com/${BASE_REPO}.git" 2>/dev/null || true
+          fi
+
           if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
             echo "Fetching base commit ${BASE_SHA}..."
-            if ! git fetch --depth=1 origin "$BASE_SHA" 2>/dev/null; then
+            if ! git fetch --depth=1 "$FETCH_REMOTE" "$BASE_SHA" 2>/dev/null; then
               echo "::warning::Could not fetch base commit ${BASE_SHA}; skipping new-issue check"
               exit 0
             fi

--- a/.github/workflows/clang-tidy-fix.yaml
+++ b/.github/workflows/clang-tidy-fix.yaml
@@ -83,6 +83,7 @@ jobs:
           ref: ${{ needs.setup.outputs.ref }}
           repository: ${{ needs.setup.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
+          persist-credentials: false
 
       - name: Try to download existing fixes from check workflow
         id: download_fixes_check

--- a/.github/workflows/cmake-build.yaml
+++ b/.github/workflows/cmake-build.yaml
@@ -160,8 +160,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: ${{ needs.setup.outputs.checkout_path }}
-          ref: ${{ needs.setup.outputs.ref }}
-          repository: ${{ needs.setup.outputs.repo }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           persist-credentials: false
 
       - name: Setup build environment

--- a/.github/workflows/cmake-format-check.yaml
+++ b/.github/workflows/cmake-format-check.yaml
@@ -79,9 +79,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
-          repository: ${{ needs.setup.outputs.repo }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           persist-credentials: false
 
       - name: Install uv

--- a/.github/workflows/cmake-format-fix.yaml
+++ b/.github/workflows/cmake-format-fix.yaml
@@ -98,6 +98,7 @@ jobs:
           ref: ${{ needs.setup.outputs.ref }}
           repository: ${{ needs.setup.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -307,6 +307,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Framework-R-D/phlex
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name ==
+            'workflow_call' && inputs.pr-base-sha || github.sha }}
           path: phlex
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -232,9 +232,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           path: ${{ env.local_checkout_path }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup build environment
         uses: Framework-R-D/action-setup-build-env@780fd75b00a291df6a42d9d2337651330ebdb907 # v1
@@ -298,18 +303,13 @@ jobs:
       - name: Set log file path
         id: set_log_path
         run: echo "path=$RUNNER_TEMP/codeql-alerts.log" >> "$GITHUB_OUTPUT"
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
       - name: Checkout Phlex for scripts
-        if: github.event_name == 'workflow_call'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Framework-R-D/phlex
           path: phlex
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download CodeQL SARIF artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -341,11 +341,7 @@ jobs:
             ARGS+=(--ref "refs/pull/${PR_NUMBER}/merge")
           fi
 
-          script_path="scripts/check_codeql_alerts.py"
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_call" ]; then
-            script_path="phlex/$script_path"
-          fi
-          python3 "$script_path" "${ARGS[@]}"
+          python3 "phlex/scripts/check_codeql_alerts.py" "${ARGS[@]}"
 
       - name: Upload CodeQL alerts debug log
         if: always()

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -108,9 +108,12 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
-          repository: ${{ needs.setup.outputs.repo }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           persist-credentials: false
 
       - name: Setup build environment
@@ -386,8 +389,11 @@ jobs:
       - name: Check out source code for Codecov mapping
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
-          repository: ${{ needs.setup.outputs.repo }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           fetch-depth: 0
 
       - name: Download coverage bundle

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -395,6 +395,7 @@ jobs:
             ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
             needs.setup.outputs.repo }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download coverage bundle
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/header-guards-check.yaml
+++ b/.github/workflows/header-guards-check.yaml
@@ -82,9 +82,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
-          repository: ${{ needs.setup.outputs.repo }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           persist-credentials: false
 
       - name: Set up Python

--- a/.github/workflows/header-guards-fix.yaml
+++ b/.github/workflows/header-guards-fix.yaml
@@ -98,6 +98,7 @@ jobs:
           ref: ${{ needs.setup.outputs.ref }}
           repository: ${{ needs.setup.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/jsonnet-format-check.yaml
+++ b/.github/workflows/jsonnet-format-check.yaml
@@ -79,8 +79,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
-          repository: ${{ needs.setup.outputs.repo }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           path: ${{ needs.setup.outputs.checkout_path }}
           persist-credentials: false
 

--- a/.github/workflows/jsonnet-format-fix.yaml
+++ b/.github/workflows/jsonnet-format-fix.yaml
@@ -99,6 +99,7 @@ jobs:
           ref: ${{ needs.setup.outputs.ref }}
           repository: ${{ needs.setup.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
+          persist-credentials: false
 
       - name: Setup jsonnet
         id: setup-jsonnet

--- a/.github/workflows/markdown-check.yaml
+++ b/.github/workflows/markdown-check.yaml
@@ -82,9 +82,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
-          repository: ${{ needs.setup.outputs.repo }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           persist-credentials: false
 
       - name: Add problem matcher

--- a/.github/workflows/markdown-fix.yaml
+++ b/.github/workflows/markdown-fix.yaml
@@ -98,6 +98,7 @@ jobs:
           ref: ${{ needs.setup.outputs.ref }}
           repository: ${{ needs.setup.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -84,9 +84,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
-          repository: ${{ needs.setup.outputs.repo }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           persist-credentials: false
 
       - name: Install uv
@@ -146,9 +149,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
-          repository: ${{ needs.setup.outputs.repo }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           persist-credentials: false
 
       - name: Install uv

--- a/.github/workflows/python-fix.yaml
+++ b/.github/workflows/python-fix.yaml
@@ -97,6 +97,7 @@ jobs:
           ref: ${{ needs.setup.outputs.ref }}
           repository: ${{ needs.setup.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/yaml-check.yaml
+++ b/.github/workflows/yaml-check.yaml
@@ -76,9 +76,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || needs.setup.outputs.ref }}
           path: ${{ needs.setup.outputs.checkout_path }}
-          repository: ${{ needs.setup.outputs.repo }}
+          repository:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ||
+            needs.setup.outputs.repo }}
           persist-credentials: false
 
       - name: Install uv

--- a/.github/workflows/yaml-fix.yaml
+++ b/.github/workflows/yaml-fix.yaml
@@ -99,6 +99,7 @@ jobs:
           ref: ${{ needs.setup.outputs.ref }}
           repository: ${{ needs.setup.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **CI workflow hardening**
  - Standardized pull-request checkouts across validation workflows to use the PR head SHA and source repository, while preserving existing refs for non-PR events.
  - Disabled persisted GitHub credentials in formatting, fixing, CodeQL, and other checkout steps.
  - Improved base-repository checkout handling for gating and clang-tidy checks, including fork PR support and correct `BASE_SHA` retrieval.
  - Removed redundant CodeQL checkout logic and standardized helper-script paths.
- **Tooling**
  - Pinned the actionlint container using a SHA-256 digest via `ACTIONLINT_IMAGE_URL`.
  - Updated checkout/action tooling and related workflow configuration, including YAML indentation and pre-commit/tool version fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->