### PR TITLE
Fix set construction when deciding to insert repeaters

### DIFF
--- a/phlex/core/multilayer_join_node.hpp
+++ b/phlex/core/multilayer_join_node.hpp
@@ -80,7 +80,7 @@ namespace phlex::detail {
       // Collapse to the set of distinct layer names.  More than one distinct layer means
       // at least one input crosses a layer boundary and therefore every input stream
       // needs a repeater_node.
-      std::set collapsed_layers{layers_.begin(), layers_.end()};
+      std::set collapsed_layers(layers_.begin(), layers_.end());
 
       // Add repeaters only if the inputs span more than one distinct layer.
       if (collapsed_layers.size() > 1) {


### PR DESCRIPTION
Previously we were constructing a set of two iterators, and therefore unconditionally inserting repeaters.

Ultimately it doesn't look like this saves any appreciable time on the tests so we might as well remove the condition when we make layer names optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Fixed `collapsed_layers` set construction in `phlex/core/multilayer_join_node.hpp`.
  - The set now contains layer values instead of two iterators.
  - Repeaters are inserted only when the required layers are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->