### PR TITLE
FORM Testing Use c++11 Random

### DIFF
--- a/test/form/toy_tracker.cpp
+++ b/test/form/toy_tracker.cpp
@@ -3,12 +3,14 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cassert>
 
 ToyTracker::ToyTracker(int max_tracks) :
   gen_(std::chrono::system_clock().now().time_since_epoch().count()),
   size_dist_(0, max_tracks - 1),
   value_dist_(0, 1)
 {
+  assert(max_tracks > 1);
 }
 
 std::vector<TrackStart> ToyTracker::operator()()

--- a/test/form/toy_tracker.cpp
+++ b/test/form/toy_tracker.cpp
@@ -10,7 +10,7 @@ std::vector<TrackStart> ToyTracker::operator()()
 {
   int32_t const npx = m_sizeDist(m_gen);
   std::vector<TrackStart> points;
-  points.reserve(npx);
+  points.resize(npx);
   std::generate_n(std::back_inserter(points), npx, [this] {
     return TrackStart(m_valueDist(m_gen), m_valueDist(m_gen), m_valueDist(m_gen));
   });

--- a/test/form/toy_tracker.cpp
+++ b/test/form/toy_tracker.cpp
@@ -2,8 +2,8 @@
 #include "data_products/track_start.hpp"
 
 #include <algorithm>
-#include <chrono>
 #include <cassert>
+#include <chrono>
 
 ToyTracker::ToyTracker(int max_tracks) :
   gen_(std::chrono::system_clock().now().time_since_epoch().count()),

--- a/test/form/toy_tracker.cpp
+++ b/test/form/toy_tracker.cpp
@@ -2,30 +2,18 @@
 #include "data_products/track_start.hpp"
 
 #include <algorithm>
-#include <cstdlib>
+#include <chrono>
 
-ToyTracker::ToyTracker(int maxTracks) : m_maxTracks(maxTracks) {}
+ToyTracker::ToyTracker(int maxTracks) : m_gen(std::chrono::system_clock().now().time_since_epoch().count()), m_sizeDist(0, maxTracks), m_valueDist(0, 1) {}
 
 std::vector<TrackStart> ToyTracker::operator()()
 {
-  int32_t const npx = generateRandom() % m_maxTracks;
+  int32_t const npx = m_sizeDist(m_gen);
   std::vector<TrackStart> points;
   points.reserve(npx);
   std::generate_n(std::back_inserter(points), npx, [this] {
-    return TrackStart(static_cast<float>(generateRandom()) / static_cast<float>(random_max),
-                      static_cast<float>(generateRandom()) / static_cast<float>(random_max),
-                      static_cast<float>(generateRandom()) / static_cast<float>(random_max));
+    return TrackStart(m_valueDist(m_gen), m_valueDist(m_gen), m_valueDist(m_gen));
   });
 
   return points;
-}
-
-int32_t ToyTracker::generateRandom()
-{
-  //Get a 32-bit random integer with even the lowest allowed precision of rand()
-  // NOLINTBEGIN(concurrency-mt-unsafe, cert-msc30-c, misc-predictable-rand, cert-msc50-cpp) - Test code, single-threaded
-  int rand1 = rand() % 32768;
-  int rand2 = rand() % 32768;
-  // NOLINTEND(concurrency-mt-unsafe, cert-msc30-c, misc-predictable-rand, cert-msc50-cpp) - Test code, single-threaded
-  return (rand1 * 32768) + rand2;
 }

--- a/test/form/toy_tracker.cpp
+++ b/test/form/toy_tracker.cpp
@@ -4,7 +4,12 @@
 #include <algorithm>
 #include <chrono>
 
-ToyTracker::ToyTracker(int maxTracks) : m_gen(std::chrono::system_clock().now().time_since_epoch().count()), m_sizeDist(0, maxTracks-1), m_valueDist(0, 1) {}
+ToyTracker::ToyTracker(int maxTracks) :
+  m_gen(std::chrono::system_clock().now().time_since_epoch().count()),
+  m_sizeDist(0, maxTracks - 1),
+  m_valueDist(0, 1)
+{
+}
 
 std::vector<TrackStart> ToyTracker::operator()()
 {

--- a/test/form/toy_tracker.cpp
+++ b/test/form/toy_tracker.cpp
@@ -4,15 +4,15 @@
 #include <algorithm>
 #include <chrono>
 
-ToyTracker::ToyTracker(int maxTracks) : m_gen(std::chrono::system_clock().now().time_since_epoch().count()), m_sizeDist(0, maxTracks-1), m_valueDist(0, 1) {}
+ToyTracker::ToyTracker(int max_tracks) : gen_(std::chrono::system_clock().now().time_since_epoch().count()), size_dist_(0, max_tracks-1), value_dist_(0, 1) {}
 
 std::vector<TrackStart> ToyTracker::operator()()
 {
-  int32_t const npx = m_sizeDist(m_gen);
+  int32_t const npx = size_dist_(gen_);
   std::vector<TrackStart> points;
-  points.resize(npx);
+  points.reserve(npx);
   std::generate_n(std::back_inserter(points), npx, [this] {
-    return TrackStart(m_valueDist(m_gen), m_valueDist(m_gen), m_valueDist(m_gen));
+    return TrackStart(value_dist_(gen_), value_dist_(gen_), value_dist_(gen_));
   });
 
   return points;

--- a/test/form/toy_tracker.cpp
+++ b/test/form/toy_tracker.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <chrono>
 
-ToyTracker::ToyTracker(int maxTracks) : m_gen(std::chrono::system_clock().now().time_since_epoch().count()), m_sizeDist(0, maxTracks), m_valueDist(0, 1) {}
+ToyTracker::ToyTracker(int maxTracks) : m_gen(std::chrono::system_clock().now().time_since_epoch().count()), m_sizeDist(0, maxTracks-1), m_valueDist(0, 1) {}
 
 std::vector<TrackStart> ToyTracker::operator()()
 {

--- a/test/form/toy_tracker.cpp
+++ b/test/form/toy_tracker.cpp
@@ -6,7 +6,7 @@
 
 ToyTracker::ToyTracker(int max_tracks) :
   gen_(std::chrono::system_clock().now().time_since_epoch().count()),
-  size_dist_(0, max_tracks-1),
+  size_dist_(0, max_tracks - 1),
   value_dist_(0, 1)
 {
 }

--- a/test/form/toy_tracker.hpp
+++ b/test/form/toy_tracker.hpp
@@ -3,6 +3,7 @@
 #define TEST_FORM_TOY_TRACKER_HPP
 #include <cstdint>
 #include <vector>
+#include <random>
 
 class TrackStart;
 
@@ -14,9 +15,9 @@ public:
   std::vector<TrackStart> operator()();
 
 private:
-  int m_maxTracks;
-  int32_t generateRandom();
-  int32_t random_max = 32768 * 32768;
+  std::mt19937 m_gen;
+  std::uniform_int_distribution<int> m_sizeDist;
+  std::uniform_real_distribution<float> m_valueDist;
 };
 
 #endif // TEST_FORM_TOY_TRACKER_HPP

--- a/test/form/toy_tracker.hpp
+++ b/test/form/toy_tracker.hpp
@@ -9,15 +9,15 @@ class TrackStart;
 
 class ToyTracker {
 public:
-  explicit ToyTracker(int maxTracks);
+  explicit ToyTracker(int max_tracks);
   ~ToyTracker() = default;
 
   std::vector<TrackStart> operator()();
 
 private:
-  std::mt19937 m_gen;
-  std::uniform_int_distribution<int> m_sizeDist;
-  std::uniform_real_distribution<float> m_valueDist;
+  std::mt19937 gen_;
+  std::uniform_int_distribution<int> size_dist_;
+  std::uniform_real_distribution<float> value_dist_;
 };
 
 #endif // TEST_FORM_TOY_TRACKER_HPP

--- a/test/form/toy_tracker.hpp
+++ b/test/form/toy_tracker.hpp
@@ -2,8 +2,8 @@
 #ifndef TEST_FORM_TOY_TRACKER_HPP
 #define TEST_FORM_TOY_TRACKER_HPP
 #include <cstdint>
-#include <vector>
 #include <random>
+#include <vector>
 
 class TrackStart;
 

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -7,6 +7,7 @@
 #include "test_utils.hpp"
 #include "toy_tracker.hpp"
 
+#include <cassert>
 #include <chrono>
 #include <cstdlib>
 #include <ctime>
@@ -17,7 +18,6 @@
 #include <random>
 #include <ranges>
 #include <vector>
-#include <cassert>
 
 static int const NUMBER_EVENT = 4;
 static int const NUMBER_SEGMENT = 15;

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -17,6 +17,7 @@
 #include <random>
 #include <ranges>
 #include <vector>
+#include <cassert>
 
 static int const NUMBER_EVENT = 4;
 static int const NUMBER_SEGMENT = 15;
@@ -26,6 +27,7 @@ struct Generator {
 
   void operator()(std::vector<float>& vrand, int size)
   {
+    assert(size > 1);
     std::uniform_int_distribution size_dist(0, size - 1);
     size_t const howMany = size_dist(gen_);
     vrand.resize(howMany);

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -44,8 +44,6 @@ struct Generator
 int main(int argc, char** argv)
 {
   std::cout << "In main" << '\n';
-  // Deliberately use C-style random number generation for simplicity in a test
-  // NOLINTNEXTLINE(bugprone-random-generator-seed, cert-msc32-c, cert-msc51-cpp)
 
   std::string const filename = (argc > 1) ? argv[1] : "toy.root";
   std::string const checksum_filename = (argc > 2) ? argv[2] : "toy_checksums.txt";

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -21,24 +21,23 @@
 static int const NUMBER_EVENT = 4;
 static int const NUMBER_SEGMENT = 15;
 
-struct Generator
-{
+struct Generator {
   Generator() : gen_(std::chrono::system_clock::now().time_since_epoch().count()), dist_(0, 1) {}
 
   void operator()(std::vector<float>& vrand, int size)
   {
-    std::uniform_int_distribution size_dist(0, size-1);
+    std::uniform_int_distribution size_dist(0, size - 1);
     size_t const howMany = size_dist(gen_);
     vrand.resize(howMany);
 
-    for(auto& rand: vrand) {
+    for (auto& rand : vrand) {
       rand = dist_(gen_);
     }
   }
 
-  private:
-    std::mt19937 gen_;
-    std::uniform_real_distribution<float> dist_;
+private:
+  std::mt19937 gen_;
+  std::uniform_real_distribution<float> dist_;
 };
 
 int main(int argc, char** argv)

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -29,7 +29,7 @@ struct Generator
   {
     std::uniform_int_distribution sizeDist(0, size);
     size_t const howMany = sizeDist(m_gen);
-    vrand.reserve(howMany);
+    vrand.resize(howMany);
 
     for(auto& rand: vrand) {
       rand = m_dist(m_gen);

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -27,7 +27,7 @@ struct Generator
 
   void operator ()(std::vector<float>& vrand, int size)
   {
-    std::uniform_int_distribution sizeDist(0, size);
+    std::uniform_int_distribution sizeDist(0, size-1);
     size_t const howMany = sizeDist(m_gen);
     vrand.resize(howMany);
 

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -23,22 +23,22 @@ static int const NUMBER_SEGMENT = 15;
 
 struct Generator
 {
-  Generator(): m_gen(std::chrono::system_clock::now().time_since_epoch().count()), m_dist(0, 1) {}
+  Generator(): gen_(std::chrono::system_clock::now().time_since_epoch().count()), dist_(0, 1) {}
 
   void operator ()(std::vector<float>& vrand, int size)
   {
-    std::uniform_int_distribution sizeDist(0, size-1);
-    size_t const howMany = sizeDist(m_gen);
+    std::uniform_int_distribution size_dist(0, size-1);
+    size_t const howMany = size_dist(gen_);
     vrand.resize(howMany);
 
     for(auto& rand: vrand) {
-      rand = m_dist(m_gen);
+      rand = dist_(gen_);
     }
   }
 
   private:
-    std::mt19937 m_gen;
-    std::uniform_real_distribution<float> m_dist;
+    std::mt19937 gen_;
+    std::uniform_real_distribution<float> dist_;
 };
 
 int main(int argc, char** argv)

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -15,26 +15,31 @@
 #include <iostream>
 #include <ranges>
 #include <vector>
+#include <random>
+#include <chrono>
 
 static int const NUMBER_EVENT = 4;
 static int const NUMBER_SEGMENT = 15;
 
-void generate(std::vector<float>& vrand, int size)
+struct Generator
 {
-  // NOLINTBEGIN(concurrency-mt-unsafe, cert-msc30-c, misc-predictable-rand, cert-msc50-cpp) - Single-threaded test
-  int rand1 = rand() % 32768;
-  int rand2 = rand() % 32768;
-  // NOLINTEND(concurrency-mt-unsafe, cert-msc30-c, misc-predictable-rand, cert-msc50-cpp) - Single-threaded test
-  int npx = ((rand1 * 32768) + rand2) % size;
-  for (int nelement = 0; nelement < npx; ++nelement) {
-    // NOLINTBEGIN(concurrency-mt-unsafe, cert-msc30-c, misc-predictable-rand, cert-msc50-cpp) - Single-threaded test
-    int rand1 = rand() % 32768;
-    int rand2 = rand() % 32768;
-    // NOLINTEND(concurrency-mt-unsafe, cert-msc30-c, misc-predictable-rand, cert-msc50-cpp) - Single-threaded test
-    float random = static_cast<float>((rand1 * 32768) + rand2) / (32768.0f * 32768);
-    vrand.push_back(random);
+  Generator(): m_gen(std::chrono::system_clock::now().time_since_epoch().count()), m_dist(0, 1) {}
+
+  void operator ()(std::vector<float>& vrand, int size)
+  {
+    std::uniform_int_distribution sizeDist(0, size);
+    size_t const howMany = sizeDist(m_gen);
+    vrand.reserve(howMany);
+
+    for(auto& rand: vrand) {
+      rand = m_dist(m_gen);
+    }
   }
-}
+
+  private:
+    std::mt19937 m_gen;
+    std::uniform_real_distribution<float> m_dist;
+};
 
 int main(int argc, char** argv)
 {
@@ -71,6 +76,8 @@ int main(int argc, char** argv)
     std::cerr << "ERROR: Could not open checksum file: " << checksum_filename << '\n';
     return 1;
   }
+
+  Generator generate;
 
   for (int nevent = 0; nevent < NUMBER_EVENT; nevent++) {
     std::cout << "PHLEX: Write Event No. " << nevent << '\n';

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -7,38 +7,37 @@
 #include "test_utils.hpp"
 #include "toy_tracker.hpp"
 
+#include <chrono>
 #include <cstdlib>
 #include <ctime>
 #include <format>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <random>
 #include <ranges>
 #include <vector>
-#include <random>
-#include <chrono>
 
 static int const NUMBER_EVENT = 4;
 static int const NUMBER_SEGMENT = 15;
 
-struct Generator
-{
-  Generator(): m_gen(std::chrono::system_clock::now().time_since_epoch().count()), m_dist(0, 1) {}
+struct Generator {
+  Generator() : m_gen(std::chrono::system_clock::now().time_since_epoch().count()), m_dist(0, 1) {}
 
-  void operator ()(std::vector<float>& vrand, int size)
+  void operator()(std::vector<float>& vrand, int size)
   {
-    std::uniform_int_distribution sizeDist(0, size-1);
+    std::uniform_int_distribution sizeDist(0, size - 1);
     size_t const howMany = sizeDist(m_gen);
     vrand.resize(howMany);
 
-    for(auto& rand: vrand) {
+    for (auto& rand : vrand) {
       rand = m_dist(m_gen);
     }
   }
 
-  private:
-    std::mt19937 m_gen;
-    std::uniform_real_distribution<float> m_dist;
+private:
+  std::mt19937 m_gen;
+  std::uniform_real_distribution<float> m_dist;
 };
 
 int main(int argc, char** argv)

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -46,7 +46,6 @@ int main(int argc, char** argv)
   std::cout << "In main" << '\n';
   // Deliberately use C-style random number generation for simplicity in a test
   // NOLINTNEXTLINE(bugprone-random-generator-seed, cert-msc32-c, cert-msc51-cpp)
-  srand(time(nullptr));
 
   std::string const filename = (argc > 1) ? argv[1] : "toy.root";
   std::string const checksum_filename = (argc > 2) ? argv[2] : "toy_checksums.txt";


### PR DESCRIPTION
Upgraded how we generate random numbers for some FORM tests.  The new version is intended to be easier to read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code quality:** Replaced C-style `rand()`/`srand()` usage in selected FORM tests with seeded C++11 `std::mt19937` generators and standard uniform distributions.
- **FORM test data generation:** Updated `ToyTracker` and the FORM writer utility to resize vectors and populate them through distribution-based generation.
- **Behavior preservation:** Retained the previous number-of-tracks distribution while generating track values with the new random engine.
- **Correctness:** Replaced incorrect `vector::reserve()` usage with `vector::resize()` before filling generated data.
- **Cleanup:** Removed obsolete random-generation helpers, constants, and state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->