### PR TITLE
Make layer specification optional

### DIFF
--- a/phlex/configuration.cpp
+++ b/phlex/configuration.cpp
@@ -40,12 +40,12 @@ namespace phlex {
   product_selector tag_invoke(boost::json::value_to_tag<product_selector> const&,
                               boost::json::value const& jv)
   {
-    using detail::value_decorate_exception;
+    using detail::value_if_exists;
     auto query_object = jv.as_object();
-    auto creator = value_decorate_exception<experimental::identifier>(query_object, "creator");
-    auto layer = value_decorate_exception<experimental::identifier>(query_object, "layer");
-    auto suffix = detail::value_if_exists(query_object, "suffix");
-    auto stage = detail::value_if_exists(query_object, "stage");
+    auto creator = value_if_exists(query_object, "creator");
+    auto layer = value_if_exists(query_object, "layer");
+    auto suffix = value_if_exists(query_object, "suffix");
+    auto stage = value_if_exists(query_object, "stage");
     return product_selector{
       .creator = std::move(creator), .layer = std::move(layer), .suffix = suffix, .stage = stage};
   }

--- a/phlex/core/CMakeLists.txt
+++ b/phlex/core/CMakeLists.txt
@@ -1,13 +1,3 @@
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14.1)
-    set(_std_stacktrace_library stdc++exp)
-  else()
-    set(_std_stacktrace_library stdc++_libbacktrace)
-  endif()
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  set(_std_stacktrace_library stdc++exp)
-endif()
-
 cet_make_library(
   LIBRARY_NAME
   phlex_core
@@ -44,7 +34,6 @@ cet_make_library(
   phlex::metaprogramming
   phlex::model
   phlex::utilities
-  ${_std_stacktrace_library}
   PRIVATE
   Boost::json
   spdlog::spdlog
@@ -106,7 +95,6 @@ phlex_make_internal_library(
   phlex_core
   LIBRARIES
   PUBLIC TBB::tbb phlex::metaprogramming phlex_model_internal phlex_utilities_internal
-         ${_std_stacktrace_library}
   PRIVATE Boost::json spdlog::spdlog
 )
 add_library(phlex::core_internal ALIAS phlex_core_internal)

--- a/phlex/core/CMakeLists.txt
+++ b/phlex/core/CMakeLists.txt
@@ -38,6 +38,15 @@ cet_make_library(
   Boost::json
   spdlog::spdlog
 )
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14.1)
+    target_link_libraries(phlex_core PUBLIC -lstdc++exp)
+  else()
+    target_link_libraries(phlex_core PUBLIC -lstdc++_libbacktrace)
+  endif()
+endif()
+
 install(
   FILES
     concepts.hpp

--- a/phlex/core/CMakeLists.txt
+++ b/phlex/core/CMakeLists.txt
@@ -1,3 +1,13 @@
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14.1)
+    set(_std_stacktrace_library stdc++exp)
+  else()
+    set(_std_stacktrace_library stdc++_libbacktrace)
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  set(_std_stacktrace_library stdc++exp)
+endif()
+
 cet_make_library(
   LIBRARY_NAME
   phlex_core
@@ -34,18 +44,11 @@ cet_make_library(
   phlex::metaprogramming
   phlex::model
   phlex::utilities
+  ${_std_stacktrace_library}
   PRIVATE
   Boost::json
   spdlog::spdlog
 )
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14.1)
-    target_link_libraries(phlex_core PUBLIC -lstdc++exp)
-  else()
-    target_link_libraries(phlex_core PUBLIC -lstdc++_libbacktrace)
-  endif()
-endif()
 
 install(
   FILES
@@ -103,17 +106,10 @@ phlex_make_internal_library(
   phlex_core
   LIBRARIES
   PUBLIC TBB::tbb phlex::metaprogramming phlex_model_internal phlex_utilities_internal
+         ${_std_stacktrace_library}
   PRIVATE Boost::json spdlog::spdlog
 )
 add_library(phlex::core_internal ALIAS phlex_core_internal)
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14.1)
-    target_link_libraries(phlex_core_internal PUBLIC -lstdc++exp)
-  else()
-    target_link_libraries(phlex_core_internal PUBLIC -lstdc++_libbacktrace)
-  endif()
-endif()
 
 # Interface library
 cet_make_library(

--- a/phlex/core/CMakeLists.txt
+++ b/phlex/core/CMakeLists.txt
@@ -107,6 +107,14 @@ phlex_make_internal_library(
 )
 add_library(phlex::core_internal ALIAS phlex_core_internal)
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14.1)
+    target_link_libraries(phlex_core_internal PUBLIC -lstdc++exp)
+  else()
+    target_link_libraries(phlex_core_internal PUBLIC -lstdc++_libbacktrace)
+  endif()
+endif()
+
 # Interface library
 cet_make_library(
   LIBRARY_NAME

--- a/phlex/core/declared_fold.cpp
+++ b/phlex/core/declared_fold.cpp
@@ -5,10 +5,8 @@ namespace phlex::detail {
                                std::vector<std::string> predicates,
                                product_selectors input_products,
                                std::string partition_layer) :
-    products_consumer{std::move(name),
-                      std::move(predicates),
-                      std::move(input_products),
-                      true /* layers mandatory */},
+    products_consumer{
+      std::move(name), std::move(predicates), std::move(input_products), layers_required::always},
     partition_layer_{std::move(partition_layer)}
   {
   }

--- a/phlex/core/declared_fold.cpp
+++ b/phlex/core/declared_fold.cpp
@@ -6,7 +6,7 @@ namespace phlex::detail {
                                product_selectors input_products,
                                std::string partition_layer) :
     products_consumer{
-      std::move(name), std::move(predicates), std::move(input_products), layers_required::always},
+      std::move(name), std::move(predicates), std::move(input_products), require_layers::always},
     partition_layer_{std::move(partition_layer)}
   {
   }

--- a/phlex/core/declared_fold.cpp
+++ b/phlex/core/declared_fold.cpp
@@ -5,7 +5,10 @@ namespace phlex::detail {
                                std::vector<std::string> predicates,
                                product_selectors input_products,
                                std::string partition_layer) :
-    products_consumer{std::move(name), std::move(predicates), std::move(input_products)},
+    products_consumer{std::move(name),
+                      std::move(predicates),
+                      std::move(input_products),
+                      true /* layers mandatory */},
     partition_layer_{std::move(partition_layer)}
   {
   }

--- a/phlex/core/declared_observer.cpp
+++ b/phlex/core/declared_observer.cpp
@@ -4,7 +4,10 @@ namespace phlex::detail {
   declared_observer::declared_observer(phlex::experimental::algorithm_name name,
                                        std::vector<std::string> predicates,
                                        product_selectors input_products) :
-    products_consumer{std::move(name), std::move(predicates), std::move(input_products)}
+    products_consumer{std::move(name),
+                      std::move(predicates),
+                      std::move(input_products),
+                      require_layers::multi_input_only}
   {
   }
 

--- a/phlex/core/declared_predicate.cpp
+++ b/phlex/core/declared_predicate.cpp
@@ -4,7 +4,10 @@ namespace phlex::detail {
   declared_predicate::declared_predicate(phlex::experimental::algorithm_name name,
                                          std::vector<std::string> predicates,
                                          product_selectors input_products) :
-    products_consumer{std::move(name), std::move(predicates), std::move(input_products)}
+    products_consumer{std::move(name),
+                      std::move(predicates),
+                      std::move(input_products),
+                      require_layers::multi_input_only}
   {
   }
 

--- a/phlex/core/declared_transform.cpp
+++ b/phlex/core/declared_transform.cpp
@@ -4,7 +4,10 @@ namespace phlex::detail {
   declared_transform::declared_transform(phlex::experimental::algorithm_name name,
                                          std::vector<std::string> predicates,
                                          product_selectors input_products) :
-    products_consumer{std::move(name), std::move(predicates), std::move(input_products)}
+    products_consumer{std::move(name),
+                      std::move(predicates),
+                      std::move(input_products),
+                      require_layers::multi_input_only}
   {
   }
 

--- a/phlex/core/declared_unfold.cpp
+++ b/phlex/core/declared_unfold.cpp
@@ -32,7 +32,7 @@ namespace phlex::detail {
                                    product_selectors input_products,
                                    std::string child_layer) :
     products_consumer{
-      std::move(name), std::move(predicates), std::move(input_products), layers_required::always},
+      std::move(name), std::move(predicates), std::move(input_products), require_layers::always},
     child_layer_{std::move(child_layer)}
   {
   }

--- a/phlex/core/declared_unfold.cpp
+++ b/phlex/core/declared_unfold.cpp
@@ -31,7 +31,8 @@ namespace phlex::detail {
                                    std::vector<std::string> predicates,
                                    product_selectors input_products,
                                    std::string child_layer) :
-    products_consumer{std::move(name), std::move(predicates), std::move(input_products)},
+    products_consumer{
+      std::move(name), std::move(predicates), std::move(input_products), layers_required::always},
     child_layer_{std::move(child_layer)}
   {
   }

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -66,10 +66,7 @@ namespace phlex::detail {
         phlex::experimental::identifier const child_layer{n->child_layer()};
         std::set<phlex::experimental::identifier> input_layers_for_unfold;
         for (auto const& input : n->input()) {
-          if (!input.layer) {
-            throw std::runtime_error(fmt::format(
-              "{} used by unfold {} has no layer defined", input, n->name().to_string()));
-          }
+          // Existence of layer already validated
           auto const& input_layer =
             static_cast<phlex::experimental::identifier const&>(input.layer);
           if (not input_layers_for_unfold.insert(input_layer).second) {

--- a/phlex/core/framework_graph.cpp
+++ b/phlex/core/framework_graph.cpp
@@ -66,11 +66,12 @@ namespace phlex::detail {
         phlex::experimental::identifier const child_layer{n->child_layer()};
         std::set<phlex::experimental::identifier> input_layers_for_unfold;
         for (auto const& input : n->input()) {
+          if (!input.layer) {
+            throw std::runtime_error(fmt::format(
+              "{} used by unfold {} has no layer defined", input, n->name().to_string()));
+          }
           auto const& input_layer =
             static_cast<phlex::experimental::identifier const&>(input.layer);
-          if (input_layer.empty()) {
-            continue;
-          }
           if (not input_layers_for_unfold.insert(input_layer).second) {
             continue;
           }

--- a/phlex/core/index_router.cpp
+++ b/phlex/core/index_router.cpp
@@ -108,6 +108,7 @@ namespace phlex::detail {
                               fold_partition_ports_t fold_partition_ports,
                               std::map<std::string, named_index_ports> const& multilayer_join_ports)
   {
+    using namespace phlex::experimental::literals;
     // We must have at least one provider port, or there can be no data to process.
     assert(!provider_input_ports.empty());
 
@@ -196,7 +197,7 @@ namespace phlex::detail {
                                               provider_input_ports_t provider_input_ports)
   {
     for (auto& [input_product, provider_port] : provider_input_ports | std::views::values) {
-      auto [it, _] = index_set_nodes_.emplace(input_product.layer,
+      auto [it, _] = index_set_nodes_.emplace(input_product.layer ? *input_product.layer : "*"_id,
                                               std::make_shared<internal::index_set_node>(g));
       make_edge(*it->second, *provider_port);
     }

--- a/phlex/core/make_computational_edges.cpp
+++ b/phlex/core/make_computational_edges.cpp
@@ -52,8 +52,12 @@ namespace phlex::detail {
           // output port) and the right family (hidden in the input port).
           if (auto* matched_provider = find_matching_provider(explicit_providers, input_product)) {
             auto const provider_name = matched_provider->name().to_string();
-            provider_input_ports.try_emplace(
+            auto&& [it, _] = provider_input_ports.try_emplace(
               provider_name, input_product, matched_provider->input_port());
+            // Rewrite the stored layer if it's empty
+            if (!input_product.layer) {
+              it->second.input_product.layer = matched_provider->layer();
+            }
             spdlog::debug("Connecting provider {} to node {} (product: {})",
                           provider_name,
                           node_name,
@@ -80,7 +84,7 @@ namespace phlex::detail {
         for (auto const& [input_product, port] : ports) {
           auto existing_provider_it = std::ranges::find_if(
             provider_input_ports, [&input_product](auto const& provider_entry) {
-              return provider_entry.second.input_product == input_product;
+              return input_product.match(provider_entry.second.input_product);
             });
 
           if (existing_provider_it != provider_input_ports.end()) {
@@ -110,8 +114,12 @@ namespace phlex::detail {
           auto& bundle = bundles[0];
           auto node = std::make_unique<provider_node>(g, std::move(bundle));
           auto const provider_name = node->name().to_string();
-          auto [_, inserted] =
+          auto&& [it, inserted] =
             provider_input_ports.try_emplace(provider_name, input_product, node->input_port());
+          // Rewrite the stored layer if it's empty
+          if (!input_product.layer) {
+            it->second.input_product.layer = node->layer();
+          }
           if (!inserted) {
             throw std::runtime_error(
               fmt::format("Failed to create implicit provider for product selector '{}'\n"

--- a/phlex/core/make_computational_edges.cpp
+++ b/phlex/core/make_computational_edges.cpp
@@ -22,10 +22,24 @@ namespace phlex::detail {
       };
       auto proj = [](auto const& pair) -> provider_node* { return pair.second.get(); };
 
-      if (auto it = std::ranges::find_if(providers, pred, proj); it != providers.end()) {
-        return it->second.get();
+      auto candidates = providers | std::views::transform(proj) | std::views::filter(pred) |
+                        std::ranges::to<std::vector>();
+      switch (candidates.size()) {
+      case 0:
+        return nullptr;
+      case 1:
+        return candidates[0];
+      default:
+        auto items = candidates | std::views::transform([](provider_node* p) {
+                       return fmt::format("spec: {}, layer: {}, stage: {}",
+                                          p->output_product().to_string(),
+                                          p->layer(),
+                                          p->stage());
+                     });
+        throw std::runtime_error(fmt::format("Multiple explicit providers found for {}:\n{}",
+                                             input_product.to_string(),
+                                             bulleted_list(items)));
       }
-      return nullptr;
     }
 
     provider_bundles find_matching_implicit_providers(source_map const& sources,

--- a/phlex/core/multilayer_join_node.hpp
+++ b/phlex/core/multilayer_join_node.hpp
@@ -83,7 +83,7 @@ namespace phlex::detail {
       std::set collapsed_layers(layers_.begin(), layers_.end());
 
       // Add repeaters only if the inputs span more than one distinct layer.
-      if (collapsed_layers.size() > 1 || collapsed_layers.contains("*"_id)) {
+      if (collapsed_layers.size() > 1) {
         repeaters_.reserve(NInputs);
         for (auto const& layer : layers_) {
           repeaters_.push_back(std::make_unique<internal::repeater_node>(g, name_, layer));

--- a/phlex/core/multilayer_join_node.hpp
+++ b/phlex/core/multilayer_join_node.hpp
@@ -76,15 +76,14 @@ namespace phlex::detail {
       name_{std::move(node_name)},
       layers_{std::move(layer_names)}
     {
-      assert(NInputs == layers_.size());
-
+      using namespace experimental::literals;
       // Collapse to the set of distinct layer names.  More than one distinct layer means
       // at least one input crosses a layer boundary and therefore every input stream
       // needs a repeater_node.
       std::set collapsed_layers(layers_.begin(), layers_.end());
 
       // Add repeaters only if the inputs span more than one distinct layer.
-      if (collapsed_layers.size() > 1) {
+      if (collapsed_layers.size() > 1 || collapsed_layers.contains("*"_id)) {
         repeaters_.reserve(NInputs);
         for (auto const& layer : layers_) {
           repeaters_.push_back(std::make_unique<internal::repeater_node>(g, name_, layer));

--- a/phlex/core/multilayer_join_node.hpp
+++ b/phlex/core/multilayer_join_node.hpp
@@ -76,7 +76,7 @@ namespace phlex::detail {
       name_{std::move(node_name)},
       layers_{std::move(layer_names)}
     {
-      using namespace experimental::literals;
+      assert(NInputs == layers_.size());
       // Collapse to the set of distinct layer names.  More than one distinct layer means
       // at least one input crosses a layer boundary and therefore every input stream
       // needs a repeater_node.

--- a/phlex/core/product_selector.cpp
+++ b/phlex/core/product_selector.cpp
@@ -77,7 +77,7 @@ namespace phlex {
       suffix.transform(&identifier::operator std::string_view).value_or("[ANY]");
     std::string type_str = this->type.valid() ? fmt::format("<{}>", this->type)
                                               : "[UNSET TYPE]"; // will later be concept
-    auto layer_str = layer ? std::string_view(layer) : "[ANY]";
+    auto layer_str = std::string_view(layer);
     std::string_view creator_str = creator ? std::string_view(*creator) : "[ANY]";
     std::string_view stage_str =
       stage.transform(&identifier::operator std::string_view).value_or("[ANY]");

--- a/phlex/core/product_selector.cpp
+++ b/phlex/core/product_selector.cpp
@@ -99,12 +99,8 @@ namespace phlex {
   std::strong_ordering product_selector::operator<=>(product_selector const& rhs) const
   {
     using experimental::identifier;
-    return std::tie(type, creator, static_cast<identifier const&>(layer), suffix, stage) <=>
-           std::tie(rhs.type,
-                    rhs.creator,
-                    static_cast<identifier const&>(rhs.layer),
-                    rhs.suffix,
-                    rhs.stage);
+    return std::tie(type, creator, layer, suffix, stage) <=>
+           std::tie(rhs.type, rhs.creator, rhs.layer, rhs.suffix, rhs.stage);
   }
 
   detail::product_specification const* resolve_in_store(product_selector const& query,

--- a/phlex/core/product_selector.cpp
+++ b/phlex/core/product_selector.cpp
@@ -9,7 +9,7 @@ namespace phlex {
     if (creator && creator != other.creator) {
       return false;
     }
-    if (layer != other.layer) {
+    if (layer && layer != other.layer) {
       return false;
     }
     if (suffix && suffix != other.suffix) {
@@ -50,7 +50,7 @@ namespace phlex {
     if (!match(spec)) {
       return false;
     }
-    if (experimental::identifier(this->layer) != layer) {
+    if (this->layer && experimental::identifier(this->layer) != layer) {
       return false;
     }
     if (this->stage && this->stage != stage) {
@@ -77,7 +77,7 @@ namespace phlex {
       suffix.transform(&identifier::operator std::string_view).value_or("[ANY]");
     std::string type_str = this->type.valid() ? fmt::format("<{}>", this->type)
                                               : "[UNSET TYPE]"; // will later be concept
-    auto layer_str = std::string_view(layer);
+    auto layer_str = layer ? std::string_view(layer) : "[ANY]";
     std::string_view creator_str = creator ? std::string_view(*creator) : "[ANY]";
     std::string_view stage_str =
       stage.transform(&identifier::operator std::string_view).value_or("[ANY]");

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -21,8 +21,6 @@ using namespace phlex::experimental::literals;
 
 namespace phlex {
   namespace detail {
-    // The creator_name has to be a template for static_assert(false)
-    template <std::same_as<experimental::identifier> T>
     class creator_name {
     public:
       creator_name() : content_{std::nullopt} {}
@@ -33,7 +31,7 @@ namespace phlex {
         }
       }
       template <typename U>
-        requires std::constructible_from<T, U>
+        requires std::constructible_from<experimental::identifier, U>
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
       creator_name(U&& rhs) : content_(std::forward<U>(rhs))
       {
@@ -55,8 +53,6 @@ namespace phlex {
       std::optional<experimental::identifier> content_;
     };
 
-    // The required_layer_name has to be a template for static_assert(false)
-    template <std::same_as<experimental::identifier> T>
     class layer_name {
     public:
       layer_name() : content_(std::nullopt) {}
@@ -67,7 +63,7 @@ namespace phlex {
         }
       }
       template <typename U>
-        requires std::constructible_from<T, U>
+        requires std::constructible_from<experimental::identifier, U>
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
       layer_name(U&& rhs) : content_(std::forward<U>(rhs))
       {
@@ -103,8 +99,8 @@ namespace phlex {
   }
 
   struct PHLEX_CORE_EXPORT product_selector {
-    detail::creator_name<experimental::identifier> creator;
-    detail::layer_name<experimental::identifier> layer;
+    detail::creator_name creator;
+    detail::layer_name layer;
     std::optional<experimental::identifier> suffix;
     std::optional<experimental::identifier> stage;
     detail::type_id type;

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -11,7 +11,6 @@
 #include <concepts>
 #include <format>
 #include <optional>
-#include <stacktrace>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -81,9 +80,7 @@ namespace phlex {
       operator T const&() const
       {
         if (!content_.has_value()) {
-          throw std::logic_error(
-            std::format("Cannot retrieve layer from product_selector with no layer\n{}\n",
-                        std::stacktrace::current()));
+          throw std::logic_error("Cannot retrieve layer from product_selector with no layer");
         }
         return content_.operator*();
       }

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -44,6 +44,7 @@ namespace phlex {
         return me.content_.value_or("[ANY]");
       }
       bool operator==(creator_name const&) const noexcept = default;
+      auto operator<=>(creator_name const&) const noexcept = default;
 
     private:
       std::optional<experimental::identifier> content_;
@@ -85,6 +86,7 @@ namespace phlex {
       }
       operator bool() const noexcept { return content_.has_value(); }
       bool operator==(layer_name const&) const noexcept = default;
+      auto operator<=>(layer_name const&) const noexcept = default;
 
     private:
       std::optional<experimental::identifier> content_;

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -41,12 +41,11 @@ namespace phlex {
       }
 
       operator bool() const noexcept { return content_.has_value(); }
-      experimental::identifier const& operator*() const noexcept { return content_.operator*(); }
+      experimental::identifier const& operator*() const noexcept { return *content_; }
       friend experimental::identifier format_as(creator_name const& me) noexcept
       {
         return me.content_.value_or("[ANY]");
       }
-      bool operator==(creator_name const&) const noexcept = default;
       auto operator<=>(creator_name const&) const noexcept = default;
 
     private:
@@ -73,15 +72,15 @@ namespace phlex {
       }
 
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
-      operator T const&() const
+      operator experimental::identifier const&() const
       {
         if (!content_.has_value()) {
           throw std::logic_error("Cannot retrieve layer from product_selector with no layer");
         }
-        return content_.operator*();
+        return *content_;
       }
 
-      experimental::identifier const& operator*() const noexcept { return content_.operator*(); }
+      experimental::identifier const& operator*() const noexcept { return *content_; }
       explicit operator std::string_view() const noexcept
       {
         using namespace std::string_view_literals;
@@ -90,7 +89,6 @@ namespace phlex {
           .value_or(""sv);
       }
       operator bool() const noexcept { return content_.has_value(); }
-      bool operator==(layer_name const&) const noexcept = default;
       auto operator<=>(layer_name const&) const noexcept = default;
 
     private:

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -9,7 +9,9 @@
 #include "phlex/model/type_id.hpp"
 
 #include <concepts>
+#include <format>
 #include <optional>
+#include <stacktrace>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -49,35 +51,49 @@ namespace phlex {
 
     // The required_layer_name has to be a template for static_assert(false)
     template <std::same_as<experimental::identifier> T>
-    class required_layer_name {
+    class layer_name {
     public:
-      required_layer_name()
-      {
-        static_assert(false, "The layer name has not been set in this product_selector.");
-      }
+      layer_name() : content_(std::nullopt) {}
       template <typename U>
         requires std::constructible_from<T, U>
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
-      required_layer_name(U&& rhs) : content_(std::forward<U>(rhs))
+      layer_name(U&& rhs) : content_(std::forward<U>(rhs))
       {
-        if (content_.empty()) {
+        if (content_.value().empty()) {
           throw std::runtime_error("Cannot specify the empty string as a data layer.");
         }
       }
 
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
-      operator T const&() const noexcept { return content_; }
-      explicit operator std::string_view() const noexcept { return std::string_view(content_); }
-      bool operator==(required_layer_name const&) const noexcept = default;
+      operator T const&() const
+      {
+        if (!content_.has_value()) {
+          throw std::logic_error(
+            std::format("Cannot retrieve layer from product_selector with no layer\n{}\n",
+                        std::stacktrace::current()));
+        }
+        return content_.operator*();
+      }
+
+      experimental::identifier const& operator*() const noexcept { return content_.operator*(); }
+      explicit operator std::string_view() const noexcept
+      {
+        using namespace std::string_view_literals;
+        return content_
+          .transform([](experimental::identifier const& id) { return std::string_view(id); })
+          .value_or(""sv);
+      }
+      operator bool() const noexcept { return content_.has_value(); }
+      bool operator==(layer_name const&) const noexcept = default;
 
     private:
-      experimental::identifier content_;
+      std::optional<experimental::identifier> content_;
     };
   }
 
   struct PHLEX_CORE_EXPORT product_selector {
     detail::creator_name<experimental::identifier> creator;
-    detail::required_layer_name<experimental::identifier> layer;
+    detail::layer_name<experimental::identifier> layer;
     std::optional<experimental::identifier> suffix;
     std::optional<experimental::identifier> stage;
     detail::type_id type;

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -86,7 +86,7 @@ namespace phlex {
         using namespace std::string_view_literals;
         return content_
           .transform([](experimental::identifier const& id) { return std::string_view(id); })
-          .value_or(""sv);
+          .value_or("[ANY]"sv);
       }
       operator bool() const noexcept { return content_.has_value(); }
       auto operator<=>(layer_name const&) const noexcept = default;

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -27,6 +27,12 @@ namespace phlex {
     class creator_name {
     public:
       creator_name() : content_{std::nullopt} {}
+      creator_name(std::optional<experimental::identifier>&& content) : content_{std::move(content)}
+      {
+        if (content_ && content_.value().empty()) {
+          throw std::runtime_error("Cannot specify product with empty creator name.");
+        }
+      }
       template <typename U>
         requires std::constructible_from<T, U>
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional
@@ -55,6 +61,12 @@ namespace phlex {
     class layer_name {
     public:
       layer_name() : content_(std::nullopt) {}
+      layer_name(std::optional<experimental::identifier>&& content) : content_{std::move(content)}
+      {
+        if (content_ && content_.value().empty()) {
+          throw std::runtime_error("Cannot specify the empty string as a data layer.");
+        }
+      }
       template <typename U>
         requires std::constructible_from<T, U>
       // NOLINTNEXTLINE(google-explicit-constructor) - Implicit conversion is intentional

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -41,7 +41,7 @@ namespace phlex {
       }
 
       operator bool() const noexcept { return content_.has_value(); }
-      experimental::identifier const& operator*() const noexcept { return *content_; }
+      experimental::identifier const& operator*() const noexcept { return content_.operator*(); }
       friend experimental::identifier format_as(creator_name const& me) noexcept
       {
         return me.content_.value_or("[ANY]");
@@ -80,7 +80,7 @@ namespace phlex {
         return *content_;
       }
 
-      experimental::identifier const& operator*() const noexcept { return *content_; }
+      experimental::identifier const& operator*() const noexcept { return content_.operator*(); }
       explicit operator std::string_view() const noexcept
       {
         using namespace std::string_view_literals;

--- a/phlex/core/products_consumer.cpp
+++ b/phlex/core/products_consumer.cpp
@@ -1,5 +1,7 @@
 #include "phlex/core/products_consumer.hpp"
 
+#include "fmt/format.h"
+
 namespace {
   std::vector<phlex::experimental::identifier> layers_from(phlex::product_selectors const& queries)
   {
@@ -22,11 +24,29 @@ namespace phlex::detail {
 
   products_consumer::products_consumer(phlex::experimental::algorithm_name name,
                                        std::vector<std::string> predicates,
-                                       product_selectors input_products) :
+                                       product_selectors input_products,
+                                       bool always_require_layers) :
     consumer{std::move(name), std::move(predicates)},
     input_products_{std::move(input_products)},
     layers_{layers_from(input_products_)}
   {
+    using namespace phlex::experimental::literals;
+    if (always_require_layers || input_products_.size() > 1) {
+      std::vector<std::string> err_selectors{};
+      for (auto const& p : input_products_) {
+        if (!p.layer) {
+          err_selectors.push_back(p.to_string());
+        }
+      }
+      if (!err_selectors.empty()) {
+        std::string error = fmt::format(
+          "Product selectors in multi-input algorithms (here: {}) must define their layers:\n"
+          "  (Only invalid selectors are listed)\n{}",
+          this->name().to_string(),
+          bulleted_list(err_selectors));
+        throw std::runtime_error(error);
+      }
+    }
   }
 
   products_consumer::~products_consumer() = default;

--- a/phlex/core/products_consumer.cpp
+++ b/phlex/core/products_consumer.cpp
@@ -15,8 +15,37 @@ namespace {
         result.push_back("*"_id);
       }
     }
-    result.shrink_to_fit();
     return result;
+  }
+
+  void validate_layers(phlex::detail::require_layers layers_required,
+                       phlex::product_selectors const& inputs,
+                       phlex::experimental::algorithm_name const& algo)
+  {
+    using namespace phlex::detail;
+    if (layers_required == require_layers::never) {
+      return;
+    }
+    if (layers_required == require_layers::multi_input_only && inputs.size() <= 1) {
+      return;
+    }
+    std::vector<std::string> err_selectors{};
+    for (auto const& p : inputs) {
+      if (!p.layer) {
+        err_selectors.push_back(p.to_string());
+      }
+    }
+    if (!err_selectors.empty()) {
+      std::string type =
+        layers_required == require_layers::always ? "layer-mandatory" : "multi-input";
+      std::string error =
+        fmt::format("Product selectors in {} algorithm {} must define their layers:\n"
+                    "  (Only invalid selectors are listed)\n{}",
+                    type,
+                    algo.to_string(),
+                    bulleted_list(err_selectors));
+      throw std::runtime_error(error);
+    }
   }
 }
 
@@ -30,27 +59,7 @@ namespace phlex::detail {
     input_products_{std::move(input_products)},
     layers_{layers_from(input_products_)}
   {
-    using namespace phlex::experimental::literals;
-    if (layers_required == require_layers::always ||
-        (layers_required != require_layers::never && input_products_.size() > 1)) {
-      std::vector<std::string> err_selectors{};
-      for (auto const& p : input_products_) {
-        if (!p.layer) {
-          err_selectors.push_back(p.to_string());
-        }
-      }
-      if (!err_selectors.empty()) {
-        std::string type =
-          layers_required == require_layers::always ? "layer-mandatory" : "multi-input";
-        std::string error =
-          fmt::format("Product selectors in {} algorithm {} must define their layers:\n"
-                      "  (Only invalid selectors are listed)\n{}",
-                      type,
-                      this->name().to_string(),
-                      bulleted_list(err_selectors));
-        throw std::runtime_error(error);
-      }
-    }
+    validate_layers(layers_required, input_products_, this->name());
   }
 
   products_consumer::~products_consumer() = default;

--- a/phlex/core/products_consumer.cpp
+++ b/phlex/core/products_consumer.cpp
@@ -25,14 +25,14 @@ namespace phlex::detail {
   products_consumer::products_consumer(phlex::experimental::algorithm_name name,
                                        std::vector<std::string> predicates,
                                        product_selectors input_products,
-                                       layers_required layers_required) :
+                                       require_layers layers_required) :
     consumer{std::move(name), std::move(predicates)},
     input_products_{std::move(input_products)},
     layers_{layers_from(input_products_)}
   {
     using namespace phlex::experimental::literals;
-    if (layers_required == layers_required::always ||
-        (layers_required != layers_required::never && input_products_.size() > 1)) {
+    if (layers_required == require_layers::always ||
+        (layers_required != require_layers::never && input_products_.size() > 1)) {
       std::vector<std::string> err_selectors{};
       for (auto const& p : input_products_) {
         if (!p.layer) {
@@ -41,7 +41,7 @@ namespace phlex::detail {
       }
       if (!err_selectors.empty()) {
         std::string type =
-          layers_required == layers_required::always ? "layer-mandatory" : "multi-input";
+          layers_required == require_layers::always ? "layer-mandatory" : "multi-input";
         std::string error =
           fmt::format("Product selectors in {} algorithm {} must define their layers:\n"
                       "  (Only invalid selectors are listed)\n{}",

--- a/phlex/core/products_consumer.cpp
+++ b/phlex/core/products_consumer.cpp
@@ -25,13 +25,14 @@ namespace phlex::detail {
   products_consumer::products_consumer(phlex::experimental::algorithm_name name,
                                        std::vector<std::string> predicates,
                                        product_selectors input_products,
-                                       bool always_require_layers) :
+                                       layers_required layers_required) :
     consumer{std::move(name), std::move(predicates)},
     input_products_{std::move(input_products)},
     layers_{layers_from(input_products_)}
   {
     using namespace phlex::experimental::literals;
-    if (always_require_layers || input_products_.size() > 1) {
+    if (layers_required == layers_required::always ||
+        (layers_required != layers_required::never && input_products_.size() > 1)) {
       std::vector<std::string> err_selectors{};
       for (auto const& p : input_products_) {
         if (!p.layer) {

--- a/phlex/core/products_consumer.cpp
+++ b/phlex/core/products_consumer.cpp
@@ -3,11 +3,17 @@
 namespace {
   std::vector<phlex::experimental::identifier> layers_from(phlex::product_selectors const& queries)
   {
+    using namespace phlex::experimental::literals;
     std::vector<phlex::experimental::identifier> result;
     result.reserve(queries.size());
     for (auto const& query : queries) {
-      result.push_back(query.layer);
+      if (query.layer) {
+        result.push_back(query.layer);
+      } else {
+        result.push_back("*"_id);
+      }
     }
+    result.shrink_to_fit();
     return result;
   }
 }

--- a/phlex/core/products_consumer.cpp
+++ b/phlex/core/products_consumer.cpp
@@ -40,11 +40,14 @@ namespace phlex::detail {
         }
       }
       if (!err_selectors.empty()) {
-        std::string error = fmt::format(
-          "Product selectors in multi-input algorithms (here: {}) must define their layers:\n"
-          "  (Only invalid selectors are listed)\n{}",
-          this->name().to_string(),
-          bulleted_list(err_selectors));
+        std::string type =
+          layers_required == layers_required::always ? "layer-mandatory" : "multi-input";
+        std::string error =
+          fmt::format("Product selectors in {} algorithm {} must define their layers:\n"
+                      "  (Only invalid selectors are listed)\n{}",
+                      type,
+                      this->name().to_string(),
+                      bulleted_list(err_selectors));
         throw std::runtime_error(error);
       }
     }

--- a/phlex/core/products_consumer.cpp
+++ b/phlex/core/products_consumer.cpp
@@ -36,11 +36,10 @@ namespace {
       }
     }
     if (!err_selectors.empty()) {
-      std::string error =
-        fmt::format("Must specify layers in the product selectors for node {}:\n"
-                    "  (Only invalid selectors are listed)\n{}",
-                    algo.to_string(),
-                    bulleted_list(err_selectors));
+      std::string error = fmt::format("Must specify layers in the product selectors for node {}:\n"
+                                      "  (Only invalid selectors are listed)\n{}",
+                                      algo.to_string(),
+                                      bulleted_list(err_selectors));
       throw std::runtime_error(error);
     }
   }

--- a/phlex/core/products_consumer.cpp
+++ b/phlex/core/products_consumer.cpp
@@ -36,12 +36,9 @@ namespace {
       }
     }
     if (!err_selectors.empty()) {
-      std::string type =
-        layers_required == require_layers::always ? "layer-mandatory" : "multi-input";
       std::string error =
-        fmt::format("Product selectors in {} algorithm {} must define their layers:\n"
+        fmt::format("Must specify layers in the product selectors for node {}:\n"
                     "  (Only invalid selectors are listed)\n{}",
-                    type,
                     algo.to_string(),
                     bulleted_list(err_selectors));
       throw std::runtime_error(error);

--- a/phlex/core/products_consumer.hpp
+++ b/phlex/core/products_consumer.hpp
@@ -21,7 +21,8 @@ namespace phlex::detail {
   public:
     products_consumer(phlex::experimental::algorithm_name name,
                       std::vector<std::string> predicates,
-                      product_selectors input_products);
+                      product_selectors input_products,
+                      bool always_require_layers = false);
 
     virtual ~products_consumer();
 

--- a/phlex/core/products_consumer.hpp
+++ b/phlex/core/products_consumer.hpp
@@ -17,12 +17,13 @@
 #include <vector>
 
 namespace phlex::detail {
+  enum class layers_required : char { never, multi_input_only, always };
   class PHLEX_CORE_EXPORT products_consumer : public consumer {
   public:
     products_consumer(phlex::experimental::algorithm_name name,
                       std::vector<std::string> predicates,
                       product_selectors input_products,
-                      bool always_require_layers = false);
+                      layers_required layers_required = layers_required::multi_input_only);
 
     virtual ~products_consumer();
 

--- a/phlex/core/products_consumer.hpp
+++ b/phlex/core/products_consumer.hpp
@@ -17,13 +17,13 @@
 #include <vector>
 
 namespace phlex::detail {
-  enum class layers_required : char { never, multi_input_only, always };
+  enum class require_layers : char { never, multi_input_only, always };
   class PHLEX_CORE_EXPORT products_consumer : public consumer {
   public:
     products_consumer(phlex::experimental::algorithm_name name,
                       std::vector<std::string> predicates,
                       product_selectors input_products,
-                      layers_required layers_required = layers_required::multi_input_only);
+                      require_layers layers_required);
 
     virtual ~products_consumer();
 

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -112,11 +112,17 @@ namespace phlex::detail {
     void create_node(std::vector<std::string> output_product_suffixes)
     {
       assert(creator_);
-      auto ptr = creator_(release_predicates(), std::move(output_product_suffixes));
-      auto name = ptr->name().to_string();
-      auto [_, inserted] = nodes_->try_emplace(name, std::move(ptr));
-      if (not inserted) {
-        internal::add_to_error_messages(*errors_, "Node", name);
+      try {
+        auto ptr = creator_(release_predicates(), std::move(output_product_suffixes));
+        auto name = ptr->name().to_string();
+        auto [_, inserted] = nodes_->try_emplace(name, std::move(ptr));
+        if (not inserted) {
+          internal::add_to_error_messages(*errors_, "Node", name);
+        }
+      } catch (...) {
+        // Prevent trying to re-run create_node
+        creator_ = nullptr;
+        throw;
       }
     }
 

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -52,9 +52,11 @@
 #include "phlex/utilities/simple_ptr_map.hpp"
 
 #include <cassert>
+
 #include <functional>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace phlex::detail {
@@ -112,17 +114,12 @@ namespace phlex::detail {
     void create_node(std::vector<std::string> output_product_suffixes)
     {
       assert(creator_);
-      try {
-        auto ptr = creator_(release_predicates(), std::move(output_product_suffixes));
-        auto name = ptr->name().to_string();
-        auto [_, inserted] = nodes_->try_emplace(name, std::move(ptr));
-        if (not inserted) {
-          internal::add_to_error_messages(*errors_, "Node", name);
-        }
-      } catch (...) {
-        // Prevent trying to re-run create_node
-        creator_ = nullptr;
-        throw;
+      auto create = std::exchange(creator_, node_creator{});
+      auto ptr = create(release_predicates(), std::move(output_product_suffixes));
+      auto name = ptr->name().to_string();
+      auto [_, inserted] = nodes_->try_emplace(name, std::move(ptr));
+      if (not inserted) {
+        internal::add_to_error_messages(*errors_, "Node", name);
       }
     }
 

--- a/phlex/core/registrar.hpp
+++ b/phlex/core/registrar.hpp
@@ -95,7 +95,6 @@ namespace phlex::detail {
     void set_output_product_suffixes(std::vector<std::string> output_product_suffixes)
     {
       create_node(std::move(output_product_suffixes));
-      creator_ = nullptr;
     }
 
     ~registrar() noexcept(false)

--- a/test/config_test.cpp
+++ b/test/config_test.cpp
@@ -45,10 +45,15 @@ TEST_CASE("Retrieve product_selector", "[config]")
   malformed_input2["creator"] = "hits";
   malformed_input2["layer"] = "";
 
+  boost::json::object malformed_input3;
+  malformed_input3["creator"] = "";
+  malformed_input3["layer"] = "job";
+
   boost::json::object underlying_config;
   underlying_config["input"] = std::move(input);
   underlying_config["malformed1"] = std::move(malformed_input1);
   underlying_config["malformed2"] = std::move(malformed_input2);
+  underlying_config["malformed3"] = std::move(malformed_input3);
   configuration config{underlying_config};
 
   auto input_query = config.get<product_selector>("input");
@@ -60,4 +65,7 @@ TEST_CASE("Retrieve product_selector", "[config]")
   CHECK_THROWS_WITH(config.get<product_selector>("malformed2"),
                     ContainsSubstring("Error retrieving parameter 'malformed2'") &&
                       ContainsSubstring("Cannot specify the empty string as a data layer."));
+  CHECK_THROWS_WITH(config.get<product_selector>("malformed3"),
+                    ContainsSubstring("Error retrieving parameter 'malformed3'") &&
+                      ContainsSubstring("Cannot specify product with empty creator name."));
 }

--- a/test/config_test.cpp
+++ b/test/config_test.cpp
@@ -36,6 +36,8 @@ TEST_CASE("Retrieve product_selector", "[config]")
   input["suffix"] = "tracks";
   input["layer"] = "job";
 
+  boost::json::object unconstrained_input;
+
   boost::json::object malformed_input1;
   malformed_input1["creator"] = "test_alg";
   malformed_input1["suffix"] = 16.; // Should be string
@@ -51,6 +53,7 @@ TEST_CASE("Retrieve product_selector", "[config]")
 
   boost::json::object underlying_config;
   underlying_config["input"] = std::move(input);
+  underlying_config["unconstrained"] = std::move(unconstrained_input);
   underlying_config["malformed1"] = std::move(malformed_input1);
   underlying_config["malformed2"] = std::move(malformed_input2);
   underlying_config["malformed3"] = std::move(malformed_input3);
@@ -59,6 +62,9 @@ TEST_CASE("Retrieve product_selector", "[config]")
   auto input_query = config.get<product_selector>("input");
   CHECK(input_query.match(
     product_selector{.creator = "tracks_alg", .layer = "job", .suffix = "tracks"}));
+  auto unconstrained_query = config.get<product_selector>("unconstrained");
+  CHECK_FALSE(unconstrained_query.creator);
+  CHECK_FALSE(unconstrained_query.layer);
   CHECK_THROWS_WITH(config.get<product_selector>("malformed1"),
                     ContainsSubstring("Error retrieving parameter 'malformed1'") &&
                       ContainsSubstring("not a string"));

--- a/test/config_test.cpp
+++ b/test/config_test.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Retrieve product_selector", "[config]")
 
   boost::json::object malformed_input2;
   malformed_input2["creator"] = "hits";
-  malformed_input2["level"] = "should be layer, not level";
+  malformed_input2["layer"] = "";
 
   boost::json::object underlying_config;
   underlying_config["input"] = std::move(input);
@@ -59,5 +59,5 @@ TEST_CASE("Retrieve product_selector", "[config]")
                       ContainsSubstring("not a string"));
   CHECK_THROWS_WITH(config.get<product_selector>("malformed2"),
                     ContainsSubstring("Error retrieving parameter 'malformed2'") &&
-                      ContainsSubstring("Error retrieving parameter 'layer'"));
+                      ContainsSubstring("Cannot specify the empty string as a data layer."));
 }

--- a/test/product_selecting_test.cpp
+++ b/test/product_selecting_test.cpp
@@ -50,13 +50,13 @@ TEST_CASE("Querying products in different ways", "[graph]")
 
   // Duplicate with transform
   g.transform("duplicate_temperature", [](double const& t) { return t; })
-    .input_family(product_selector{.creator = "input", .layer = "event", .suffix = "temperature"})
+    .input_family(product_selector{.creator = "input", .suffix = "temperature"})
     .output_product_suffixes("temperature");
 
   SECTION("All fields")
   {
     g.transform("all_fields", [](int const& i) { return i + 1; })
-      .input_family(product_selector{.creator = "input", .layer = "job", .suffix = "number"})
+      .input_family(product_selector{.creator = "input", .suffix = "number"})
       .output_product_suffixes("job_number");
     g.execute();
     CHECK(g.execution_count("all_fields") == 1);
@@ -71,7 +71,7 @@ TEST_CASE("Querying products in different ways", "[graph]")
        "verify_name",
        [](std::string const& str, int const& n) { CHECK(str == fmt::format("John the {}th", n)); })
       .input_family(product_selector{.creator = "give_name", .layer = "event"},
-                    product_selector{.creator = "input", .layer = "event"});
+                    product_selector{.creator = "input"});
     g.execute();
     CHECK(g.execution_count("creator_and_layer_by_creator") == num_events);
   }
@@ -88,7 +88,7 @@ TEST_CASE("Querying products in different ways", "[graph]")
   SECTION("Creator and Layer, using layer")
   {
     g.transform("creator_and_layer_by_layer", [](double const& d) { return d; })
-      .input_family(product_selector{.creator = "input", .layer = "event"})
+      .input_family(product_selector{.creator = "input"})
       .output_product_suffixes("event_temp");
     g.execute();
     CHECK(g.execution_count("creator_and_layer_by_layer") == num_events);

--- a/test/product_selecting_test.cpp
+++ b/test/product_selecting_test.cpp
@@ -71,7 +71,7 @@ TEST_CASE("Querying products in different ways", "[graph]")
        "verify_name",
        [](std::string const& str, int const& n) { CHECK(str == fmt::format("John the {}th", n)); })
       .input_family(product_selector{.creator = "give_name", .layer = "event"},
-                    product_selector{.creator = "input"});
+                    product_selector{.creator = "input", .layer = "event"});
     g.execute();
     CHECK(g.execution_count("creator_and_layer_by_creator") == num_events);
   }

--- a/test/product_selecting_test.cpp
+++ b/test/product_selecting_test.cpp
@@ -1,8 +1,10 @@
 #include "phlex/core/framework_graph.hpp"
 #include "phlex/model/data_cell_index.hpp"
 #include "phlex/model/product_store.hpp"
+#include "phlex/source.hpp"
 
 #include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_string.hpp"
 #include "plugins/layer_generator.hpp"
 
 #include "fmt/format.h"
@@ -26,6 +28,42 @@ namespace {
   {
     return fmt::format("John the {}th", dci.number());
   }
+
+  detail::product_ptr provide_archived_count(data_cell_index const& dci)
+  {
+    return std::make_unique<detail::product<int>>(static_cast<int>(dci.number()));
+  }
+
+  class archived_count_source : public source {
+  public:
+    detail::provider_bundles create_providers(product_selector const& selector) override
+    {
+      using namespace experimental::literals;
+      phlex::detail::product_specification spec{
+        "archived_input", "archived_count", phlex::detail::make_type_id<int>()};
+      if (!selector.match(spec, "event"_id, "previous_process"_id)) {
+        return {};
+      }
+      return {{.provider_function = provide_archived_count,
+               .max_concurrency = concurrency::unlimited,
+               .spec = std::move(spec),
+               .layer = "event",
+               .stage = "previous_process"}};
+    }
+
+    index_generator indices() override { co_return; }
+  };
+
+  class copy_temperature_once {
+  public:
+    explicit copy_temperature_once(double const temperature) : temperature_{temperature} {}
+    bool initial_value() const { return true; }
+    bool predicate(bool const emit) const { return emit; }
+    auto unfold(bool const) const { return std::pair{false, temperature_}; }
+
+  private:
+    double temperature_;
+  };
 }
 
 TEST_CASE("Querying products in different ways", "[graph]")
@@ -35,6 +73,7 @@ TEST_CASE("Querying products in different ways", "[graph]")
   gen->add_layer("event", {.parent_layer = "job", .count = num_events});
   auto g = phlex::detail::framework_graph::without_driver();
   g.add_driver(gen);
+  g.add_source<archived_count_source>("archived_count_source");
 
   // Register providers
   g.provide("provide_number_in_job", provide_number, concurrency::unlimited)
@@ -53,18 +92,18 @@ TEST_CASE("Querying products in different ways", "[graph]")
     .input_family(product_selector{.creator = "input", .suffix = "temperature"})
     .output_product_suffixes("temperature");
 
-  SECTION("All fields")
+  SECTION("Creator and suffix without layer")
   {
-    g.transform("all_fields", [](int const& i) { return i + 1; })
+    g.transform("creator_and_suffix_without_layer", [](int const& i) { return i + 1; })
       .input_family(product_selector{.creator = "input", .suffix = "number"})
       .output_product_suffixes("job_number");
     g.execute();
-    CHECK(g.execution_count("all_fields") == 1);
+    CHECK(g.execution_count("creator_and_suffix_without_layer") == 1);
   }
 
-  SECTION("Creator and Layer, using creator (and using type alone)")
+  SECTION("Creator and layer, distinguished by type")
   {
-    g.transform("creator_and_layer_by_creator", [](std::string const& str) { return str; })
+    g.transform("name_by_creator_and_layer", [](std::string const& str) { return str; })
       .input_family(product_selector{.creator = "give_name", .layer = "event"})
       .output_product_suffixes("event_name");
     g.observe(
@@ -73,33 +112,82 @@ TEST_CASE("Querying products in different ways", "[graph]")
       .input_family(product_selector{.creator = "give_name", .layer = "event"},
                     product_selector{.creator = "input", .layer = "event"});
     g.execute();
-    CHECK(g.execution_count("creator_and_layer_by_creator") == num_events);
+    CHECK(g.execution_count("name_by_creator_and_layer") == num_events);
   }
 
   SECTION("Layer alone, distinguished by type")
   {
-    g.transform("layer_by_type", [](std::string const& str) { return str; })
+    g.transform("name_by_layer_and_type", [](std::string const& str) { return str; })
       .input_family(product_selector{.layer = "event"})
       .output_product_suffixes("new_name");
     g.execute();
-    CHECK(g.execution_count("layer_by_type") == num_events);
+    CHECK(g.execution_count("name_by_layer_and_type") == num_events);
   }
 
-  SECTION("Creator and Layer, using layer")
+  SECTION("Creator only without layer")
   {
-    g.transform("creator_and_layer_by_layer", [](double const& d) { return d; })
+    g.transform("temperature_by_creator_without_layer", [](double const& d) { return d; })
       .input_family(product_selector{.creator = "input"})
       .output_product_suffixes("event_temp");
     g.execute();
-    CHECK(g.execution_count("creator_and_layer_by_layer") == num_events);
+    CHECK(g.execution_count("temperature_by_creator_without_layer") == num_events);
   }
 
-  SECTION("Creator and Layer only, after transform")
+  SECTION("Creator only without layer, after transform")
   {
-    g.transform("creator_and_layer_after_transform", [](double const& d) { return d; })
-      .input_family(product_selector{.creator = "duplicate_temperature", .layer = "event"})
+    g.transform("temperature_from_transform_without_layer", [](double const& d) { return d; })
+      .input_family(product_selector{.creator = "duplicate_temperature"})
       .output_product_suffixes("event_temp");
     g.execute();
-    CHECK(g.execution_count("creator_and_layer_after_transform") == num_events);
+    CHECK(g.execution_count("temperature_from_transform_without_layer") == num_events);
+  }
+
+  SECTION("Predicate and observer inputs without layer")
+  {
+    g.predicate(
+       "even_event_temperature",
+       [](double const temperature) { return static_cast<int>(temperature / 100.0) % 2 == 0; },
+       concurrency::unlimited)
+      .input_family(product_selector{.creator = "input", .suffix = "temperature"});
+    g.observe(
+       "observe_even_event_temperature", [](double const) {}, concurrency::unlimited)
+      .input_family(product_selector{.creator = "input", .suffix = "temperature"})
+      .experimental_when("even_event_temperature");
+    g.execute();
+    CHECK(g.execution_count("even_event_temperature") == num_events);
+    CHECK(g.execution_count("observe_even_event_temperature") == 13);
+  }
+
+  SECTION("Unfold inputs without layer are rejected")
+  {
+    g.unfold<copy_temperature_once>("copy_temperature_once",
+                                    &copy_temperature_once::predicate,
+                                    &copy_temperature_once::unfold,
+                                    concurrency::unlimited,
+                                    "temperature_copy")
+      .input_family(product_selector{.creator = "input", .suffix = "temperature"})
+      .output_product_suffixes("temperature");
+    CHECK_THROWS_WITH(
+      g.execute(),
+      "<suffix temperature (of type <double>) by creator input (of stage [ANY]) in layer "
+      "[ANY]> used by unfold copy_temperature_once has no layer defined");
+  }
+
+  SECTION("Shared implicit provider inputs without layer")
+  {
+    auto const archived_count =
+      product_selector{.creator = "archived_input", .suffix = "archived_count"};
+    g.transform("copy_archived_count", [](int const count) { return count; })
+      .input_family(archived_count)
+      .output_product_suffixes("archived_count_copy");
+    g.observe(
+       "observe_archived_count",
+       [](handle<int> const count) { CHECK(count.stage() == "previous_process"); },
+       concurrency::unlimited)
+      .input_family(archived_count);
+    g.execute();
+    CHECK(g.execution_count("archived_input") == num_events);
+    CHECK(g.execution_count("copy_archived_count") == num_events);
+    CHECK(g.execution_count("observe_archived_count") == num_events);
   }
 }

--- a/test/product_selecting_test.cpp
+++ b/test/product_selecting_test.cpp
@@ -92,6 +92,16 @@ TEST_CASE("Querying products in different ways", "[graph]")
     .input_family(product_selector{.creator = "input", .suffix = "temperature"})
     .output_product_suffixes("temperature");
 
+  SECTION("All fields")
+  {
+    g.transform("all_fields", [](int const& i) { return i + 1; })
+      .input_family(product_selector{
+        .creator = "input", .layer = "event", .suffix = "evt_number", .stage = "CURRENT"_id})
+      .output_product_suffixes("event_number");
+    g.execute();
+    CHECK(g.execution_count("all_fields") == num_events);
+  }
+
   SECTION("Creator and suffix without layer")
   {
     g.transform("creator_and_suffix_without_layer", [](int const& i) { return i + 1; })

--- a/test/product_selecting_test.cpp
+++ b/test/product_selecting_test.cpp
@@ -160,17 +160,18 @@ TEST_CASE("Querying products in different ways", "[graph]")
 
   SECTION("Unfold inputs without layer are rejected")
   {
-    g.unfold<copy_temperature_once>("copy_temperature_once",
-                                    &copy_temperature_once::predicate,
-                                    &copy_temperature_once::unfold,
-                                    concurrency::unlimited,
-                                    "temperature_copy")
-      .input_family(product_selector{.creator = "input", .suffix = "temperature"})
-      .output_product_suffixes("temperature");
     CHECK_THROWS_WITH(
-      g.execute(),
-      "<suffix temperature (of type <double>) by creator input (of stage [ANY]) in layer "
-      "[ANY]> used by unfold copy_temperature_once has no layer defined");
+      g.unfold<copy_temperature_once>("copy_temperature_once",
+                                      &copy_temperature_once::predicate,
+                                      &copy_temperature_once::unfold,
+                                      concurrency::unlimited,
+                                      "temperature_copy")
+        .input_family(product_selector{.creator = "input", .suffix = "temperature"}),
+      "Product selectors in layer-mandatory algorithm copy_temperature_once must define their "
+      "layers:\n"
+      "  (Only invalid selectors are listed)\n"
+      "  - <suffix temperature (of type <double>) by creator input (of stage [ANY]) in layer "
+      "[ANY]>");
   }
 
   SECTION("Shared implicit provider inputs without layer")

--- a/test/product_selecting_test.cpp
+++ b/test/product_selecting_test.cpp
@@ -166,7 +166,8 @@ TEST_CASE("Querying products in different ways", "[graph]")
                                       &copy_temperature_once::unfold,
                                       concurrency::unlimited,
                                       "temperature_copy")
-        .input_family(product_selector{.creator = "input", .suffix = "temperature"}),
+        .input_family(product_selector{.creator = "input", .suffix = "temperature"})
+        .output_product_suffixes("temperature"),
       "Product selectors in layer-mandatory algorithm copy_temperature_once must define their "
       "layers:\n"
       "  (Only invalid selectors are listed)\n"

--- a/test/product_selecting_test.cpp
+++ b/test/product_selecting_test.cpp
@@ -178,8 +178,7 @@ TEST_CASE("Querying products in different ways", "[graph]")
                                       "temperature_copy")
         .input_family(product_selector{.creator = "input", .suffix = "temperature"})
         .output_product_suffixes("temperature"),
-      "Product selectors in layer-mandatory algorithm copy_temperature_once must define their "
-      "layers:\n"
+      "Must specify layers in the product selectors for node copy_temperature_once:\n"
       "  (Only invalid selectors are listed)\n"
       "  - <suffix temperature (of type <double>) by creator input (of stage [ANY]) in layer "
       "[ANY]>");

--- a/test/product_selector_test.cpp
+++ b/test/product_selector_test.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Product name with data layer", "[data model]")
 {
   product_selector label({.creator = "creator", .layer = "event", .suffix = "product"});
   CHECK(*label.creator == "creator"_idq);
-  CHECK(label.layer == "event"_idq);
+  CHECK(*label.layer == "event"_idq);
   CHECK(label.suffix == "product"_id);
   // Mismatched creator
   CHECK(!product_selector{.creator = "1", .layer = "event", .suffix = "prod"}.match(

--- a/test/product_selector_test.cpp
+++ b/test/product_selector_test.cpp
@@ -7,14 +7,26 @@
 
 using namespace phlex;
 
-TEST_CASE("Empty specifications", "[data model]")
+TEST_CASE("Empty creator name", "[data model]")
 {
   CHECK_THROWS_WITH(
     (product_selector{.creator = "", .layer = "layer"}),
     Catch::Matchers::ContainsSubstring("Cannot specify product with empty creator name."));
+}
+
+TEST_CASE("Empty layer name", "[data model]")
+{
   CHECK_THROWS_WITH(
     (product_selector{.creator = "creator", .layer = ""}),
     Catch::Matchers::ContainsSubstring("Cannot specify the empty string as a data layer."));
+}
+
+TEST_CASE("Retrieving a non-existent layer name", "[data model]")
+{
+  product_selector const selector;
+  CHECK_THROWS_WITH((static_cast<experimental::identifier const&>(selector.layer)),
+                    Catch::Matchers::ContainsSubstring(
+                      "Cannot retrieve layer from product_selector with no layer"));
 }
 
 TEST_CASE("Product name with data layer", "[data model]")

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -104,6 +104,27 @@ TEST_CASE("Explicit providers")
   CHECK(g.execution_count("verify_explicit_stage") == num_spills);
 }
 
+TEST_CASE("Explicit Provider Ambiguity")
+{
+  auto g = phlex::detail::framework_graph::with_default_driver();
+
+  // Register two providers that can provide the same product
+  g.provide("provide_vertices", give_me_vertices, concurrency::unlimited)
+    .output_product("vertices_maker", "happy_vertices", "job");
+  g.provide("provide_vertices_again", give_me_vertices, concurrency::unlimited)
+    .output_product("vertices_maker", "happy_vertices", "job");
+
+  g.transform("passer", pass_on, concurrency::unlimited)
+    .input_family(
+      product_selector{.creator = "vertices_maker", .layer = "job", .suffix = "happy_vertices"});
+
+  CHECK_THROWS_WITH(
+    g.execute(),
+    ContainsSubstring("Multiple explicit providers found for <suffix happy_vertices") &&
+      ContainsSubstring("by creator vertices_maker") && ContainsSubstring("in layer job") &&
+      ContainsSubstring("spec: vertices_maker/happy_vertices"));
+}
+
 TEST_CASE("Implicit providers")
 {
   constexpr auto num_spills{3u};


### PR DESCRIPTION
Layer specifications are now optional in `product_selector`s. As discussed with Kyle and Marc, this is currently limited to single input functions. Folds are always considered multi-input (they have an implicit accumulator input).

In addition, this is not currently enabled for unfolds because their input layers are used in the flush machinery.

_AI summary below_
___

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Core behavior**
  - Allows omitted `product_selector` layers for single-input functions.
  - Resolves omitted layers from explicit or implicit providers.
  - Treats omitted query layers as wildcards during selector matching.
  - Keeps folds as multi-input functions and requires their layers.
  - Rejects unfold inputs without layers because flush machinery uses those layers.
  - Improves diagnostics for missing and invalid layer names.

- **Implementation**
  - Adds optional layer storage and validation in `product_selector`.
  - Updates provider wiring and implicit-provider reuse.
  - Uses wildcard identifiers for unresolved provider input layers.
  - Updates `products_consumer` to enforce layers for multi-input consumers.
  - Adds required compiler-specific linking for GNU toolchains.

- **Tests**
  - Covers layerless selectors for computational nodes, predicates, observers, transformed products, and explicit or implicit providers.
  - Verifies shared implicit-provider inputs and execution counts.
  - Verifies the expected diagnostic for layerless unfold inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->