### PR TITLE
test: add scoped shared ostream logger utility

### DIFF
--- a/test/accumulator_test.cpp
+++ b/test/accumulator_test.cpp
@@ -1,12 +1,11 @@
 #include "phlex/core/detail/accumulator_node.hpp"
 #include "phlex/model/data_cell_index.hpp"
 #include "phlex/model/product_specification.hpp"
+#include "test/ostream_logger.hpp"
 
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"
 #include "oneapi/tbb/flow_graph.h"
-#include "spdlog/sinks/ostream_sink.h"
-#include "spdlog/spdlog.h"
 
 #include <atomic>
 #include <cassert>
@@ -58,13 +57,6 @@ namespace {
   private:
     std::map<std::size_t, message> messages_;
   };
-
-  void use_ostream_logger(std::ostringstream& oss)
-  {
-    auto ostream_sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
-    auto ostream_logger = std::make_shared<spdlog::logger>("my_logger", ostream_sink);
-    spdlog::set_default_logger(ostream_logger);
-  }
 
   // Fold function: increments the accumulator by 1 per call. The accumulated value thus equals
   // the number of data cells processed.
@@ -212,7 +204,7 @@ TEST_CASE("Test accumulator with index messages before partition", "[multithread
 TEST_CASE("Test accumulator warning message if cache is not flushed", "[multithreading]")
 {
   std::ostringstream oss;
-  use_ostream_logger(oss);
+  auto logger = phlex::test::use_ostream_logger(oss);
 
   tbb::flow::graph g;
   auto accumulator = std::make_unique<internal::accumulator_node<int>>(

--- a/test/data_cell_tracker_test.cpp
+++ b/test/data_cell_tracker_test.cpp
@@ -1,22 +1,12 @@
 #include "phlex/model/data_cell_index.hpp"
 #include "phlex/model/data_cell_tracker.hpp"
+#include "test/ostream_logger.hpp"
 
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"
-#include "spdlog/sinks/ostream_sink.h"
-#include "spdlog/spdlog.h"
 
 using namespace phlex;
 using namespace phlex::detail;
-
-namespace {
-  void use_ostream_logger(std::ostringstream& oss)
-  {
-    auto ostream_sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
-    auto ostream_logger = std::make_shared<spdlog::logger>("my_logger", ostream_sink);
-    spdlog::set_default_logger(ostream_logger);
-  }
-}
 
 TEST_CASE("Test data-cell tracker", "[graph]")
 {
@@ -98,7 +88,7 @@ TEST_CASE("Test data-cell tracker with missing intermediate layers", "[graph]")
 TEST_CASE("Cached flush counts at destruction generate warning message", "[graph]")
 {
   std::ostringstream oss;
-  use_ostream_logger(oss);
+  auto logger = phlex::test::use_ostream_logger(oss);
   auto tracker = std::make_unique<data_cell_tracker>();
 
   auto job_index = data_cell_index::job();

--- a/test/data_cell_tracker_test.cpp
+++ b/test/data_cell_tracker_test.cpp
@@ -5,6 +5,8 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"
 
+#include <sstream>
+
 using namespace phlex;
 using namespace phlex::detail;
 

--- a/test/ostream_logger.hpp
+++ b/test/ostream_logger.hpp
@@ -28,7 +28,10 @@ namespace phlex::test {
     std::shared_ptr<spdlog::logger> previous_logger_;
   };
 
-  inline ostream_logger use_ostream_logger(std::ostream& stream) { return ostream_logger{stream}; }
+  [[nodiscard]] inline ostream_logger use_ostream_logger(std::ostream& stream)
+  {
+    return ostream_logger{stream};
+  }
 }
 
 #endif // TEST_OSTREAM_LOGGER_HPP

--- a/test/ostream_logger.hpp
+++ b/test/ostream_logger.hpp
@@ -1,0 +1,34 @@
+#ifndef TEST_OSTREAM_LOGGER_HPP
+#define TEST_OSTREAM_LOGGER_HPP
+
+#include "spdlog/sinks/ostream_sink.h"
+#include "spdlog/spdlog.h"
+
+#include <memory>
+#include <ostream>
+#include <utility>
+
+namespace phlex::test {
+  class ostream_logger {
+  public:
+    explicit ostream_logger(std::ostream& stream) : previous_logger_{spdlog::default_logger()}
+    {
+      auto sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(stream);
+      spdlog::set_default_logger(std::make_shared<spdlog::logger>("test_logger", sink));
+    }
+
+    ostream_logger(ostream_logger const&) = delete;
+    ostream_logger& operator=(ostream_logger const&) = delete;
+    ostream_logger(ostream_logger&&) = delete;
+    ostream_logger& operator=(ostream_logger&&) = delete;
+
+    ~ostream_logger() { spdlog::set_default_logger(std::move(previous_logger_)); }
+
+  private:
+    std::shared_ptr<spdlog::logger> previous_logger_;
+  };
+
+  inline ostream_logger use_ostream_logger(std::ostream& stream) { return ostream_logger{stream}; }
+}
+
+#endif // TEST_OSTREAM_LOGGER_HPP

--- a/test/repeater_node_test.cpp
+++ b/test/repeater_node_test.cpp
@@ -1,11 +1,10 @@
 #include "phlex/core/detail/repeater_node.hpp"
 #include "phlex/model/data_cell_index.hpp"
 #include "phlex/model/product_store.hpp"
+#include "test/ostream_logger.hpp"
 
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"
-#include "spdlog/sinks/ostream_sink.h"
-#include "spdlog/spdlog.h"
 
 #include <algorithm>
 #include <atomic>
@@ -60,13 +59,6 @@ namespace {
   private:
     std::vector<message> messages_;
   };
-
-  void use_ostream_logger(std::ostringstream& oss)
-  {
-    auto ostream_sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
-    auto ostream_logger = std::make_shared<spdlog::logger>("my_logger", ostream_sink);
-    spdlog::set_default_logger(ostream_logger);
-  }
 
   class repeater_test_fixture {
   public:
@@ -289,7 +281,7 @@ TEST_CASE("Test warning message if there are cached messages", "[multithreading]
 {
   // Setup ostream sink to capture warning message
   std::ostringstream oss;
-  use_ostream_logger(oss);
+  auto logger = phlex::test::use_ostream_logger(oss);
 
   // Below, we want to trigger the destruction of the repeater, which will emit a warning if
   // there are still cached messages that were never flushed. To do this without introducing a


### PR DESCRIPTION
Resolves #808 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Added the shared RAII utility `phlex::test::ostream_logger`.
  - Temporarily replaces `spdlog::default_logger()` with an `ostream_sink_mt` logger.
  - Restores the previous default logger before the target `std::ostringstream` is destroyed.
  - Added `use_ostream_logger(std::ostream&)` for convenient construction.
  - Deleted copy and move operations to preserve logger ownership.

- **Tests**
  - Updated accumulator, data-cell tracker, and repeater-node tests to use the shared utility.
  - Removed duplicated local logger setup helpers and direct logger configuration.
  - Preserved warning-capture behavior, including logger lifetime during destruction-warning tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->