### PR TITLE
Form local naming readability and regression-test cleanup

### DIFF
--- a/form/form/form_reader.cpp
+++ b/form/form/form_reader.cpp
@@ -27,8 +27,8 @@ namespace form::experimental {
                                    product_with_name& product)
   {
 
-    auto it = m_product_to_config.find(product.label);
-    if (it == m_product_to_config.end()) {
+    auto config_it = m_product_to_config.find(product.label);
+    if (config_it == m_product_to_config.end()) {
       throw std::runtime_error("No configuration found for product: " + product.label);
     }
 

--- a/form/form/form_writer.cpp
+++ b/form/form/form_writer.cpp
@@ -28,8 +28,8 @@ namespace form::experimental {
                                     product_with_name const& product)
   {
 
-    auto it = m_product_to_config.find(product.label);
-    if (it == m_product_to_config.end()) {
+    auto config_it = m_product_to_config.find(product.label);
+    if (config_it == m_product_to_config.end()) {
       std::cerr << "No configuration found for product: " << product.label << '\n';
       return;
     }
@@ -51,8 +51,8 @@ namespace form::experimental {
       return;
     }
 
-    auto it = m_product_to_config.find(products[0].label);
-    if (it == m_product_to_config.end()) {
+    auto config_it = m_product_to_config.find(products[0].label);
+    if (config_it == m_product_to_config.end()) {
       std::cerr << "No configuration found for product: " << products[0].label << '\n';
       return;
     }

--- a/form/root_storage/root_rfield_write_container.cpp
+++ b/form/root_storage/root_rfield_write_container.cpp
@@ -113,9 +113,9 @@ namespace form::detail::experimental {
     if (m_force_streamer_field) {
       field = std::make_unique<ROOT::RStreamerField>(col_name(), type_name);
     } else {
-      auto result = ROOT::RFieldBase::Create(col_name(), type_name);
-      if (result) {
-        field = result.Unwrap();
+      auto field_result = ROOT::RFieldBase::Create(col_name(), type_name);
+      if (field_result) {
+        field = field_result.Unwrap();
       } else {
         std::cerr
           << "ROOT_RField_Write_ContainerImp::setupWrite could not create column-wise storage for "

--- a/test/form/form_basics_test.cpp
+++ b/test/form/form_basics_test.cpp
@@ -2,6 +2,7 @@
 #include "form/config.hpp"
 #include "form/form_reader.hpp"
 #include "form/form_source_type_registry.hpp"
+#include "form/form_writer.hpp"
 #include "form/technology.hpp"
 #include "persistence/persistence_reader.hpp"
 #include "persistence/persistence_writer.hpp"
@@ -303,6 +304,30 @@ TEST_CASE("form_reader_interface::indices exercises persistence listIndices path
   // indices() calls persistence listIndices; with tech=0 the index container is
   // always empty, so it throws -- but the call itself covers form_reader.cpp L48.
   CHECK_THROWS_AS(reader.indices("creator", "prod"), std::runtime_error);
+}
+
+TEST_CASE("form_reader_interface::read throws for missing product config", "[form]")
+{
+  using namespace form::experimental::config;
+
+  ItemConfig cfg;
+  cfg.addItem("prod", "dummy_reader_test.root", 0);
+  form::experimental::form_reader_interface reader{cfg, tech_setting_config{}};
+
+  form::experimental::product_with_name product{"missing", nullptr, &typeid(int)};
+  CHECK_THROWS_AS(reader.read("creator", "segment", product), std::runtime_error);
+}
+
+TEST_CASE("form_writer_interface handles missing product config without crashing", "[form]")
+{
+  using namespace form::experimental::config;
+
+  ItemConfig cfg;
+  cfg.addItem("prod", "dummy_writer_test.root", 0);
+  form::experimental::form_writer_interface writer{cfg, tech_setting_config{}};
+
+  form::experimental::product_with_name product{"missing", nullptr, &typeid(int)};
+  CHECK_NOTHROW(writer.write("creator", "segment", product));
 }
 
 TEST_CASE("form_source_type_registry product_from_data_fn throws on null data", "[form]")


### PR DESCRIPTION
This PR keeps the change set small and focused on FORM interface cleanup. It combines the earlier local-variable naming cleanup with a small regression-test addition covering the missing-product-config path. The intent is to improve readability and make the current behavior easier to reason about without expanding the scope into broader storage or interface changes.

What changed:
- Kept the earlier local naming cleanup for readability in the FORM-related code.
- Added regression tests covering the missing-product-config cases for the reader and writer interfaces.
- Kept the change narrowly scoped to clarity and test coverage rather than functional refactoring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code quality**
  - Renamed local configuration iterators from `it` to `config_it` in `form_reader_interface::read` and both `form_writer` overloads.
  - Renamed the `RFieldBase::Create` result variable to `field_result` in `setupWrite`.
  - Preserved existing behavior, including field creation and streamer fallback logic.
- **API and tests**
  - No exported or public entities changed.
  - No test changes were required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->