### PR TITLE
fix(cmake): propagate public dependencies to installed package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,11 +158,15 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 
 list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/Modules)
 
-find_package(Boost REQUIRED COMPONENTS json program_options)
-find_package(TBB REQUIRED)
-find_package(fmt REQUIRED)
+# Dependencies required by public API
+find_package(Boost REQUIRED COMPONENTS json EXPORT)
+find_package(TBB REQUIRED EXPORT)
+find_package(fmt REQUIRED EXPORT)
+find_package(spdlog REQUIRED EXPORT)
+
+# Dependencies required by internal implementation
+find_package(Boost REQUIRED COMPONENTS program_options)
 find_package(jsonnet REQUIRED)
-find_package(spdlog REQUIRED)
 
 # Apply ThreadSanitizer flags if enabled
 if(ENABLE_TSAN)


### PR DESCRIPTION
Resolves #656.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Build system**
  - Split dependencies into public API and internal implementation groups.
  - Export Boost JSON, TBB, fmt, and spdlog so the installed `phlexConfig.cmake` can re-find them with `find_dependency()`.
  - Keep Boost program_options and jsonnet internal because they are not part of the public dependency surface.
  - Ensure consumers can use installed Phlex targets without declaring Phlex’s public dependencies separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->