### PR TITLE
FORM Canonical Index Format

### DIFF
--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -397,12 +397,11 @@ TEST_CASE("StorageReader getIndex: malformed ids and compatibility fallbacks", "
   CHECK(reader.getIndex(index_token, "plain-text-id", settings) == 0);
 
   // Malformed IDs must be rejected by the storage-layer index parser
-  CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT,SEG=00000001]", settings),
-                  std::runtime_error);
+  CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT,SEG=1]", settings), std::runtime_error);
   CHECK_THROWS_AS(
     reader.getIndex(index_token, "[EVENT=99999999999999999999999999999999]", settings),
     std::runtime_error);
-  CHECK_THROWS_AS(reader.getIndex(index_token, "[=00000001]", settings), std::runtime_error);
+  CHECK_THROWS_AS(reader.getIndex(index_token, "[=1]", settings), std::runtime_error);
   CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT]", settings), std::runtime_error);
   CHECK_THROWS_AS(reader.getIndex(index_token, "[    ]", settings), std::runtime_error);
 }

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Storage_Container read wrong type", "[form]")
 TEST_CASE("Storage_Container sharing an Association", "[form]")
 {
   std::vector<float> piData(10, std::numbers::pi_v<float>);
-  std::string indexData = "[EVENT=00000001;SEG=00000001]";
+  std::string indexData = "[event:1, segment:1]";
 
   form::test::write(technology, piData, indexData);
 
@@ -80,7 +80,7 @@ TEST_CASE("Storage_Container multiple containers in Association", "[form]")
   std::vector<float> piData(10, std::numbers::pi_v<float>);
   std::vector<int> magicData(17);
   std::ranges::iota(magicData, 42);
-  std::string indexData = "[EVENT=00000001;SEG=00000001]";
+  std::string indexData = "[event:1, segment:1]";
 
   form::test::write(technology, piData, magicData, indexData);
 
@@ -295,8 +295,8 @@ TEST_CASE("Persistence round-trip: structured index normalization and listing", 
   std::vector<int> first = {10, 20, 30};
   std::vector<int> second = {40, 50, 60};
 
-  std::string const first_id = "[EVENT=00000001;SEG=00000002]";
-  std::string const second_id = "[EVENT=00000003;SEG=00000004]";
+  std::string const first_id = "[event:1, segment:2]";
+  std::string const second_id = "[event:3, segment:4]";
 
   {
     auto writer = createPersistenceWriter();
@@ -359,7 +359,7 @@ TEST_CASE("Persistence round-trip: all-zero structured id fallback", "[form]")
   reader->configureTechSettings(tech_setting_config{});
 
   void const* raw = nullptr;
-  reader->read(creator, "prod", "[EVENT=00000000;SEG=00000000]", &raw, typeid(std::vector<int>));
+  reader->read(creator, "prod", "[event:0, segment:0]", &raw, typeid(std::vector<int>));
 
   auto const* read_payload = static_cast<std::vector<int> const*>(raw);
   REQUIRE(read_payload != nullptr);
@@ -386,7 +386,7 @@ TEST_CASE("StorageReader getIndex: malformed ids and compatibility fallbacks", "
     writer->configureTechSettings(tech_setting_config{});
     writer->createContainers(creator, {{"prod", &typeid(std::vector<int>)}});
     writer->registerWrite(creator, "prod", &payload, typeid(std::vector<int>));
-    writer->commitOutput(creator, "[EVENT=00000001;SEG=00000002]");
+    writer->commitOutput(creator, "[event:1, segment:2]");
   }
 
   StorageReader reader;
@@ -396,6 +396,7 @@ TEST_CASE("StorageReader getIndex: malformed ids and compatibility fallbacks", "
   CHECK(reader.getIndex(index_token, "[]", settings) == 0);
   CHECK(reader.getIndex(index_token, "plain-text-id", settings) == 0);
 
+  // Malformed IDs must be rejected by the storage-layer index parser
   CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT,SEG=00000001]", settings),
                   std::runtime_error);
   CHECK_THROWS_AS(
@@ -414,13 +415,13 @@ TEST_CASE("StorageReader getIndex: empty container and tech-table branches", "[f
   Token const token{"storage_reader_hdf5_get_index.root", "creator/index", form::technology::HDF5};
 
   tech_setting_config empty_settings;
-  CHECK_THROWS_AS(reader.getIndex(token, "[EVENT=00000001;SEG=00000001]", empty_settings),
+  CHECK_THROWS_AS(reader.getIndex(token, "[event:1, segment:1]", empty_settings),
                   std::runtime_error);
 
   tech_setting_config tech_only_settings;
   tech_only_settings.file_settings[form::technology::HDF5]["different_file"] = {};
   tech_only_settings.container_settings[form::technology::HDF5]["different_container"] = {};
-  CHECK_THROWS_AS(reader.getIndex(token, "[EVENT=00000001;SEG=00000001]", tech_only_settings),
+  CHECK_THROWS_AS(reader.getIndex(token, "[event:1, segment:1]", tech_only_settings),
                   std::runtime_error);
 
   std::string const file_name =
@@ -436,7 +437,7 @@ TEST_CASE("StorageReader getIndex: empty container and tech-table branches", "[f
     writer->configureTechSettings(tech_setting_config{});
     writer->createContainers(creator, {{"prod", &typeid(std::vector<int>)}});
     writer->registerWrite(creator, "prod", &payload, typeid(std::vector<int>));
-    writer->commitOutput(creator, "[EVENT=00000005;SEG=00000006]");
+    writer->commitOutput(creator, "[event:5, segment:6]");
   }
 
   tech_setting_config attr_settings;
@@ -467,7 +468,7 @@ TEST_CASE("StorageReader prime/listIndices/readContainer: attribute and error br
     writer->configureTechSettings(tech_setting_config{});
     writer->createContainers(creator, {{"prod", &typeid(std::vector<int>)}});
     writer->registerWrite(creator, "prod", &payload, typeid(std::vector<int>));
-    writer->commitOutput(creator, "[EVENT=00000009;SEG=00000008]");
+    writer->commitOutput(creator, "[event:9, segment:8]");
   }
 
   StorageReader reader;

--- a/test/form/reader.cpp
+++ b/test/form/reader.cpp
@@ -89,7 +89,8 @@ int main(int argc, char** argv)
     for (int nseg = 0; nseg < NUMBER_SEGMENT; nseg++) {
 
       void const* rawPtr = nullptr;
-      std::string const seg_id_text = std::format("[EVENT={:08X};SEG={:08X}]", nevent, nseg);
+      // Must match the canonical format emitted by writer.cpp (phlex data_cell_index format)
+      std::string const seg_id_text = std::format("[event:{}, segment:{}]", nevent, nseg);
 
       std::string const& segment_id = seg_id_text;
 
@@ -160,7 +161,7 @@ int main(int argc, char** argv)
     }
     std::cout << "PHLEX: Read Event segments done " << nevent << '\n';
 
-    std::string const evt_id_text = std::format("[EVENT={:08X}]", nevent);
+    std::string const evt_id_text = std::format("[event:{}]", nevent);
 
     std::string const& event_id = evt_id_text;
 

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -91,7 +91,9 @@ int main(int argc, char** argv)
         check += val;
       }
 
-      std::string const seg_id_text = std::format("[EVENT={:08X};SEG={:08X}]", nevent, nseg);
+      // Canonical Phlex index format: [layer:number, ...], base-10, ", "-joined.
+      // Matches phlex::data_cell_index::to_string() and is directly parseable by the source parser.
+      std::string const seg_id_text = std::format("[event:{}, segment:{}]", nevent, nseg);
 
       std::string const& segment_id = seg_id_text;
 
@@ -141,7 +143,7 @@ int main(int argc, char** argv)
       check += val;
     }
 
-    std::string const evt_id_text = std::format("[EVENT={:08X}]", nevent);
+    std::string const evt_id_text = std::format("[event:{}]", nevent);
 
     std::string const& event_id = evt_id_text;
 


### PR DESCRIPTION
**Summary:**
Align the FORM toy test writer/reader with the canonical index format used by Phlex.

The toy writer/reader emitted a hex, `=`/`;`-delimited index string (`[EVENT={:08X};SEG={:08X}]`), which the Phlex source parser (`form_source.cpp::parse_index_string` — base-10, `:`-separated) cannot parse directly. Production write/read already use the canonical form via `phlex::data_cell_index::to_string()`, so the toy files were the only divergent emitter.

This switches the toy writer/reader and the valid index strings in the storage-layer tests to the canonical `[layer:number, ...]` base-10 format, so FORM-written index strings are directly consumable by the source. Intentionally malformed error-path strings are left unchanged — they exercise the reader's rejection logic.