### PR TITLE
Fix straggling `clang-tidy` errors

### DIFF
--- a/form/core/technology.hpp
+++ b/form/core/technology.hpp
@@ -2,6 +2,7 @@
 #define FORM_CORE_TECHNOLOGY_HPP
 
 #include <compare>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -11,7 +12,7 @@
 namespace form::technology {
 
   // Major storage type (ROOT, HDF5, ...)
-  enum class Major {
+  enum class Major : std::uint8_t {
     generic = 0, // no specific technology requested
     root = 1,
     hdf5 = 2,

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -31,7 +31,7 @@ ROOT_TBranch_Read_ContainerImp::ROOT_TBranch_Read_ContainerImp(std::string const
 
 void ROOT_TBranch_Read_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
 {
-  ROOT_TFileImp* root_tfile_imp = dynamic_cast<ROOT_TFileImp*>(file.get());
+  auto* root_tfile_imp = dynamic_cast<ROOT_TFileImp*>(file.get());
   if (root_tfile_imp == nullptr) {
     throw std::runtime_error(
       "ROOT_TBranch_Read_ContainerImp::setFile can't attach to non-ROOT file");
@@ -166,7 +166,9 @@ bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_i
                                " (col_name='" + col_name() + "', type='" + DemangleName(type) +
                                "')");
     }
-    branchBuffer = klass->New();
+    // ROOT returns ownership of dynamically created branch payload objects here.
+    // NOLINTNEXTLINE(readability-redundant-casting)
+    branchBuffer = gsl::owner<void*>{klass->New()};
     branchStatus = m_tree->SetBranchAddress(
       col_name().c_str(), reinterpret_cast<void*>(&branchBuffer), klass, EDataType::kOther_t, true);
   }

--- a/form/root_storage/root_tbranch_write_container.cpp
+++ b/form/root_storage/root_tbranch_write_container.cpp
@@ -32,7 +32,7 @@ void ROOT_TBranch_Write_ContainerImp::setAttribute(std::string const& key, std::
 void ROOT_TBranch_Write_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
 {
   this->Storage_Associative_Write_Container::setFile(file);
-  ROOT_TFileImp* root_tfile_imp = dynamic_cast<ROOT_TFileImp*>(file.get());
+  auto* root_tfile_imp = dynamic_cast<ROOT_TFileImp*>(file.get());
   if (root_tfile_imp == nullptr) {
     throw std::runtime_error(
       "ROOT_TBranch_Write_ContainerImp::setFile can't attach to non-ROOT file");
@@ -43,8 +43,7 @@ void ROOT_TBranch_Write_ContainerImp::setFile(std::shared_ptr<IStorage_File> fil
 void ROOT_TBranch_Write_ContainerImp::setParent(std::shared_ptr<IStorage_Write_Container> parent)
 {
   this->Storage_Associative_Write_Container::setParent(parent);
-  ROOT_TTree_Write_ContainerImp* root_ttree_imp =
-    dynamic_cast<ROOT_TTree_Write_ContainerImp*>(parent.get());
+  auto* root_ttree_imp = dynamic_cast<ROOT_TTree_Write_ContainerImp*>(parent.get());
   if (root_ttree_imp == nullptr) {
     throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::setParent");
   }

--- a/form/root_storage/root_ttree_write_container.cpp
+++ b/form/root_storage/root_ttree_write_container.cpp
@@ -18,12 +18,12 @@ ROOT_TTree_Write_ContainerImp::ROOT_TTree_Write_ContainerImp(std::string const& 
 void ROOT_TTree_Write_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
 {
   this->Storage_Write_Association::setFile(file);
-  ROOT_TFileImp* root_tfile_imp = dynamic_cast<ROOT_TFileImp*>(file.get());
+  auto* root_tfile_imp = dynamic_cast<ROOT_TFileImp*>(file.get());
   if (root_tfile_imp == nullptr) {
     throw std::runtime_error(
       "ROOT_TTree_Write_ContainerImp::setFile can't attach to non-ROOT file");
   }
-  m_tfile = dynamic_cast<ROOT_TFileImp*>(file.get())->getTFile();
+  m_tfile = root_tfile_imp->getTFile();
 }
 
 void ROOT_TTree_Write_ContainerImp::setupWrite(std::type_info const& /* type*/)
@@ -35,7 +35,9 @@ void ROOT_TTree_Write_ContainerImp::setupWrite(std::type_info const& /* type*/)
     m_tree.reset(m_tfile->Get<TTree>(name().c_str()));
   }
   if (m_tree == nullptr) {
-    m_tree.reset(new TTree(name().c_str(), name().c_str()));
+    // Mark the raw allocation as an owning pointer before transferring it.
+    // NOLINTNEXTLINE(readability-redundant-casting)
+    m_tree.reset(gsl::owner<TTree*>{new TTree(name().c_str(), name().c_str())});
     m_tree->SetDirectory(m_tfile.get());
   }
   if (m_tree == nullptr) {

--- a/form/root_storage/root_ttree_write_container.hpp
+++ b/form/root_storage/root_ttree_write_container.hpp
@@ -16,6 +16,7 @@ namespace form::detail::experimental {
   class ROOT_TTree_Write_ContainerImp : public Storage_Write_Association {
   public:
     explicit ROOT_TTree_Write_ContainerImp(std::string const& name);
+    ~ROOT_TTree_Write_ContainerImp() override = default;
 
     ROOT_TTree_Write_ContainerImp(ROOT_TTree_Write_ContainerImp const&) = delete;
     ROOT_TTree_Write_ContainerImp& operator=(ROOT_TTree_Write_ContainerImp const&) = delete;

--- a/form/storage/storage_reader.cpp
+++ b/form/storage/storage_reader.cpp
@@ -389,5 +389,4 @@ void StorageReader::readContainer(Token const& token,
     }
   }
   cont->second->read(token.id(), data, type);
-  return;
 }

--- a/phlex/core/.clang-tidy
+++ b/phlex/core/.clang-tidy
@@ -1,0 +1,7 @@
+---
+InheritParentConfig: true
+
+# TBB's type-erased flow-graph tbb::flow::tagged_msg<>::cast_to<> command trigger a false positive
+# in this path-sensitive analyzer check; the diagnostic is reported in TBB headers.
+Checks: >
+  -clang-analyzer-core.CallAndMessage

--- a/phlex/core/detail/accumulator_node.hpp
+++ b/phlex/core/detail/accumulator_node.hpp
@@ -120,9 +120,9 @@ namespace phlex::detail::internal {
 
     struct cached_accumulator {
       std::shared_ptr<accumulator_msg_t> accumulator_msg;
-      tbb::concurrent_queue<std::size_t> msg_ids{};
+      tbb::concurrent_queue<std::size_t> msg_ids;
       std::atomic<int> counter;
-      std::atomic_flag flush_received{};
+      std::atomic_flag flush_received;
       std::size_t original_message_id{};
     };
 

--- a/phlex/core/detail/repeater_node.cpp
+++ b/phlex/core/detail/repeater_node.cpp
@@ -169,5 +169,4 @@ namespace phlex::detail::internal {
       cached_products_.erase(a);
     }
   }
-
 }

--- a/phlex/core/fold/send.hpp
+++ b/phlex/core/fold/send.hpp
@@ -48,7 +48,7 @@ namespace phlex::experimental {
   }
 
   template <typename T>
-  using sendable_type = typename detail::sendable_type_impl<T>::type;
+  using sendable_type = detail::sendable_type_impl<T>::type;
 }
 
 #endif // PHLEX_CORE_FOLD_SEND_HPP

--- a/phlex/core/fold_join_node.hpp
+++ b/phlex/core/fold_join_node.hpp
@@ -57,8 +57,8 @@ namespace phlex::detail {
     using base_t = fold_join_node_base_t<FoldResult, NInputs>;
     using join_args_t = accumulator_with_messages<FoldResult, NInputs>;
     using result_initializer_t = std::function<std::unique_ptr<FoldResult>(data_cell_index const&)>;
-    using input_t = typename base_t::input_ports_type;
-    using output_t = typename base_t::output_ports_type;
+    using input_t = base_t::input_ports_type;
+    using output_t = base_t::output_ports_type;
 
     template <std::size_t... Is>
     static auto make_join(tbb::flow::graph& g, std::index_sequence<Is...>)

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -45,7 +45,7 @@ namespace phlex::detail {
     index_router::fold_partition_ports_t fold_partition_ports(declared_folds const& folds)
     {
       index_router::fold_partition_ports_t result;
-      for (auto& [fold_name, fold_node] : folds) {
+      for (auto const& [fold_name, fold_node] : folds) {
         result.try_emplace(fold_name, fold_node->partition_layer(), &fold_node->partition_port());
       }
       return result;
@@ -254,6 +254,6 @@ namespace phlex::detail {
                            unfold_layers(nodes_.unfolds),
                            std::move(provider_input_ports),
                            fold_partition_ports(nodes_.folds),
-                           std::move(multilayer_join_index_ports));
+                           multilayer_join_index_ports);
   }
 }

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -23,6 +23,7 @@
 #include "oneapi/tbb/info.h"
 
 #include <concepts>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -190,7 +191,7 @@ namespace phlex::detail {
     void make_filter_edges();
     void make_bookkeeping_edges();
 
-    enum class driver_mode { default_driver, deferred_driver };
+    enum class driver_mode : std::uint8_t { default_driver, deferred_driver };
     explicit framework_graph(driver_mode mode, int max_parallelism);
 
     resource_usage graph_resource_usage_;

--- a/phlex/core/framework_graph.hpp
+++ b/phlex/core/framework_graph.hpp
@@ -23,6 +23,7 @@
 #include "oneapi/tbb/info.h"
 
 #include <concepts>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -187,7 +188,7 @@ namespace phlex::detail {
     void finalize_router(index_router::provider_input_ports_t provider_input_ports,
                          std::map<std::string, named_index_ports> multilayer_join_index_ports);
 
-    enum class driver_mode { default_driver, deferred_driver };
+    enum class driver_mode : std::uint8_t { default_driver, deferred_driver };
     explicit framework_graph(driver_mode mode, int max_parallelism);
 
     resource_usage graph_resource_usage_;

--- a/phlex/core/index_router.cpp
+++ b/phlex/core/index_router.cpp
@@ -114,7 +114,7 @@ namespace phlex::detail {
     unfold_count_per_input_layer_ = std::move(unfolds.count_per_input_layer);
     wire_provider_index_sets(g, std::move(provider_input_ports));
     wire_fold_partition_index_sets(g, std::move(fold_partition_ports));
-    build_multilayer_join_slots(g, std::move(multilayer_join_ports));
+    build_multilayer_join_slots(g, multilayer_join_ports);
   }
 
   // --------------------------------------------------------------------------------------------
@@ -393,7 +393,7 @@ namespace phlex::detail {
       std::size_t matched_count = 0;
 
       for (std::size_t i = 0; i != slots.size(); ++i) {
-        auto& slot = slots[i];
+        auto const& slot = slots[i];
         auto const& flush = flush_specs[i];
         if (slot->matches_exactly(layer_path)) {
           has_exact_match = true;

--- a/phlex/driver.hpp
+++ b/phlex/driver.hpp
@@ -183,7 +183,7 @@ namespace phlex::detail {
       auto h = hierarchy;
       return {[f = std::move(driver_function),
                h = std::move(h),
-               srcs = std::move(sources_),
+               srcs = sources_,
                first_arg_factory = std::move(first_arg_factory)](framework_driver& d) mutable {
                 internal::invoke_driver_with_sources<source_parameters_t>(
                   f, first_arg_factory(h, d), srcs);

--- a/phlex/model/fixed_hierarchy.cpp
+++ b/phlex/model/fixed_hierarchy.cpp
@@ -21,7 +21,7 @@ namespace {
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
   std::vector<layer_path> unique_paths(std::vector<layer_path> paths)
   {
-    std::set<layer_path> const unique{std::from_range, std::move(paths)};
+    std::set<layer_path> unique{std::from_range, std::move(paths)};
     return {std::from_range, std::move(unique)};
   }
 
@@ -50,7 +50,7 @@ namespace {
   }
 
   std::vector<layer_path> convert_vector_vector_string(
-    std::vector<std::vector<std::string>>&& layer_path_strings)
+    std::vector<std::vector<std::string>> layer_path_strings)
   {
     std::vector<layer_path> layer_paths;
     layer_paths.reserve(layer_path_strings.size());

--- a/plugins/generate_layers.cpp
+++ b/plugins/generate_layers.cpp
@@ -38,5 +38,5 @@ PHLEX_REGISTER_DRIVER(d, config)
                     .starting_value = layer_config.get<unsigned int>("starting_number", 0)});
   }
 
-  return d.driver(std::move(gen));
+  return d.driver(gen);
 }

--- a/plugins/python/src/modulewrap.cpp
+++ b/plugins/python/src/modulewrap.cpp
@@ -143,13 +143,11 @@ namespace {
     }
     py_callback_base(py_callback_base&& other) = delete;
     py_callback_base& operator=(py_callback_base&& other) = delete;
-    virtual ~py_callback_base()
-    {
-      // TODO: cleanup deferred to Phlex shutdown hook
-      // Cannot safely Py_DECREF during arbitrary destruction due to:
-      // - TOCTOU race on Py_IsInitialized() without GIL
-      // - Module offloading in interpreter cleanup phase 2
-    }
+    // TODO: cleanup deferred to Phlex shutdown hook
+    // Cannot safely Py_DECREF during arbitrary destruction due to:
+    // - TOCTOU race on Py_IsInitialized() without GIL
+    // - Module offloading in interpreter cleanup phase 2
+    virtual ~py_callback_base() = default;
   };
 
   // type repeater to automatically instantiate callbacks taking N args

--- a/test/core_misc_test.cpp
+++ b/test/core_misc_test.cpp
@@ -91,7 +91,7 @@ TEST_CASE("verify_name tests", "[core]")
       FAIL("Should have thrown");
     } catch (std::runtime_error const& e) {
       std::string msg = e.what();
-      CHECK(msg.find("my_module") != std::string::npos);
+      CHECK(msg.contains("my_module"));
     }
   }
 }
@@ -104,5 +104,5 @@ TEST_CASE("add_to_error_messages tests", "[core]")
   add_to_error_messages(errors, "Node", "duplicate_node");
 
   REQUIRE(errors.size() == 1);
-  CHECK(errors[0].find("duplicate_node") != std::string::npos);
+  CHECK(errors[0].contains("duplicate_node"));
 }

--- a/test/fold_duplicate_layer_name_test.cpp
+++ b/test/fold_duplicate_layer_name_test.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Fold different layer paths with same trailing name", "[graph]")
   g.execute();
 
   CHECK(g.execution_count("run_add") == std::size_t{index_limit} * number_limit);
-  CHECK(g.execution_count("job_add") == index_limit * number_limit + top_level_event_limit);
+  CHECK(g.execution_count("job_add") == (index_limit * number_limit) + top_level_event_limit);
   CHECK(g.execution_count("verify_run_sum") == index_limit);
   CHECK(g.execution_count("verify_job_sum") == 1);
 }

--- a/test/form/form_basics_test.cpp
+++ b/test/form/form_basics_test.cpp
@@ -13,12 +13,12 @@
 #include "storage/storage_read_container.hpp"
 #include "storage/storage_write_association.hpp"
 #include "storage/storage_write_container.hpp"
-#if defined(USE_ROOT_STORAGE)
+#ifdef USE_ROOT_STORAGE
 #include "root_storage/root_tbranch_read_container.hpp"
 #include "root_storage/root_tbranch_write_container.hpp"
 #include "root_storage/root_ttree_write_container.hpp"
 #endif
-#if defined(USE_RNTUPLE_STORAGE)
+#ifdef USE_RNTUPLE_STORAGE
 #include "root_storage/root_rfield_read_container.hpp"
 #include "root_storage/root_rfield_write_container.hpp"
 #include "root_storage/root_rntuple_write_container.hpp"
@@ -203,7 +203,7 @@ TEST_CASE("Factories fallback", "[form]")
 
 TEST_CASE("Factories ROOT storage dispatch", "[form]")
 {
-#if defined(USE_ROOT_STORAGE)
+#ifdef USE_ROOT_STORAGE
   auto rc_ttree = createReadContainer(form::technology::ROOT_TTREE, "cont");
   CHECK(dynamic_cast<ROOT_TBranch_Read_ContainerImp*>(rc_ttree.get()) != nullptr);
 
@@ -227,7 +227,7 @@ TEST_CASE("Factories ROOT storage dispatch", "[form]")
 
 TEST_CASE("Factories RNTuple storage dispatch", "[form]")
 {
-#if defined(USE_RNTUPLE_STORAGE)
+#ifdef USE_RNTUPLE_STORAGE
   auto rc_rntuple = createReadContainer(form::technology::ROOT_RNTUPLE, "cont");
   CHECK(dynamic_cast<ROOT_RField_Read_ContainerImp*>(rc_rntuple.get()) != nullptr);
 

--- a/test/unfold.cpp
+++ b/test/unfold.cpp
@@ -81,10 +81,7 @@ namespace {
   // Provider algorithms
   unsigned int provide_max_number(data_cell_index const& id) { return 10u * (id.number() + 1); }
 
-  numbers_t provide_ten_numbers(data_cell_index const& id)
-  {
-    return numbers_t(10, id.number() + 1);
-  }
+  auto provide_ten_numbers(data_cell_index const& id) { return numbers_t(10, id.number() + 1); }
 }
 
 TEST_CASE("Splitting the processing", "[graph]")

--- a/test/unfold.cpp
+++ b/test/unfold.cpp
@@ -82,10 +82,7 @@ namespace {
   // Provider algorithms
   unsigned int provide_max_number(data_cell_index const& id) { return 10u * (id.number() + 1); }
 
-  numbers_t provide_ten_numbers(data_cell_index const& id)
-  {
-    return numbers_t(10, id.number() + 1);
-  }
+  auto provide_ten_numbers(data_cell_index const& id) { return numbers_t(10, id.number() + 1); }
 
   class iota_two_inputs {
   public:


### PR DESCRIPTION
This PR addresses some `clang-tidy` issues that should already be resolved (according to the `docs/dev/clang-tidy-fixes-2026-04.md` checklist), but they either crept back in or were somehow skipped.

Checks found to have crept back in and addressed by this PR:

- `cppcoreguidelines-rvalue-reference-param-not-moved`
- `modernize-use-equals-default`
- `performance-enum-size`
- `performance-move-const-arg`
- `readability-use-concise-preprocessor-directives`
- `clang-analyzer-core.CallAndMessage` (a false positive from oneAPI TBB type-erased flow-graph casts; suppressed only for `phlex/core`)

----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Code quality**
  - Fixed `clang-tidy` findings in ROOT storage code with inferred pointer types and explicit `gsl::owner<void*>` annotations.
  - Added a defaulted virtual destructor to `ROOT_TTree_Write_ContainerImp`.
  - Removed a redundant `return` statement from `StorageReader::readContainer`.
  - Defined `framework_graph::driver_mode` and `technology::Major` with `std::uint8_t`.
  - Added a `phlex/core/.clang-tidy` configuration that inherits parent settings and disables a false-positive analyzer check.
  - Removed redundant `typename` qualifiers and unnecessary move operations.
  - Simplified ownership, constness, initialization, and type-deduction patterns across core and plugin code.
  - Defaulted the `py_callback_base` destructor.

- **Tests**
  - Replaced `find(...) != std::string::npos` checks with `std::string::contains`.
  - Used an explicitly typed `std::size_t` value in an execution-count assertion.
  - Simplified `provide_ten_numbers` with return-type deduction without changing behavior.
  - Updated ROOT storage preprocessor guards from `#if defined(...)` to `#ifdef`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->