### PR TITLE
chore(deps): add npm release age constraint for @kilocode/cli

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -103,6 +103,7 @@ INSTALL_DEV_UTILS
 
 RUN bash <<'INSTALL_NPM_PACKAGES'
 set -euo pipefail
+npm update -g npm@^11.10.0
 npm config set allow-scripts=@kilocode/cli --location=user
 npm config set min-release-age=3 --location=user
 npm install -g @kilocode/cli

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -104,6 +104,7 @@ INSTALL_DEV_UTILS
 RUN bash <<'INSTALL_NPM_PACKAGES'
 set -euo pipefail
 npm config set allow-scripts=@kilocode/cli --location=user
+npm config set min-release-age=3 --location=user
 npm install -g @kilocode/cli
 INSTALL_NPM_PACKAGES
 

--- a/.github/workflows/markdown-fix.yaml
+++ b/.github/workflows/markdown-fix.yaml
@@ -103,10 +103,12 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "26"
+          package-manager-cache: false
 
       - name: Install markdownlint-cli2
-        run: npm install -g markdownlint-cli2
+        run: |
+          npm install -g markdownlint-cli2
 
       - name: Run markdownlint-cli2 fix
         working-directory: ${{ needs.setup.outputs.checkout_path }}

--- a/.github/workflows/markdown-fix.yaml
+++ b/.github/workflows/markdown-fix.yaml
@@ -91,16 +91,6 @@ jobs:
       commit_sha_short: ${{ steps.handle_commit.outputs.commit_sha_short }}
       patch_name: ${{ steps.handle_commit.outputs.patch_name }}
     steps:
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "26"
-          package-manager-cache: false
-
-      - name: Ensure recent npm
-        run: |
-          npm update -g npm@^11.10.0
-
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -110,8 +100,16 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "26"
+          package-manager-cache: false
+
       - name: Install markdownlint-cli2
         run: |
+          npm update -g npm@^11.10.0
+          npm config set min-release-age=3 --location=user
           npm install -g markdownlint-cli2
 
       - name: Run markdownlint-cli2 fix

--- a/.github/workflows/markdown-fix.yaml
+++ b/.github/workflows/markdown-fix.yaml
@@ -91,6 +91,16 @@ jobs:
       commit_sha_short: ${{ steps.handle_commit.outputs.commit_sha_short }}
       patch_name: ${{ steps.handle_commit.outputs.patch_name }}
     steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "26"
+          package-manager-cache: false
+
+      - name: Ensure recent npm
+        run: |
+          npm update -g npm@^11.10.0
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -99,12 +109,6 @@ jobs:
           repository: ${{ needs.setup.outputs.repo }}
           token: ${{ secrets.WORKFLOW_PAT }}
           persist-credentials: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "26"
-          package-manager-cache: false
 
       - name: Install markdownlint-cli2
         run: |

--- a/.github/workflows/yaml-fix.yaml
+++ b/.github/workflows/yaml-fix.yaml
@@ -104,7 +104,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "26"
+          package-manager-cache: false
 
       - name: Install prettier
         run: npm install -g prettier

--- a/.github/workflows/yaml-fix.yaml
+++ b/.github/workflows/yaml-fix.yaml
@@ -92,16 +92,6 @@ jobs:
       patch_name: ${{ steps.handle_commit.outputs.patch_name }}
 
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "26"
-          package-manager-cache: false
-
-      - name: Ensure recent npm
-        run: |
-          npm update -g npm@^11.10.0
-
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -111,8 +101,16 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}
           persist-credentials: false
 
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "26"
+          package-manager-cache: false
+
       - name: Install prettier
         run: |
+          npm update -g npm@^11.10.0
+          npm config set min-release-age=3 --location=user
           npm install -g prettier
 
       - name: Apply YAML formatting

--- a/.github/workflows/yaml-fix.yaml
+++ b/.github/workflows/yaml-fix.yaml
@@ -92,6 +92,16 @@ jobs:
       patch_name: ${{ steps.handle_commit.outputs.patch_name }}
 
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "26"
+          package-manager-cache: false
+
+      - name: Ensure recent npm
+        run: |
+          npm update -g npm@^11.10.0
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -101,14 +111,9 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "26"
-          package-manager-cache: false
-
       - name: Install prettier
-        run: npm install -g prettier
+        run: |
+          npm install -g prettier
 
       - name: Apply YAML formatting
         working-directory: ${{ needs.setup.outputs.checkout_path }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-min-release-age=3


### PR DESCRIPTION
- Set min-release-age=3 to defer installation of npm packages released within
  the last 3 days, reducing risk of installing unstable prereleases
- Add .npmrc config file to persist this setting across builds
- Update Dockerfile to configure npm before installing @kilocode/cli


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Build system**
  - Add `.npmrc` with `min-release-age=3`.
  - Configure npm with the three-day release-age limit before installing `@kilocode/cli` in `.devcontainer/Dockerfile`.
  - Defer installation of packages released within the previous three days.

- **CI**
  - Update the Markdown Fix and YAML Fix workflows to use Node.js v26.
  - Disable the setup-node package-manager cache to avoid stale npm dependencies.
  - Install `markdownlint-cli2` with a multiline shell command in the Markdown Fix workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->