### PR TITLE
Fix name shadowing in storage_reader and storage_writer

### DIFF
--- a/form/storage/storage_reader.cpp
+++ b/form/storage/storage_reader.cpp
@@ -202,8 +202,8 @@ int StorageReader::getIndex(Token const& token,
   }
 
   if (m_indexMaps[token.containerName()].empty()) {
-    auto key = std::make_pair(token.fileName(), token.containerName());
-    auto cont = m_read_containers.find(key);
+    auto contKey = std::make_pair(token.fileName(), token.containerName());
+    auto cont = m_read_containers.find(contKey);
     if (cont == m_read_containers.end()) {
       auto file = m_files.find(token.fileName());
       if (file == m_files.end()) {
@@ -216,7 +216,7 @@ int StorageReader::getIndex(Token const& token,
         }
       }
       cont = m_read_containers
-               .insert({key, createReadContainer(token.technology(), token.containerName())})
+               .insert({contKey, createReadContainer(token.technology(), token.containerName())})
                .first;
       for (auto const& [key, value] :
            get_container_table(settings, token.technology(), token.containerName())) {
@@ -279,8 +279,8 @@ void StorageReader::prime(Token const& token,
                           std::type_info const& type,
                           form::experimental::config::tech_setting_config const& settings)
 {
-  auto key = std::make_pair(token.fileName(), token.containerName());
-  auto cont = m_read_containers.find(key);
+  auto contKey = std::make_pair(token.fileName(), token.containerName());
+  auto cont = m_read_containers.find(contKey);
   if (cont == m_read_containers.end()) {
     auto file = m_files.find(token.fileName());
     if (file == m_files.end()) {
@@ -293,7 +293,7 @@ void StorageReader::prime(Token const& token,
       }
     }
     cont = m_read_containers
-             .insert({key, createReadContainer(token.technology(), token.containerName())})
+             .insert({contKey, createReadContainer(token.technology(), token.containerName())})
              .first;
     cont->second->setFile(file->second);
     for (auto const& [key, value] :
@@ -308,8 +308,8 @@ std::vector<std::string> StorageReader::listIndices(
   Token const& token, form::experimental::config::tech_setting_config const& settings)
 {
   if (m_indexMaps[token.containerName()].empty()) {
-    auto key = std::make_pair(token.fileName(), token.containerName());
-    auto cont = m_read_containers.find(key);
+    auto contKey = std::make_pair(token.fileName(), token.containerName());
+    auto cont = m_read_containers.find(contKey);
     if (cont == m_read_containers.end()) {
       auto file = m_files.find(token.fileName());
       if (file == m_files.end()) {
@@ -322,7 +322,7 @@ std::vector<std::string> StorageReader::listIndices(
         }
       }
       cont = m_read_containers
-               .insert({key, createReadContainer(token.technology(), token.containerName())})
+               .insert({contKey, createReadContainer(token.technology(), token.containerName())})
                .first;
       for (auto const& [key, value] :
            get_container_table(settings, token.technology(), token.containerName())) {
@@ -368,8 +368,8 @@ void StorageReader::readContainer(Token const& token,
                                   std::type_info const& type,
                                   form::experimental::config::tech_setting_config const& settings)
 {
-  auto key = std::make_pair(token.fileName(), token.containerName());
-  auto cont = m_read_containers.find(key);
+  auto contKey = std::make_pair(token.fileName(), token.containerName());
+  auto cont = m_read_containers.find(contKey);
   if (cont == m_read_containers.end()) {
     auto file = m_files.find(token.fileName());
     if (file == m_files.end()) {
@@ -382,7 +382,7 @@ void StorageReader::readContainer(Token const& token,
       }
     }
     cont = m_read_containers
-             .insert({key, createReadContainer(token.technology(), token.containerName())})
+             .insert({contKey, createReadContainer(token.technology(), token.containerName())})
              .first;
     cont->second->setFile(file->second);
     for (auto const& [key, value] :

--- a/form/storage/storage_writer.cpp
+++ b/form/storage/storage_writer.cpp
@@ -57,8 +57,8 @@ void StorageWriter::createContainers(
 {
   for (auto const& [plcmnt, type] : containers) {
     // Use file+container as composite key
-    auto key = std::make_pair(plcmnt->fileName(), plcmnt->containerName());
-    auto cont = m_write_containers.find(key);
+    auto contKey = std::make_pair(plcmnt->fileName(), plcmnt->containerName());
+    auto cont = m_write_containers.find(contKey);
     if (cont == m_write_containers.end()) {
       // Ensure the file exists
       auto file = m_files.find(plcmnt->fileName());
@@ -74,7 +74,7 @@ void StorageWriter::createContainers(
       }
       // Create and bind container to file
       auto container = createWriteContainer(plcmnt->technology(), plcmnt->containerName());
-      m_write_containers.insert({key, container});
+      m_write_containers.insert({contKey, container});
       // For associative container, create association layer
       auto associative_container =
         dynamic_pointer_cast<Storage_Associative_Write_Container>(container);
@@ -108,8 +108,8 @@ void StorageWriter::fillContainer(Placement const& plcmnt,
                                   std::type_info const& /* type*/)
 {
   // Use file+container as composite key
-  auto key = std::make_pair(plcmnt.fileName(), plcmnt.containerName());
-  auto cont = m_write_containers.find(key);
+  auto contKey = std::make_pair(plcmnt.fileName(), plcmnt.containerName());
+  auto cont = m_write_containers.find(contKey);
   if (cont == m_write_containers.end()) {
     // FIXME: For now throw an exception here, but in future, we may have storage technology do that.
     throw std::runtime_error("StorageWriter::fillContainer Container doesn't exist: " +
@@ -120,7 +120,7 @@ void StorageWriter::fillContainer(Placement const& plcmnt,
 
 void StorageWriter::commitContainers(Placement const& plcmnt)
 {
-  auto key = std::make_pair(plcmnt.fileName(), plcmnt.containerName());
-  auto cont = m_write_containers.find(key);
+  auto contKey = std::make_pair(plcmnt.fileName(), plcmnt.containerName());
+  auto cont = m_write_containers.find(contKey);
   cont->second->commit();
 }


### PR DESCRIPTION
Solves name shadowing from #779 .  Improves code readability.  Does not change functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code quality**
  - Renamed local container-key variables from `key` to `contKey` in `storage_reader` and `storage_writer`.
  - Removed name shadowing in container lookup, creation, filling, commit, and index operations.
  - Preserved existing container lookup and insertion behavior.
- **API and tests**
  - No public or exported declarations changed.
  - No functional changes or test updates required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->