### PR TITLE
FORM: apply naming conventions used as Phlex

### DIFF
--- a/form/core/placement.cpp
+++ b/form/core/placement.cpp
@@ -7,16 +7,16 @@
 using namespace form::detail::experimental;
 
 /// Constructor with initialization
-Placement::Placement(std::string fileName, std::string containerName, technology::Id technology) :
-  m_technology(technology),
-  m_fileName(std::move(fileName)),
-  m_containerName(std::move(containerName))
+placement::placement(std::string file_name, std::string container_name, technology::id technology) :
+  technology_(technology),
+  file_name_(std::move(file_name)),
+  container_name_(std::move(container_name))
 {
 }
 
 /// Access file name
-std::string const& Placement::fileName() const { return m_fileName; }
+std::string const& placement::file_name() const { return file_name_; }
 /// Access container name
-std::string const& Placement::containerName() const { return m_containerName; }
+std::string const& placement::container_name() const { return container_name_; }
 /// Access technology type
-form::technology::Id Placement::technology() const { return m_technology; }
+form::technology::id placement::technology() const { return technology_; }

--- a/form/core/placement.hpp
+++ b/form/core/placement.hpp
@@ -7,33 +7,33 @@
 
 #include <string>
 
-/* @class Placement
+/* @class placement
  * @brief This class holds all the necessary information to guide the writing of an object in a physical file.
  */
 namespace form::detail::experimental {
 
-  class Placement {
+  class placement {
   public:
     /// Default Constructor
-    Placement() = default;
+    placement() = default;
 
     /// Constructor with initialization
-    Placement(std::string fileName, std::string containerName, technology::Id technology);
+    placement(std::string file_name, std::string container_name, technology::id technology);
 
     /// Access file name
-    std::string const& fileName() const;
+    std::string const& file_name() const;
     /// Access container name
-    std::string const& containerName() const;
+    std::string const& container_name() const;
     /// Access technology type
-    technology::Id technology() const;
+    technology::id technology() const;
 
   private:
     /// Technology identifier
-    technology::Id m_technology{};
+    technology::id technology_{};
     /// File name
-    std::string m_fileName;
+    std::string file_name_;
     /// Container name
-    std::string m_containerName;
+    std::string container_name_;
   };
 } // namespace form::detail::experimental
 

--- a/form/core/technology.hpp
+++ b/form/core/technology.hpp
@@ -12,34 +12,34 @@
 namespace form::technology {
 
   // Major storage type (ROOT, HDF5, ...)
-  enum class Major : std::uint8_t {
+  enum class major : std::uint8_t {
     generic = 0, // no specific technology requested
     root = 1,
     hdf5 = 2,
   };
 
-  // Minor variant within a Major (e.g. TTree vs RNTuple within ROOT)
-  struct Id {
-    Major major{Major::generic};
+  // Minor variant within a major (e.g. TTree vs RNTuple within ROOT)
+  struct id {
+    major major{major::generic};
     int minor{0};
 
-    // Exact ordering over (major, minor): lets an Id be a std::map key and drives backend dispatch
-    constexpr auto operator<=>(Id const&) const = default;
+    // Exact ordering over (major, minor): lets an id be a std::map key and drives backend dispatch
+    constexpr auto operator<=>(id const&) const = default;
   };
 
-  // Backends: valid (major, minor) pairs, stable numeric values as a future Token may persist them
-  inline constexpr Id ROOT_TTREE{.major = Major::root, .minor = 1};
-  inline constexpr Id ROOT_RNTUPLE{.major = Major::root, .minor = 2};
-  inline constexpr Id HDF5{.major = Major::hdf5, .minor = 1};
+  // Backends: valid (major, minor) pairs, stable numeric values as a future token may persist them
+  inline constexpr id root_ttree{.major = major::root, .minor = 1};
+  inline constexpr id root_rntuple{.major = major::root, .minor = 2};
+  inline constexpr id hdf5{.major = major::hdf5, .minor = 1};
 
   // Canonical string -> technology mapping: the single place a technology string is parsed, replacing the copies that used to live in each module/source/test
-  inline Id from_string(std::string_view name)
+  inline id from_string(std::string_view name)
   {
     if (name == "ROOT_TTREE") {
-      return ROOT_TTREE;
+      return root_ttree;
     }
     if (name == "ROOT_RNTUPLE") {
-      return ROOT_RNTUPLE;
+      return root_rntuple;
     }
     if (name == "HDF5") {
       // HDF5 is a reserved technology but has no backend yet: reject it at parse time
@@ -49,15 +49,15 @@ namespace form::technology {
   }
 
   // Canonical technology -> string mapping
-  inline std::string to_string(Id tech)
+  inline std::string to_string(id tech)
   {
-    if (tech == ROOT_TTREE) {
+    if (tech == root_ttree) {
       return "ROOT_TTREE";
     }
-    if (tech == ROOT_RNTUPLE) {
+    if (tech == root_rntuple) {
       return "ROOT_RNTUPLE";
     }
-    if (tech == HDF5) {
+    if (tech == hdf5) {
       return "HDF5";
     }
     return "UNKNOWN";

--- a/form/core/technology.hpp
+++ b/form/core/technology.hpp
@@ -20,7 +20,12 @@ namespace form::technology {
 
   // Minor variant within a major (e.g. TTree vs RNTuple within ROOT)
   struct id {
-    major major{major::generic};
+    // Member is named 'major' to keep the {major, minor} pair. The type must be
+    // written QUALIFIED: GCC's -Wchanges-meaning rejects an unqualified
+    // 'major major' (the name 'major' would mean the type, then the member),
+    // while a qualified type is looked up in namespace scope and is fine.
+    // clang accepts either, so the unqualified form breaks only in a GCC build.
+    form::technology::major major{}; // value-initializes to major::generic (0)
     int minor{0};
 
     // Exact ordering over (major, minor): lets an id be a std::map key and drives backend dispatch

--- a/form/core/token.cpp
+++ b/form/core/token.cpp
@@ -6,36 +6,36 @@
 
 using namespace form::detail::experimental;
 
-/// Placement-only constructor; id is left unset
-Token::Token(std::string fileName, std::string containerName, technology::Id technology) :
-  m_technology(technology),
-  m_fileName(std::move(fileName)),
-  m_containerName(std::move(containerName)),
-  m_id(0),
-  m_hasId(false)
+/// placement-only constructor; id is left unset
+token::token(std::string file_name, std::string container_name, technology::id technology) :
+  technology_(technology),
+  file_name_(std::move(file_name)),
+  container_name_(std::move(container_name)),
+  id_(0),
+  has_id_(false)
 {
 }
 
 /// Fully-specified constructor; id is set
-Token::Token(std::string fileName,
-             std::string containerName,
-             technology::Id technology,
+token::token(std::string file_name,
+             std::string container_name,
+             technology::id technology,
              std::uint64_t id) :
-  m_technology(technology),
-  m_fileName(std::move(fileName)),
-  m_containerName(std::move(containerName)),
-  m_id(id),
-  m_hasId(true)
+  technology_(technology),
+  file_name_(std::move(file_name)),
+  container_name_(std::move(container_name)),
+  id_(id),
+  has_id_(true)
 {
 }
 
 /// Access file name
-std::string const& Token::fileName() const { return m_fileName; }
+std::string const& token::file_name() const { return file_name_; }
 /// Access container name
-std::string const& Token::containerName() const { return m_containerName; }
+std::string const& token::container_name() const { return container_name_; }
 /// Access technology type
-form::technology::Id Token::technology() const { return m_technology; }
+form::technology::id token::technology() const { return technology_; }
 /// Access identifier/entry number (0-based row)
-std::uint64_t Token::id() const { return m_id; }
+std::uint64_t token::id() const { return id_; }
 /// Whether an id has been set on this token
-bool Token::hasId() const { return m_hasId; }
+bool token::has_id() const { return has_id_; }

--- a/form/core/token.hpp
+++ b/form/core/token.hpp
@@ -8,47 +8,47 @@
 #include <cstdint>
 #include <string>
 
-/* @class Token
+/* @class token
  * @brief This class holds all the necessary information for reading of an object from a physical file.
  */
 namespace form::detail::experimental {
-  class Token {
+  class token {
   public:
     /// Default constructor; a token with no id set (delegates to the placement-only constructor)
-    Token() : Token("", "", {}) {}
+    token() : token("", "", {}) {}
 
-    /// Placement-only constructor; leaves the id unset (hasId() == false)
-    Token(std::string fileName, std::string containerName, technology::Id technology);
+    /// placement-only constructor; leaves the id unset (has_id() == false)
+    token(std::string file_name, std::string container_name, technology::id technology);
 
-    /// Fully-specified constructor; sets the 0-based row/entry id (hasId() == true)
-    Token(std::string fileName,
-          std::string containerName,
-          technology::Id technology,
+    /// Fully-specified constructor; sets the 0-based row/entry id (has_id() == true)
+    token(std::string file_name,
+          std::string container_name,
+          technology::id technology,
           std::uint64_t id);
 
     /// Access file name
-    std::string const& fileName() const;
+    std::string const& file_name() const;
     /// Access container name
-    std::string const& containerName() const;
+    std::string const& container_name() const;
     /// Access technology type
-    technology::Id technology() const;
+    technology::id technology() const;
 
-    /// Access identifier/entry number (0-based row). Only meaningful when hasId() is true.
+    /// Access identifier/entry number (0-based row). Only meaningful when has_id() is true.
     std::uint64_t id() const;
     /// Whether an id has been set on this token
-    bool hasId() const;
+    bool has_id() const;
 
   private:
     /// Technology identifier
-    technology::Id m_technology;
+    technology::id technology_;
     /// File name
-    std::string m_fileName;
+    std::string file_name_;
     /// Container name
-    std::string m_containerName;
+    std::string container_name_;
     /// Identifier/entry number (0-based row)
-    std::uint64_t m_id;
-    /// Whether m_id holds a valid, set value
-    bool m_hasId;
+    std::uint64_t id_;
+    /// Whether id_ holds a valid, set value
+    bool has_id_;
   };
 } // namespace form::detail::experimental
 #endif // FORM_CORE_TOKEN_HPP

--- a/form/form/config.cpp
+++ b/form/form/config.cpp
@@ -1,8 +1,8 @@
 #include "form/config.hpp"
 
 namespace {
-  template <class MAP_LIKE>
-  auto const_lookup(const MAP_LIKE& map, typename MAP_LIKE::key_type const& key)
+  template <class MapLike>
+  auto const_lookup(MapLike const& map, typename MapLike::key_type const& key)
   {
     auto const found = map.find(key);
     if (found != map.end()) {
@@ -14,16 +14,16 @@ namespace {
 
 namespace form::experimental::config {
 
-  void ItemConfig::addItem(std::string const& product_name,
-                           std::string const& file_name,
-                           technology::Id technology)
+  void item_config::add_item(std::string const& product_name,
+                             std::string const& file_name,
+                             technology::id technology)
   {
-    m_items.emplace_back(product_name, file_name, technology);
+    items_.emplace_back(product_name, file_name, technology);
   }
 
-  std::optional<PersistenceItem> ItemConfig::findItem(std::string const& product_name) const
+  std::optional<persistence_item> item_config::find_item(std::string const& product_name) const
   {
-    for (auto const& item : m_items) {
+    for (auto const& item : items_) {
       if (item.product_name == product_name) {
         return item;
       }
@@ -31,18 +31,18 @@ namespace form::experimental::config {
     return std::nullopt;
   }
 
-  tech_setting_config::table_t tech_setting_config::getFileTable(technology::Id const technology,
-                                                                 std::string const& fileName) const
+  tech_setting_config::table_t tech_setting_config::get_file_table(
+    technology::id const technology, std::string const& file_name) const
   {
     auto const per_tech = ::const_lookup(file_settings, technology);
-    return ::const_lookup(per_tech, fileName);
+    return ::const_lookup(per_tech, file_name);
   }
 
-  tech_setting_config::table_t tech_setting_config::getContainerTable(
-    technology::Id const technology, std::string const& containerName) const
+  tech_setting_config::table_t tech_setting_config::get_container_table(
+    technology::id const technology, std::string const& container_name) const
   {
     auto const per_tech = ::const_lookup(container_settings, technology);
-    return ::const_lookup(per_tech, containerName);
+    return ::const_lookup(per_tech, container_name);
   }
 
 } // namespace form::experimental::config

--- a/form/form/config.hpp
+++ b/form/form/config.hpp
@@ -13,47 +13,47 @@
 
 namespace form::experimental::config {
 
-  struct PersistenceItem {
+  struct persistence_item {
     std::string product_name;    // e.g. "trackStart", "trackNumberHits"
     std::string file_name;       // e.g. "toy.root", "output.hdf5"
-    technology::Id technology{}; // technology::ROOT_TTREE, ROOT_RNTUPLE, HDF5
+    technology::id technology{}; // technology::root_ttree, root_rntuple, hdf5
 
-    PersistenceItem() = default;
+    persistence_item() = default;
 
-    PersistenceItem(std::string product, std::string file, technology::Id tech) :
+    persistence_item(std::string product, std::string file, technology::id tech) :
       product_name(std::move(product)), file_name(std::move(file)), technology(tech)
     {
     }
   };
 
-  class ItemConfig {
+  class item_config {
   public:
-    ItemConfig() = default;
-    ~ItemConfig() = default;
+    item_config() = default;
+    ~item_config() = default;
 
     // Add a configuration item
-    void addItem(std::string const& product_name,
-                 std::string const& file_name,
-                 technology::Id technology);
+    void add_item(std::string const& product_name,
+                  std::string const& file_name,
+                  technology::id technology);
 
     // Find configuration for a product+creator combination
-    std::optional<PersistenceItem> findItem(std::string const& product_name) const;
+    std::optional<persistence_item> find_item(std::string const& product_name) const;
 
     // Get all items (for debugging/validation)
-    std::vector<PersistenceItem> const& getItems() const { return m_items; }
+    std::vector<persistence_item> const& get_items() const { return items_; }
 
   private:
-    std::vector<PersistenceItem> m_items;
+    std::vector<persistence_item> items_;
   };
 
   struct tech_setting_config {
     using table_t = std::vector<std::pair<std::string, std::string>>;
-    using map_t = std::map<technology::Id, std::unordered_map<std::string, table_t>>;
+    using map_t = std::map<technology::id, std::unordered_map<std::string, table_t>>;
     map_t file_settings;
     map_t container_settings;
 
-    table_t getFileTable(technology::Id technology, std::string const& fileName) const;
-    table_t getContainerTable(technology::Id technology, std::string const& containerName) const;
+    table_t get_file_table(technology::id technology, std::string const& file_name) const;
+    table_t get_container_table(technology::id technology, std::string const& container_name) const;
   };
 
 } // namespace form::experimental::config

--- a/form/form/form_reader.cpp
+++ b/form/form/form_reader.cpp
@@ -7,19 +7,19 @@
 
 namespace form::experimental {
 
-  form_reader_interface::form_reader_interface(config::ItemConfig const& config_item,
+  form_reader_interface::form_reader_interface(config::item_config const& config_item,
                                                config::tech_setting_config const& tech_config) :
-    m_pers_reader(nullptr)
+    pers_reader_(nullptr)
   {
-    for (auto const& item : config_item.getItems()) {
-      m_product_to_config.emplace(item.product_name,
-                                  form::experimental::config::PersistenceItem(
-                                    item.product_name, item.file_name, item.technology));
+    for (auto const& item : config_item.get_items()) {
+      product_to_config_.emplace(item.product_name,
+                                 form::experimental::config::persistence_item(
+                                   item.product_name, item.file_name, item.technology));
     }
 
-    m_pers_reader = form::detail::experimental::createPersistenceReader();
-    m_pers_reader->configure(config_item);
-    m_pers_reader->configureTechSettings(tech_config);
+    pers_reader_ = form::detail::experimental::create_persistence_reader();
+    pers_reader_->configure(config_item);
+    pers_reader_->configure_tech_settings(tech_config);
   }
 
   void form_reader_interface::read(std::string const& creator,
@@ -27,24 +27,24 @@ namespace form::experimental {
                                    product_with_name& product)
   {
 
-    auto config_it = m_product_to_config.find(product.label);
-    if (config_it == m_product_to_config.end()) {
+    auto config_it = product_to_config_.find(product.label);
+    if (config_it == product_to_config_.end()) {
       throw std::runtime_error("No configuration found for product: " + product.label);
     }
 
-    m_pers_reader->read(creator, product.label, segment_id, &product.data, *product.type);
+    pers_reader_->read(creator, product.label, segment_id, &product.data, *product.type);
   }
 
   void form_reader_interface::prime(std::string const& creator,
                                     std::string const& product_name,
                                     std::type_info const& type)
   {
-    m_pers_reader->prime(creator, product_name, type);
+    pers_reader_->prime(creator, product_name, type);
   }
 
   std::vector<std::string> form_reader_interface::indices(std::string const& creator,
                                                           std::string const& product_name)
   {
-    return m_pers_reader->listIndices(creator, product_name);
+    return pers_reader_->list_indices(creator, product_name);
   }
 }

--- a/form/form/form_reader.hpp
+++ b/form/form/form_reader.hpp
@@ -17,7 +17,7 @@ namespace form::experimental {
 
   class form_reader_interface {
   public:
-    form_reader_interface(config::ItemConfig const& config_item,
+    form_reader_interface(config::item_config const& config_item,
                           config::tech_setting_config const& tech_config);
     ~form_reader_interface() = default;
 
@@ -32,8 +32,8 @@ namespace form::experimental {
     std::vector<std::string> indices(std::string const& creator, std::string const& product_name);
 
   private:
-    std::unique_ptr<form::detail::experimental::IPersistenceReader> m_pers_reader;
-    std::map<std::string, form::experimental::config::PersistenceItem> m_product_to_config;
+    std::unique_ptr<form::detail::experimental::i_persistence_reader> pers_reader_;
+    std::map<std::string, form::experimental::config::persistence_item> product_to_config_;
   };
 }
 

--- a/form/form/form_writer.cpp
+++ b/form/form/form_writer.cpp
@@ -8,19 +8,19 @@
 
 namespace form::experimental {
 
-  form_writer_interface::form_writer_interface(config::ItemConfig const& config_item,
+  form_writer_interface::form_writer_interface(config::item_config const& config_item,
                                                config::tech_setting_config const& tech_config) :
-    m_pers_writer(nullptr)
+    pers_writer_(nullptr)
   {
-    for (auto const& item : config_item.getItems()) {
-      m_product_to_config.emplace(item.product_name,
-                                  form::experimental::config::PersistenceItem(
-                                    item.product_name, item.file_name, item.technology));
+    for (auto const& item : config_item.get_items()) {
+      product_to_config_.emplace(item.product_name,
+                                 form::experimental::config::persistence_item(
+                                   item.product_name, item.file_name, item.technology));
     }
 
-    m_pers_writer = form::detail::experimental::createPersistenceWriter();
-    m_pers_writer->configure(config_item);
-    m_pers_writer->configureTechSettings(tech_config);
+    pers_writer_ = form::detail::experimental::create_persistence_writer();
+    pers_writer_->configure(config_item);
+    pers_writer_->configure_tech_settings(tech_config);
   }
 
   void form_writer_interface::write(std::string const& creator,
@@ -28,18 +28,18 @@ namespace form::experimental {
                                     product_with_name const& product)
   {
 
-    auto config_it = m_product_to_config.find(product.label);
-    if (config_it == m_product_to_config.end()) {
+    auto config_it = product_to_config_.find(product.label);
+    if (config_it == product_to_config_.end()) {
       std::cerr << "No configuration found for product: " << product.label << '\n';
       return;
     }
 
     std::map<std::string, std::type_info const*> products = {{product.label, product.type}};
-    m_pers_writer->createContainers(creator, products);
+    pers_writer_->create_containers(creator, products);
 
-    m_pers_writer->registerWrite(creator, product.label, product.data, *product.type);
+    pers_writer_->register_write(creator, product.label, product.data, *product.type);
 
-    m_pers_writer->commitOutput(creator, segment_id);
+    pers_writer_->commit_output(creator, segment_id);
   }
 
   void form_writer_interface::write(std::string const& creator,
@@ -51,8 +51,8 @@ namespace form::experimental {
       return;
     }
 
-    auto config_it = m_product_to_config.find(products[0].label);
-    if (config_it == m_product_to_config.end()) {
+    auto config_it = product_to_config_.find(products[0].label);
+    if (config_it == product_to_config_.end()) {
       std::cerr << "No configuration found for product: " << products[0].label << '\n';
       return;
     }
@@ -63,14 +63,14 @@ namespace form::experimental {
       product_types.insert(std::make_pair(pb.label, pb.type));
     }
 
-    m_pers_writer->createContainers(creator, product_types);
+    pers_writer_->create_containers(creator, product_types);
 
     for (auto const& pb : products) {
       // FIXME: We could consider checking id to be identical for all product bases here
-      m_pers_writer->registerWrite(creator, pb.label, pb.data, *pb.type);
+      pers_writer_->register_write(creator, pb.label, pb.data, *pb.type);
     }
 
-    m_pers_writer->commitOutput(creator, segment_id);
+    pers_writer_->commit_output(creator, segment_id);
   }
 
 }

--- a/form/form/form_writer.hpp
+++ b/form/form/form_writer.hpp
@@ -16,7 +16,7 @@ namespace form::experimental {
 
   class form_writer_interface {
   public:
-    form_writer_interface(config::ItemConfig const& config_item,
+    form_writer_interface(config::item_config const& config_item,
                           config::tech_setting_config const& tech_config);
     ~form_writer_interface() = default;
 
@@ -29,8 +29,8 @@ namespace form::experimental {
                std::vector<product_with_name> const& products);
 
   private:
-    std::unique_ptr<form::detail::experimental::IPersistenceWriter> m_pers_writer;
-    std::map<std::string, form::experimental::config::PersistenceItem> m_product_to_config;
+    std::unique_ptr<form::detail::experimental::i_persistence_writer> pers_writer_;
+    std::map<std::string, form::experimental::config::persistence_item> product_to_config_;
   };
 }
 

--- a/form/form_module.cpp
+++ b/form/form_module.cpp
@@ -15,19 +15,19 @@
 
 namespace {
 
-  class FormOutputModule {
+  class form_output_module {
   public:
-    FormOutputModule(std::string output_file,
-                     form::technology::Id technology,
-                     std::vector<std::string> const& products_to_save) :
-      m_output_file(std::move(output_file)), m_technology(technology)
+    form_output_module(std::string output_file,
+                       form::technology::id technology,
+                       std::vector<std::string> const& products_to_save) :
+      output_file_(std::move(output_file)), technology_(technology)
     {
-      std::cout << "FormOutputModule initialized\n";
-      std::cout << "  Output file: " << m_output_file << "\n";
-      std::cout << "  Technology: " << form::technology::to_string(m_technology) << "\n";
+      std::cout << "form_output_module initialized\n";
+      std::cout << "  Output file: " << output_file_ << "\n";
+      std::cout << "  Technology: " << form::technology::to_string(technology_) << "\n";
 
       // Build FORM configuration
-      form::experimental::config::ItemConfig output_cfg;
+      form::experimental::config::item_config output_cfg;
       form::experimental::config::tech_setting_config tech_cfg;
 
       // FIXME: Temporary solution to accommodate Phlex limitation.
@@ -37,11 +37,11 @@ namespace {
       // Temp. Sol for Phlex Prototype 0.1
       // Register products from config
       for (auto const& product : products_to_save) {
-        output_cfg.addItem(product, m_output_file, m_technology);
+        output_cfg.add_item(product, output_file_, technology_);
       }
 
       // Initialize FORM interface
-      m_form_interface =
+      form_interface_ =
         std::make_unique<form::experimental::form_writer_interface>(output_cfg, tech_cfg);
     }
 
@@ -61,7 +61,7 @@ namespace {
       // Extract segment ID (partition) - extract once for entire store
       auto segment_id = store.index()->to_string();
 
-      std::cout << "\n=== FormOutputModule::save_data_products ===\n";
+      std::cout << "\n=== form_output_module::save_data_products ===\n";
       std::cout << "Creator: " << creator.to_string() << "\n";
       std::cout << "Segment ID: " << segment_id << "\n";
       std::cout << "Number of products: " << store.size() << "\n";
@@ -94,17 +94,17 @@ namespace {
       // Write all products to FORM
       // Pass segment_id once for entire collection (not duplicated in each product)
       // No need to check if products is empty - already checked store.empty() above
-      m_form_interface->write(creator.to_string(), segment_id, products);
+      form_interface_->write(creator.to_string(), segment_id, products);
       std::cout << "Wrote " << products.size() << " products to FORM\n";
     }
 
   private:
     // Algorithm configuration fixed at construction; intentionally immutable for object lifetime.
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
-    std::string const m_output_file;
-    form::technology::Id const m_technology;
+    std::string const output_file_;
+    form::technology::id const technology_;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
-    std::unique_ptr<form::experimental::form_writer_interface> m_form_interface;
+    std::unique_ptr<form::experimental::form_writer_interface> form_interface_;
   };
 
 }
@@ -127,11 +127,11 @@ PHLEX_REGISTER_ALGORITHMS(m, config)
 
   // Phlex needs an OBJECT
   // Create the FORM output module
-  auto form_output = m.make<FormOutputModule>(output_file, technology, products_to_save);
+  auto form_output = m.make<form_output_module>(output_file, technology, products_to_save);
 
   // Phlex needs a MEMBER FUNCTION to call
   // Register the callback that Phlex will invoke
-  form_output.output("save_data_products", &FormOutputModule::save_data_products);
+  form_output.output("save_data_products", &form_output_module::save_data_products);
 
   std::cout << "FORM output module registered successfully\n";
 }

--- a/form/form_source.cpp
+++ b/form/form_source.cpp
@@ -59,13 +59,13 @@ namespace {
     return current;
   }
 
-  class FormInputSource : public phlex::source {
+  class form_input_source : public phlex::source {
   public:
-    FormInputSource(form::experimental::config::ItemConfig const& input_cfg,
-                    form::experimental::config::tech_setting_config const& tech_cfg,
-                    std::string actual_creator,
-                    std::string advertised_creator,
-                    std::vector<std::string> const& products) :
+    form_input_source(form::experimental::config::item_config const& input_cfg,
+                      form::experimental::config::tech_setting_config const& tech_cfg,
+                      std::string actual_creator,
+                      std::string advertised_creator,
+                      std::vector<std::string> const& products) :
       reader_(std::make_shared<form::experimental::form_reader_interface>(input_cfg, tech_cfg)),
       actual_creator_(std::move(actual_creator)),
       advertised_creator_(std::move(advertised_creator)),
@@ -178,14 +178,14 @@ PHLEX_REGISTER_SOURCE(s, config)
 
   auto const technology = form::technology::from_string(tech_string);
 
-  form::experimental::config::ItemConfig input_cfg;
+  form::experimental::config::item_config input_cfg;
   form::experimental::config::tech_setting_config tech_cfg;
   for (auto const& name : products) {
-    input_cfg.addItem(name, input_file, technology);
+    input_cfg.add_item(name, input_file, technology);
   }
 
   // Register the source object with Phlex
-  s.add_source<FormInputSource>(
+  s.add_source<form_input_source>(
     module_label, input_cfg, tech_cfg, actual_creator, advertised_creator, products);
 
   std::cout << "FORM input source registered successfully\n";

--- a/form/persistence/ipersistence_reader.hpp
+++ b/form/persistence/ipersistence_reader.hpp
@@ -10,21 +10,21 @@
 #include <vector>
 
 namespace form::experimental::config {
-  class ItemConfig;
+  class item_config;
   struct tech_setting_config;
 }
 
 namespace form::detail::experimental {
 
-  class IPersistenceReader {
+  class i_persistence_reader {
   public:
-    IPersistenceReader() = default;
-    virtual ~IPersistenceReader() = default;
+    i_persistence_reader() = default;
+    virtual ~i_persistence_reader() = default;
 
-    virtual void configureTechSettings(
+    virtual void configure_tech_settings(
       form::experimental::config::tech_setting_config const& tech_config_settings) = 0;
 
-    virtual void configure(form::experimental::config::ItemConfig const& configItems) = 0;
+    virtual void configure(form::experimental::config::item_config const& config_items) = 0;
 
     virtual void read(std::string const& creator,
                       std::string const& label,
@@ -36,11 +36,11 @@ namespace form::detail::experimental {
                        std::string const& label,
                        std::type_info const& type) = 0;
 
-    virtual std::vector<std::string> listIndices(std::string const& creator,
-                                                 std::string const& label) = 0;
+    virtual std::vector<std::string> list_indices(std::string const& creator,
+                                                  std::string const& label) = 0;
   };
 
-  std::unique_ptr<IPersistenceReader> createPersistenceReader();
+  std::unique_ptr<i_persistence_reader> create_persistence_reader();
 
 } // namespace form::detail::experimental
 

--- a/form/persistence/ipersistence_writer.hpp
+++ b/form/persistence/ipersistence_writer.hpp
@@ -11,34 +11,34 @@
 #include <typeinfo>
 
 namespace form::experimental::config {
-  class ItemConfig;
+  class item_config;
   struct tech_setting_config;
 }
 
 namespace form::detail::experimental {
 
-  class IPersistenceWriter {
+  class i_persistence_writer {
   public:
-    IPersistenceWriter() = default;
-    virtual ~IPersistenceWriter() = default;
+    i_persistence_writer() = default;
+    virtual ~i_persistence_writer() = default;
 
-    virtual void configureTechSettings(
+    virtual void configure_tech_settings(
       form::experimental::config::tech_setting_config const& tech_config_settings) = 0;
 
-    virtual void configure(form::experimental::config::ItemConfig const& configItems) = 0;
+    virtual void configure(form::experimental::config::item_config const& config_items) = 0;
 
-    virtual void createContainers(std::string const& creator,
-                                  std::map<std::string, std::type_info const*> const& products) = 0;
-    // Write one product and return a Token locating it: placement plus 0-based row (entry) number
-    // Throws if backend isn't row-addressed, causing Token read lookup to fail
-    virtual Token registerWrite(std::string const& creator,
-                                std::string const& label,
-                                void const* data,
-                                std::type_info const& type) = 0;
-    virtual void commitOutput(std::string const& creator, std::string const& id) = 0;
+    virtual void create_containers(
+      std::string const& creator, std::map<std::string, std::type_info const*> const& products) = 0;
+    // Write one product and return a token locating it: placement plus 0-based row (entry) number
+    // Throws if backend isn't row-addressed, causing token read lookup to fail
+    virtual token register_write(std::string const& creator,
+                                 std::string const& label,
+                                 void const* data,
+                                 std::type_info const& type) = 0;
+    virtual void commit_output(std::string const& creator, std::string const& id) = 0;
   };
 
-  std::unique_ptr<IPersistenceWriter> createPersistenceWriter();
+  std::unique_ptr<i_persistence_writer> create_persistence_writer();
 
 } // namespace form::detail::experimental
 

--- a/form/persistence/persistence_reader.cpp
+++ b/form/persistence/persistence_reader.cpp
@@ -13,87 +13,87 @@
 using namespace form::detail::experimental;
 
 namespace form::detail::experimental {
-  std::unique_ptr<IPersistenceReader> createPersistenceReader()
+  std::unique_ptr<i_persistence_reader> create_persistence_reader()
   {
-    return std::make_unique<PersistenceReader>();
+    return std::make_unique<persistence_reader>();
   }
 }
 
-PersistenceReader::PersistenceReader() :
-  m_store_reader(createStorageReader()),
-  m_config_items(),
-  m_tech_settings() // constructor takes form config
+persistence_reader::persistence_reader() :
+  store_reader_(create_storage_reader()),
+  config_items_(),
+  tech_settings_() // constructor takes form config
 {
 }
 
-void PersistenceReader::configureTechSettings(
+void persistence_reader::configure_tech_settings(
   form::experimental::config::tech_setting_config const& tech_config_settings)
 {
-  m_tech_settings = tech_config_settings;
+  tech_settings_ = tech_config_settings;
 }
 
-void PersistenceReader::configure(form::experimental::config::ItemConfig const& config_items)
+void persistence_reader::configure(form::experimental::config::item_config const& config_items)
 {
-  m_config_items = config_items;
+  config_items_ = config_items;
 }
 
-void PersistenceReader::read(std::string const& creator,
-                             std::string const& label,
-                             std::string const& id,
-                             void const** data,
-                             std::type_info const& type)
-{
-  std::unique_ptr<Token> token = getToken(creator, label, id);
-  m_store_reader->readContainer(*token, data, type, m_tech_settings);
-}
-
-void PersistenceReader::prime(std::string const& creator,
+void persistence_reader::read(std::string const& creator,
                               std::string const& label,
+                              std::string const& id,
+                              void const** data,
                               std::type_info const& type)
 {
-  auto const config_item = findConfigItem(m_config_items, label);
-
-  if (!config_item) {
-    throw std::runtime_error("No configuration found for product: " + label +
-                             " from creator: " + creator);
-  }
-
-  std::string const full_label = buildFullLabel(creator, label);
-  m_store_reader->prime(
-    Token{config_item->file_name, full_label, config_item->technology}, type, m_tech_settings);
+  std::unique_ptr<token> token = get_token(creator, label, id);
+  store_reader_->read_container(*token, data, type, tech_settings_);
 }
 
-std::vector<std::string> PersistenceReader::listIndices(std::string const& creator,
-                                                        std::string const& label)
+void persistence_reader::prime(std::string const& creator,
+                               std::string const& label,
+                               std::type_info const& type)
 {
-  auto const config_item = findConfigItem(m_config_items, label);
+  auto const config_item = find_config_item(config_items_, label);
 
   if (!config_item) {
     throw std::runtime_error("No configuration found for product: " + label +
                              " from creator: " + creator);
   }
 
-  std::string const full_label = buildFullLabel(creator, "index");
-  return m_store_reader->listIndices(
-    Token{config_item->file_name, full_label, config_item->technology}, m_tech_settings);
+  std::string const full_label = build_full_label(creator, label);
+  store_reader_->prime(
+    token{config_item->file_name, full_label, config_item->technology}, type, tech_settings_);
 }
 
-std::unique_ptr<Token> PersistenceReader::getToken(std::string const& creator,
-                                                   std::string const& label,
-                                                   std::string const& id)
+std::vector<std::string> persistence_reader::list_indices(std::string const& creator,
+                                                          std::string const& label)
 {
-  auto const config_item = findConfigItem(m_config_items, label);
+  auto const config_item = find_config_item(config_items_, label);
 
   if (!config_item) {
     throw std::runtime_error("No configuration found for product: " + label +
                              " from creator: " + creator);
   }
 
-  std::string const full_label = buildFullLabel(creator, label);
-  std::string const index_label = buildFullLabel(creator, "index");
+  std::string const full_label = build_full_label(creator, "index");
+  return store_reader_->list_indices(
+    token{config_item->file_name, full_label, config_item->technology}, tech_settings_);
+}
 
-  int const rowId = m_store_reader->getIndex(
-    Token{config_item->file_name, index_label, config_item->technology}, id, m_tech_settings);
-  return std::make_unique<Token>(
-    config_item->file_name, full_label, config_item->technology, rowId);
+std::unique_ptr<token> persistence_reader::get_token(std::string const& creator,
+                                                     std::string const& label,
+                                                     std::string const& id)
+{
+  auto const config_item = find_config_item(config_items_, label);
+
+  if (!config_item) {
+    throw std::runtime_error("No configuration found for product: " + label +
+                             " from creator: " + creator);
+  }
+
+  std::string const full_label = build_full_label(creator, label);
+  std::string const index_label = build_full_label(creator, "index");
+
+  int const row_id = store_reader_->get_index(
+    token{config_item->file_name, index_label, config_item->technology}, id, tech_settings_);
+  return std::make_unique<token>(
+    config_item->file_name, full_label, config_item->technology, row_id);
 }

--- a/form/persistence/persistence_reader.hpp
+++ b/form/persistence/persistence_reader.hpp
@@ -14,20 +14,20 @@
 
 // forward declaration for form config
 namespace form::experimental::config {
-  class ItemConfig;
+  class item_config;
   struct tech_setting_config;
 }
 
 namespace form::detail::experimental {
 
-  class PersistenceReader : public IPersistenceReader {
+  class persistence_reader : public i_persistence_reader {
   public:
-    PersistenceReader();
-    ~PersistenceReader() override = default;
-    void configureTechSettings(
+    persistence_reader();
+    ~persistence_reader() override = default;
+    void configure_tech_settings(
       form::experimental::config::tech_setting_config const& tech_config_settings) override;
 
-    void configure(form::experimental::config::ItemConfig const& config_items) override;
+    void configure(form::experimental::config::item_config const& config_items) override;
 
     void read(std::string const& creator,
               std::string const& label,
@@ -39,17 +39,17 @@ namespace form::detail::experimental {
                std::string const& label,
                std::type_info const& type) override;
 
-    std::vector<std::string> listIndices(std::string const& creator,
-                                         std::string const& label) override;
+    std::vector<std::string> list_indices(std::string const& creator,
+                                          std::string const& label) override;
 
   private:
-    std::unique_ptr<Token> getToken(std::string const& creator,
-                                    std::string const& label,
-                                    std::string const& id);
+    std::unique_ptr<token> get_token(std::string const& creator,
+                                     std::string const& label,
+                                     std::string const& id);
 
-    std::unique_ptr<IStorageReader> m_store_reader;
-    form::experimental::config::ItemConfig m_config_items;
-    form::experimental::config::tech_setting_config m_tech_settings;
+    std::unique_ptr<i_storage_reader> store_reader_;
+    form::experimental::config::item_config config_items_;
+    form::experimental::config::tech_setting_config tech_settings_;
   };
 
 } // namespace form::detail::experimental

--- a/form/persistence/persistence_utils.cpp
+++ b/form/persistence/persistence_utils.cpp
@@ -2,10 +2,10 @@
 #include "form/config.hpp"
 
 namespace form::detail::experimental {
-  std::optional<form::experimental::config::PersistenceItem const> findConfigItem(
-    form::experimental::config::ItemConfig const& config, std::string const& label)
+  std::optional<form::experimental::config::persistence_item const> find_config_item(
+    form::experimental::config::item_config const& config, std::string const& label)
   {
-    auto const& items = config.getItems();
+    auto const& items = config.get_items();
     if (label == "index") {
       return (items.empty())
                ? std::nullopt
@@ -14,10 +14,10 @@ namespace form::detail::experimental {
                       .begin()); //emulate how FORM did this before Phlex PR #22.  Will be fixed in a future FORM update.
     }
 
-    return config.findItem(label);
+    return config.find_item(label);
   }
 
-  std::string buildFullLabel(std::string_view creator, std::string_view label)
+  std::string build_full_label(std::string_view creator, std::string_view label)
   {
     std::string result;
     result.reserve(creator.size() + 1 + label.size());

--- a/form/persistence/persistence_utils.hpp
+++ b/form/persistence/persistence_utils.hpp
@@ -7,15 +7,15 @@
 
 namespace form {
   namespace experimental::config {
-    class ItemConfig;
+    class item_config;
   }
 
   namespace detail::experimental {
-    //findConfigItem() is here and not a member of ItemConfig because of the way it handles the label "index".  Different hypothetical Persistence implementations may want to handle "index" different ways.
-    std::optional<form::experimental::config::PersistenceItem const> findConfigItem(
-      form::experimental::config::ItemConfig const& config, std::string const& label);
+    //find_config_item() is here and not a member of item_config because of the way it handles the label "index".  Different hypothetical Persistence implementations may want to handle "index" different ways.
+    std::optional<form::experimental::config::persistence_item const> find_config_item(
+      form::experimental::config::item_config const& config, std::string const& label);
 
-    std::string buildFullLabel(std::string_view creator, std::string_view label);
+    std::string build_full_label(std::string_view creator, std::string_view label);
   }
 }
 

--- a/form/persistence/persistence_writer.cpp
+++ b/form/persistence/persistence_writer.cpp
@@ -13,75 +13,75 @@
 using namespace form::detail::experimental;
 
 namespace form::detail::experimental {
-  std::unique_ptr<IPersistenceWriter> createPersistenceWriter()
+  std::unique_ptr<i_persistence_writer> create_persistence_writer()
   {
-    return std::make_unique<PersistenceWriter>();
+    return std::make_unique<persistence_writer>();
   }
 }
 
-PersistenceWriter::PersistenceWriter() :
-  m_store_writer(createStorageWriter()),
-  m_config_items(),
-  m_tech_settings() // constructor takes form config
+persistence_writer::persistence_writer() :
+  store_writer_(create_storage_writer()),
+  config_items_(),
+  tech_settings_() // constructor takes form config
 {
 }
 
-void PersistenceWriter::configureTechSettings(
+void persistence_writer::configure_tech_settings(
   form::experimental::config::tech_setting_config const& tech_config_settings)
 {
-  m_tech_settings = tech_config_settings;
+  tech_settings_ = tech_config_settings;
 }
 
-void PersistenceWriter::configure(form::experimental::config::ItemConfig const& config_items)
+void persistence_writer::configure(form::experimental::config::item_config const& config_items)
 {
-  m_config_items = config_items;
+  config_items_ = config_items;
 }
 
-void PersistenceWriter::createContainers(
+void persistence_writer::create_containers(
   std::string const& creator, std::map<std::string, std::type_info const*> const& products)
 {
-  std::map<std::unique_ptr<Placement>, std::type_info const*> containers;
+  std::map<std::unique_ptr<placement>, std::type_info const*> containers;
   for (auto const& [label, type] : products) {
-    containers.insert(std::make_pair(getPlacement(creator, label), type));
+    containers.insert(std::make_pair(get_placement(creator, label), type));
   }
-  containers.insert(std::make_pair(getPlacement(creator, "index"), &typeid(std::string)));
-  m_store_writer->createContainers(containers, m_tech_settings);
+  containers.insert(std::make_pair(get_placement(creator, "index"), &typeid(std::string)));
+  store_writer_->create_containers(containers, tech_settings_);
 }
 
-Token PersistenceWriter::registerWrite(std::string const& creator,
-                                       std::string const& label,
-                                       void const* data,
-                                       std::type_info const& type)
+token persistence_writer::register_write(std::string const& creator,
+                                         std::string const& label,
+                                         void const* data,
+                                         std::type_info const& type)
 {
-  std::unique_ptr<Placement> plcmnt = getPlacement(creator, label);
-  std::uint64_t const row = m_store_writer->fillContainer(*plcmnt, data, type);
-  // A returned Token must locate a readable product: its row is the read-side navigation key.
-  // kInvalidRowId means backend does not address rows,so a product routed there could not be located on read, so throw here for such an unusable Token
-  if (row == kInvalidRowId) {
-    throw std::runtime_error("PersistenceWriter::registerWrite backend for product '" + label +
+  std::unique_ptr<placement> plcmnt = get_placement(creator, label);
+  std::uint64_t const row = store_writer_->fill_container(*plcmnt, data, type);
+  // A returned token must locate a readable product: its row is the read-side navigation key.
+  // invalid_row_id means backend does not address rows,so a product routed there could not be located on read, so throw here for such an unusable token
+  if (row == invalid_row_id) {
+    throw std::runtime_error("persistence_writer::register_write backend for product '" + label +
                              "' from creator '" + creator + "' does not address rows; " +
-                             "cannot produce a Token locating the written product");
+                             "cannot produce a token locating the written product");
   }
-  return Token{plcmnt->fileName(), plcmnt->containerName(), plcmnt->technology(), row};
+  return token{plcmnt->file_name(), plcmnt->container_name(), plcmnt->technology(), row};
 }
 
-void PersistenceWriter::commitOutput(std::string const& creator, std::string const& id)
+void persistence_writer::commit_output(std::string const& creator, std::string const& id)
 {
-  std::unique_ptr<Placement> plcmnt = getPlacement(creator, "index");
-  m_store_writer->fillContainer(*plcmnt, &id, typeid(std::string));
-  m_store_writer->commitContainers(*plcmnt);
+  std::unique_ptr<placement> plcmnt = get_placement(creator, "index");
+  store_writer_->fill_container(*plcmnt, &id, typeid(std::string));
+  store_writer_->commit_containers(*plcmnt);
 }
 
-std::unique_ptr<Placement> PersistenceWriter::getPlacement(std::string const& creator,
-                                                           std::string const& label)
+std::unique_ptr<placement> persistence_writer::get_placement(std::string const& creator,
+                                                             std::string const& label)
 {
-  auto const config_item = findConfigItem(m_config_items, label);
+  auto const config_item = find_config_item(config_items_, label);
 
   if (!config_item) {
     throw std::runtime_error("No configuration found for product: " + label +
                              " from creator: " + creator);
   }
 
-  std::string const full_label = buildFullLabel(creator, label);
-  return std::make_unique<Placement>(config_item->file_name, full_label, config_item->technology);
+  std::string const full_label = build_full_label(creator, label);
+  return std::make_unique<placement>(config_item->file_name, full_label, config_item->technology);
 }

--- a/form/persistence/persistence_writer.hpp
+++ b/form/persistence/persistence_writer.hpp
@@ -14,35 +14,35 @@
 
 // forward declaration for form config
 namespace form::experimental::config {
-  class ItemConfig;
+  class item_config;
   struct tech_setting_config;
 }
 
 namespace form::detail::experimental {
 
-  class PersistenceWriter : public IPersistenceWriter {
+  class persistence_writer : public i_persistence_writer {
   public:
-    PersistenceWriter();
-    ~PersistenceWriter() override = default;
-    void configureTechSettings(
+    persistence_writer();
+    ~persistence_writer() override = default;
+    void configure_tech_settings(
       form::experimental::config::tech_setting_config const& tech_config_settings) override;
 
-    void configure(form::experimental::config::ItemConfig const& config_items) override;
+    void configure(form::experimental::config::item_config const& config_items) override;
 
-    void createContainers(std::string const& creator,
-                          std::map<std::string, std::type_info const*> const& products) override;
-    Token registerWrite(std::string const& creator,
-                        std::string const& label,
-                        void const* data,
-                        std::type_info const& type) override;
-    void commitOutput(std::string const& creator, std::string const& id) override;
+    void create_containers(std::string const& creator,
+                           std::map<std::string, std::type_info const*> const& products) override;
+    token register_write(std::string const& creator,
+                         std::string const& label,
+                         void const* data,
+                         std::type_info const& type) override;
+    void commit_output(std::string const& creator, std::string const& id) override;
 
   private:
-    std::unique_ptr<Placement> getPlacement(std::string const& creator, std::string const& label);
+    std::unique_ptr<placement> get_placement(std::string const& creator, std::string const& label);
 
-    std::unique_ptr<IStorageWriter> m_store_writer;
-    form::experimental::config::ItemConfig m_config_items;
-    form::experimental::config::tech_setting_config m_tech_settings;
+    std::unique_ptr<i_storage_writer> store_writer_;
+    form::experimental::config::item_config config_items_;
+    form::experimental::config::tech_setting_config tech_settings_;
   };
 
 } // namespace form::detail::experimental

--- a/form/root_storage/demangle_name.cpp
+++ b/form/root_storage/demangle_name.cpp
@@ -7,27 +7,28 @@
 namespace {
   class char_string_holder {
   public:
-    explicit char_string_holder(char* cstr) : m_cstr(cstr, std::free) {}
+    explicit char_string_holder(char* cstr) : cstr_(cstr, std::free) {}
     // Implicit conversion from char* to allow direct return of
     // the result of TClassEdit::DemangleTypeIdName.
-    operator char const*() const { return m_cstr.get(); } // NOLINT(google-explicit-constructor)
+    operator char const*() const { return cstr_.get(); } // NOLINT(google-explicit-constructor)
   private:
-    std::unique_ptr<char, decltype(&std::free)> m_cstr;
+    std::unique_ptr<char, decltype(&std::free)> cstr_;
   };
 }
 
 namespace form::detail::experimental {
   // Return the demangled type name
-  std::string DemangleName(std::type_info const& type)
+  std::string demangle_name(std::type_info const& type)
   {
-    int errorCode{};
+    int error_code{};
     // The TClassEdit version works on both linux and Windows.
-    auto const demangledName = char_string_holder{TClassEdit::DemangleTypeIdName(type, errorCode)};
-    if (errorCode != 0) {
+    auto const demangled_name =
+      char_string_holder{TClassEdit::DemangleTypeIdName(type, error_code)};
+    if (error_code != 0) {
       // NOTE: Instead of throwing, we could return the mangled name as a fallback.
       throw std::runtime_error("Failed to demangle type name");
     }
-    std::string result(demangledName);
+    std::string result(demangled_name);
     return result;
   }
 }

--- a/form/root_storage/demangle_name.hpp
+++ b/form/root_storage/demangle_name.hpp
@@ -3,5 +3,5 @@
 
 namespace form::detail::experimental {
   // Return the demangled type name
-  std::string DemangleName(std::type_info const& type);
+  std::string demangle_name(std::type_info const& type);
 }

--- a/form/root_storage/root_rfield_read_container.cpp
+++ b/form/root_storage/root_rfield_read_container.cpp
@@ -1,4 +1,4 @@
-//A ROOT_RField_Read_Container reads data products of a single type from vectors stored in an RNTuple field on disk.
+//A root_rfield_read_container reads data products of a single type from vectors stored in an RNTuple field on disk.
 
 #include "root_rfield_read_container.hpp"
 #include "demangle_name.hpp"
@@ -21,77 +21,77 @@ namespace {
 }
 
 namespace form::detail::experimental {
-  ROOT_RField_Read_ContainerImp::ROOT_RField_Read_ContainerImp(std::string const& name) :
-    Storage_Read_Container(name)
+  root_rfield_read_container_imp::root_rfield_read_container_imp(std::string const& name) :
+    storage_read_container(name)
   {
   }
 
-  ROOT_RField_Read_ContainerImp::~ROOT_RField_Read_ContainerImp() {}
+  root_rfield_read_container_imp::~root_rfield_read_container_imp() {}
 
-  void ROOT_RField_Read_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
+  void root_rfield_read_container_imp::set_file(std::shared_ptr<i_storage_file> file)
   {
-    Storage_Read_Container::setFile(file);
+    storage_read_container::set_file(file);
 
-    auto form_root_file = dynamic_cast<ROOT_TFileImp*>(file.get());
+    auto form_root_file = dynamic_cast<root_tfile_imp*>(file.get());
     if (form_root_file) {
-      m_tfile = form_root_file->getTFile();
+      tfile_ = form_root_file->get_tfile();
     } else {
-      throw std::runtime_error("ROOT_RField_Read_ContainerImp::setFile failed to convert an "
-                               "IStorage_File to a ROOT_TFileImp.  "
-                               "ROOT_RField_Read_ContainerImp only works with TFiles.");
+      throw std::runtime_error("root_rfield_read_container_imp::set_file failed to convert an "
+                               "i_storage_file to a root_tfile_imp.  "
+                               "root_rfield_read_container_imp only works with TFiles.");
     }
 
-    if (!m_tfile) {
+    if (!tfile_) {
       throw std::runtime_error(
-        "ROOT_RField_Read_ContainerImp::setFile failed to get a TFile from a ROOT_TFileImp");
+        "root_rfield_read_container_imp::set_file failed to get a TFile from a root_tfile_imp");
     }
 
     return;
   }
 
-  void ROOT_RField_Read_ContainerImp::prime(std::type_info const& type)
+  void root_rfield_read_container_imp::prime(std::type_info const& type)
   {
     std::lock_guard<std::mutex> guard(root_rfield_read_mutex());
 
-    if (!m_tfile) {
-      throw std::runtime_error("ROOT_RField_Read_ContainerImp::prime No file loaded");
+    if (!tfile_) {
+      throw std::runtime_error("root_rfield_read_container_imp::prime No file loaded");
     }
 
-    if (!m_reader) {
-      m_reader = ROOT::RNTupleReader::Open(top_name(), m_tfile->GetName());
+    if (!reader_) {
+      reader_ = ROOT::RNTupleReader::Open(top_name(), tfile_->GetName());
     }
 
-    if (!m_view) {
-      createView(type);
+    if (!view_) {
+      create_view(type);
     }
 
     if (!TDictionary::GetDictionary(type)) {
-      throw std::runtime_error("ROOT_RField_Read_ContainerImp::prime unsupported type");
+      throw std::runtime_error("root_rfield_read_container_imp::prime unsupported type");
     }
   }
 
-  bool ROOT_RField_Read_ContainerImp::read(int id, void const** data, std::type_info const& type)
+  bool root_rfield_read_container_imp::read(int id, void const** data, std::type_info const& type)
   {
     std::lock_guard<std::mutex> guard(root_rfield_read_mutex());
 
     //Connect to file at the last possible moment at the cost of a little run-time branching
-    if (!m_view) {
-      createView(type);
+    if (!view_) {
+      create_view(type);
     }
 
-    if (id >= static_cast<int>(m_reader->GetNEntries())) {
+    if (id >= static_cast<int>(reader_->GetNEntries())) {
       return false;
     }
 
     //Using RNTupleView<> to read instead of reusing REntry gives us full schema evolution support: the ROOT feature that lets us read files with an old class version into a new class version's memory.
-    auto buffer = m_view->GetField().CreateObject<void>(); //PHLEX gets ownership of this memory
+    auto buffer = view_->GetField().CreateObject<void>(); //PHLEX gets ownership of this memory
     assert(buffer);
 
-    m_view->BindRawPtr(buffer.get());
+    view_->BindRawPtr(buffer.get());
     try {
-      (*m_view)(id);
+      (*view_)(id);
     } catch (ROOT::RException const& e) {
-      throw std::runtime_error("ROOT_RField_Read_ContainerImp::read got a ROOT exception: " +
+      throw std::runtime_error("root_rfield_read_container_imp::read got a ROOT exception: " +
                                std::string(e.what()));
     }
     *data =
@@ -101,53 +101,53 @@ namespace form::detail::experimental {
     return true;
   }
 
-  int ROOT_RField_Read_ContainerImp::entries()
+  int root_rfield_read_container_imp::entries()
   {
     std::lock_guard<std::mutex> guard(root_rfield_read_mutex());
 
-    if (!m_reader) {
-      if (!m_tfile) {
-        throw std::runtime_error("ROOT_RField_Read_ContainerImp::entries No file loaded");
+    if (!reader_) {
+      if (!tfile_) {
+        throw std::runtime_error("root_rfield_read_container_imp::entries No file loaded");
       }
-      m_reader = ROOT::RNTupleReader::Open(top_name(), m_tfile->GetName());
+      reader_ = ROOT::RNTupleReader::Open(top_name(), tfile_->GetName());
     }
 
-    if (!m_view &&
-        (m_reader->GetDescriptor().FindFieldId(col_name()) == ROOT::kInvalidDescriptorId)) {
-      throw std::runtime_error("ROOT_RField_Read_ContainerImp::entries field " + col_name() +
+    if (!view_ &&
+        (reader_->GetDescriptor().FindFieldId(col_name()) == ROOT::kInvalidDescriptorId)) {
+      throw std::runtime_error("root_rfield_read_container_imp::entries field " + col_name() +
                                " does not exist");
     }
 
-    return static_cast<int>(m_reader->GetNEntries());
+    return static_cast<int>(reader_->GetNEntries());
   }
 
-  void ROOT_RField_Read_ContainerImp::createView(std::type_info const& type)
+  void root_rfield_read_container_imp::create_view(std::type_info const& type)
   {
-    if (!m_reader) { //First time this RNTuple is read this job
-      if (!m_tfile) {
-        throw std::runtime_error("ROOT_RField_Read_ContainerImp::createView No file loaded to read "
-                                 "from on first read() call!");
+    if (!reader_) { //First time this RNTuple is read this job
+      if (!tfile_) {
+        throw std::runtime_error(
+          "root_rfield_read_container_imp::create_view No file loaded to read "
+          "from on first read() call!");
       }
 
-      m_reader = ROOT::RNTupleReader::Open(top_name(), m_tfile->GetName());
+      reader_ = ROOT::RNTupleReader::Open(top_name(), tfile_->GetName());
     }
 
     try {
-      m_view =
-        std::make_unique<ROOT::RNTupleView<void>>(m_reader->GetView(col_name(), nullptr, type));
+      view_ =
+        std::make_unique<ROOT::RNTupleView<void>>(reader_->GetView(col_name(), nullptr, type));
     } catch (ROOT::RException const& e) {
       //RNTupleView<void> will fail to create a field for fields written in streamer mode or for which type does not match the field's type on disk.  Passing an empty string for type forces it to create the same type of field as the object on disk.  Do this to handle streamer fields, then perform our own type check.
-      m_view =
-        std::make_unique<ROOT::RNTupleView<void>>(m_reader->GetView(col_name(), nullptr, ""));
+      view_ = std::make_unique<ROOT::RNTupleView<void>>(reader_->GetView(col_name(), nullptr, ""));
       //TClass takes the "std::" off of "std::vector<>" when RNTuple's on-disk format doesn't.  Convert RNTuple's type name to match TClass for manual type check because our dictionary of choice will likely be the same as TClass.
       if (!TDictionary::GetDictionary(type) ||
-          !TDictionary::GetDictionary(m_view->GetField().GetTypeName().c_str()) ||
-          (strcmp(TDictionary::GetDictionary(m_view->GetField().GetTypeName().c_str())->GetName(),
+          !TDictionary::GetDictionary(view_->GetField().GetTypeName().c_str()) ||
+          (strcmp(TDictionary::GetDictionary(view_->GetField().GetTypeName().c_str())->GetName(),
                   TDictionary::GetDictionary(type)->GetName()) != 0)) {
         throw std::runtime_error(
-          "ROOT_RField_Read_ContainerImp::createView type " + DemangleName(type) +
+          "root_rfield_read_container_imp::create_view type " + demangle_name(type) +
           " requested for a field named " + col_name() +
-          " does not match the type in the file: " + m_view->GetField().GetTypeName());
+          " does not match the type in the file: " + view_->GetField().GetTypeName());
       }
     }
   }

--- a/form/root_storage/root_rfield_read_container.hpp
+++ b/form/root_storage/root_rfield_read_container.hpp
@@ -1,4 +1,4 @@
-//A ROOT_RField_Read_Container is a Storage_Read_Container that uses a shared RNTuple to read data products from disk.  A single Storage_Read_Container encapsulates the location where a collection of data products of a single type is stored.
+//A root_rfield_read_container is a storage_read_container that uses a shared RNTuple to read data products from disk.  A single storage_read_container encapsulates the location where a collection of data products of a single type is stored.
 
 #ifndef FORM_ROOT_STORAGE_ROOT_RFIELD_READ_CONTAINER_HPP
 #define FORM_ROOT_STORAGE_ROOT_RFIELD_READ_CONTAINER_HPP
@@ -12,36 +12,36 @@ class TFile;
 
 namespace ROOT {
   class RNTupleReader;
-  template <class FIELD_TYPE>
+  template <class FieldType>
   class RNTupleView;
   template <>
   class RNTupleView<void>;
 }
 
 namespace form::detail::experimental {
-  class ROOT_RField_Read_ContainerImp : public Storage_Read_Container {
+  class root_rfield_read_container_imp : public storage_read_container {
   public:
-    ROOT_RField_Read_ContainerImp(std::string const& name);
-    ~ROOT_RField_Read_ContainerImp()
+    root_rfield_read_container_imp(std::string const& name);
+    ~root_rfield_read_container_imp()
       override; //Must not be defined in header because that requires definition of RNTupleReader, etc.
 
     //Rule of five
-    ROOT_RField_Read_ContainerImp(ROOT_RField_Read_ContainerImp const& other) = delete;
-    ROOT_RField_Read_ContainerImp(ROOT_RField_Read_ContainerImp&& other) = delete;
-    ROOT_RField_Read_ContainerImp& operator=(ROOT_RField_Read_ContainerImp const& other) = delete;
-    ROOT_RField_Read_ContainerImp& operator=(ROOT_RField_Read_ContainerImp&& other) = delete;
+    root_rfield_read_container_imp(root_rfield_read_container_imp const& other) = delete;
+    root_rfield_read_container_imp(root_rfield_read_container_imp&& other) = delete;
+    root_rfield_read_container_imp& operator=(root_rfield_read_container_imp const& other) = delete;
+    root_rfield_read_container_imp& operator=(root_rfield_read_container_imp&& other) = delete;
 
-    void setFile(std::shared_ptr<IStorage_File> file) override;
+    void set_file(std::shared_ptr<i_storage_file> file) override;
     void prime(std::type_info const& type) override;
     bool read(int id, void const** data, std::type_info const& type) override;
     int entries() override;
 
   private:
-    std::shared_ptr<TFile> m_tfile;
-    std::unique_ptr<ROOT::RNTupleReader> m_reader;
-    std::unique_ptr<ROOT::RNTupleView<void>> m_view;
+    std::shared_ptr<TFile> tfile_;
+    std::unique_ptr<ROOT::RNTupleReader> reader_;
+    std::unique_ptr<ROOT::RNTupleView<void>> view_;
 
-    void createView(std::type_info const& type);
+    void create_view(std::type_info const& type);
   };
 }
 

--- a/form/root_storage/root_rfield_write_container.cpp
+++ b/form/root_storage/root_rfield_write_container.cpp
@@ -12,110 +12,111 @@
 #include <iostream>
 
 namespace form::detail::experimental {
-  ROOT_RField_Write_ContainerImp::ROOT_RField_Write_ContainerImp(std::string const& name) :
-    Storage_Associative_Write_Container(name)
+  root_rfield_write_container_imp::root_rfield_write_container_imp(std::string const& name) :
+    storage_associative_write_container(name)
   {
   }
 
-  void ROOT_RField_Write_ContainerImp::setAttribute(std::string const& key,
-                                                    std::string const& value)
+  void root_rfield_write_container_imp::set_attribute(std::string const& key,
+                                                      std::string const& value)
   {
     if (key == "force_streamer_field" && value == "true") {
-      m_force_streamer_field = true;
+      force_streamer_field_ = true;
     } else {
-      throw std::runtime_error("ROOT_RField_Write_ContainerImp supports some attributes, but not " +
-                               key);
+      throw std::runtime_error(
+        "root_rfield_write_container_imp supports some attributes, but not " + key);
     }
   }
 
-  void ROOT_RField_Write_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
+  void root_rfield_write_container_imp::set_file(std::shared_ptr<i_storage_file> file)
   {
-    Storage_Write_Container::setFile(file);
+    storage_write_container::set_file(file);
 
-    auto form_root_file = dynamic_pointer_cast<ROOT_TFileImp>(file);
+    auto form_root_file = dynamic_pointer_cast<root_tfile_imp>(file);
     if (form_root_file) {
-      m_tfile = form_root_file->getTFile();
+      tfile_ = form_root_file->get_tfile();
     } else {
-      throw std::runtime_error("ROOT_RField_Write_ContainerImp::setFile failed to convert an "
-                               "IStorage_File to a ROOT_TFileImp.  "
-                               "ROOT_RField_Write_ContainerImp only works with TFiles.");
+      throw std::runtime_error("root_rfield_write_container_imp::set_file failed to convert an "
+                               "i_storage_file to a root_tfile_imp.  "
+                               "root_rfield_write_container_imp only works with TFiles.");
     }
 
-    if (!m_tfile) {
+    if (!tfile_) {
       throw std::runtime_error(
-        "ROOT_RField_Write_ContainerImp::setFile failed to get a TFile from a ROOT_TFileImp");
+        "root_rfield_write_container_imp::set_file failed to get a TFile from a root_tfile_imp");
     }
 
     return;
   }
 
-  void ROOT_RField_Write_ContainerImp::setParent(std::shared_ptr<IStorage_Write_Container> parent)
+  void root_rfield_write_container_imp::set_parent(
+    std::shared_ptr<i_storage_write_container> parent)
   {
-    this->Storage_Associative_Write_Container::setParent(parent);
-    auto parentDerived = dynamic_pointer_cast<ROOT_RNTuple_Write_ContainerImp>(parent);
-    if (!parentDerived) {
-      throw std::runtime_error("ROOT_RField_Write_ContainerImp::setParent parent is not a "
-                               "ROOT_RNTuple_Write_ContainerImp!  Something "
+    this->storage_associative_write_container::set_parent(parent);
+    auto parent_derived = dynamic_pointer_cast<root_rntuple_write_container_imp>(parent);
+    if (!parent_derived) {
+      throw std::runtime_error("root_rfield_write_container_imp::set_parent parent is not a "
+                               "root_rntuple_write_container_imp!  Something "
                                "may be wrong with how Storage works.");
     }
-    m_rntuple_parent = parentDerived;
+    rntuple_parent_ = parent_derived;
   }
 
-  std::uint64_t ROOT_RField_Write_ContainerImp::fill(void const* data)
+  std::uint64_t root_rfield_write_container_imp::fill(void const* data)
   {
-    if (!m_rntuple_parent) {
+    if (!rntuple_parent_) {
       throw std::runtime_error(
-        "ROOT_RField_Write_ContainerImp::fill No parent RNTuple set up before first fill() call");
+        "root_rfield_write_container_imp::fill No parent RNTuple set up before first fill() call");
     }
 
-    if (!m_rntuple_parent->m_writer) {
-      if (!m_tfile) {
+    if (!rntuple_parent_->writer_) {
+      if (!tfile_) {
         throw std::runtime_error(
-          "ROOT_RField_Write_ContainerImp::fill No file loaded to write to on first fill() call");
+          "root_rfield_write_container_imp::fill No file loaded to write to on first fill() call");
       }
 
-      m_rntuple_parent->m_writer =
-        ROOT::RNTupleWriter::Append(std::move(m_rntuple_parent->m_model), top_name(), *m_tfile);
-      m_rntuple_parent->m_entry = m_rntuple_parent->m_writer->CreateRawPtrWriteEntry();
+      rntuple_parent_->writer_ =
+        ROOT::RNTupleWriter::Append(std::move(rntuple_parent_->model_), top_name(), *tfile_);
+      rntuple_parent_->entry_ = rntuple_parent_->writer_->CreateRawPtrWriteEntry();
     }
-    m_rntuple_parent->m_entry->BindRawPtr(col_name(), data);
+    rntuple_parent_->entry_->BindRawPtr(col_name(), data);
 
     // Unlike a TBranch, an RNTuple entry is only written on commit();
     // every field bound before that commit shares one entry.
     // Return the 0-based index that pending entry will occupy (the current entry count).
-    return static_cast<std::uint64_t>(m_rntuple_parent->m_writer->GetNEntries());
+    return static_cast<std::uint64_t>(rntuple_parent_->writer_->GetNEntries());
   }
 
-  void ROOT_RField_Write_ContainerImp::commit()
+  void root_rfield_write_container_imp::commit()
   {
-    if (!m_rntuple_parent) {
-      throw std::runtime_error("ROOT_RField_Write_ContainerImp::commit No parent RNTuple set up.  "
-                               "You may have called commit() without calling setParent() first.");
+    if (!rntuple_parent_) {
+      throw std::runtime_error("root_rfield_write_container_imp::commit No parent RNTuple set up.  "
+                               "You may have called commit() without calling set_parent() first.");
     }
 
-    if (!m_rntuple_parent->m_entry) {
+    if (!rntuple_parent_->entry_) {
       throw std::runtime_error(
-        "ROOT_RField_Write_ContainerImp::commit No RRawPtrWriteEntry set up.  "
+        "root_rfield_write_container_imp::commit No RRawPtrWriteEntry set up.  "
         "You may have called commit() without calling fill() first.");
     }
-    assert(m_rntuple_parent->m_writer); //m_write and m_entry are set in the same place: fill()
-    m_rntuple_parent->m_writer->Fill(*m_rntuple_parent->m_entry);
+    assert(rntuple_parent_->writer_); //writer_ and entry_ are set in the same place: fill()
+    rntuple_parent_->writer_->Fill(*rntuple_parent_->entry_);
   }
 
-  //setupWrite() may not be called after the first time fill() is called.
+  //setup_write() may not be called after the first time fill() is called.
   //If needed in the future, this can be changed by using RNTupleModels' updater facilities.
-  void ROOT_RField_Write_ContainerImp::setupWrite(std::type_info const& type)
+  void root_rfield_write_container_imp::setup_write(std::type_info const& type)
   {
-    if (!m_rntuple_parent) {
+    if (!rntuple_parent_) {
       throw std::runtime_error(
-        "ROOT_RField_Write_ContainerImp::setupWrite No parent RNTuple set up.  "
-        "You may have called setupWrite() before setParent().");
+        "root_rfield_write_container_imp::setup_write No parent RNTuple set up.  "
+        "You may have called setup_write() before set_parent().");
     }
 
-    auto const& type_name = DemangleName(type);
+    auto const& type_name = demangle_name(type);
     std::unique_ptr<ROOT::RFieldBase> field;
 
-    if (m_force_streamer_field) {
+    if (force_streamer_field_) {
       field = std::make_unique<ROOT::RStreamerField>(col_name(), type_name);
     } else {
       auto field_result = ROOT::RFieldBase::Create(col_name(), type_name);
@@ -123,7 +124,8 @@ namespace form::detail::experimental {
         field = field_result.Unwrap();
       } else {
         std::cerr
-          << "ROOT_RField_Write_ContainerImp::setupWrite could not create column-wise storage for "
+          << "root_rfield_write_container_imp::setup_write could not create column-wise storage "
+             "for "
           << type_name
           << ".  This class is probably using something obsolete like TLorentzVector.  Storing it "
              "in streamer mode to keep the application going."
@@ -132,7 +134,7 @@ namespace form::detail::experimental {
       }
     }
 
-    m_rntuple_parent->m_model->AddField(std::move(field));
+    rntuple_parent_->model_->AddField(std::move(field));
   }
 
 }

--- a/form/root_storage/root_rfield_write_container.cpp
+++ b/form/root_storage/root_rfield_write_container.cpp
@@ -1,4 +1,4 @@
-//A ROOT_RField_Write_Container writes data products of a single type from vectors stored in an RNTuple field on disk.
+//A root_rfield_write_container_imp writes data products of a single type from vectors stored in an RNTuple field on disk.
 
 #include "root_rfield_write_container.hpp"
 #include "demangle_name.hpp"

--- a/form/root_storage/root_rfield_write_container.hpp
+++ b/form/root_storage/root_rfield_write_container.hpp
@@ -1,4 +1,4 @@
-//A ROOT_RField_Write_Container is a Storage_Write_Container that uses a shared RNTuple to write data products to disk.  A single Storage_Write_Container encapsulates the location where a collection of data products of a single type is stored.
+//A root_rfield_write_container is a storage_write_container that uses a shared RNTuple to write data products to disk.  A single storage_write_container encapsulates the location where a collection of data products of a single type is stored.
 
 #ifndef FORM_ROOT_STORAGE_ROOT_RFIELD_WRITE_CONTAINER_HPP
 #define FORM_ROOT_STORAGE_ROOT_RFIELD_WRITE_CONTAINER_HPP
@@ -11,26 +11,26 @@
 class TFile;
 
 namespace form::detail::experimental {
-  class ROOT_RNTuple_Write_ContainerImp;
+  class root_rntuple_write_container_imp;
 
-  class ROOT_RField_Write_ContainerImp : public Storage_Associative_Write_Container {
+  class root_rfield_write_container_imp : public storage_associative_write_container {
   public:
-    ROOT_RField_Write_ContainerImp(std::string const& name);
-    ~ROOT_RField_Write_ContainerImp() override = default;
+    root_rfield_write_container_imp(std::string const& name);
+    ~root_rfield_write_container_imp() override = default;
 
-    void setAttribute(std::string const& key, std::string const& value) override;
+    void set_attribute(std::string const& key, std::string const& value) override;
 
-    void setFile(std::shared_ptr<IStorage_File> file) override;
-    void setupWrite(std::type_info const& type) override;
-    void setParent(std::shared_ptr<IStorage_Write_Container> const parent) override;
+    void set_file(std::shared_ptr<i_storage_file> file) override;
+    void setup_write(std::type_info const& type) override;
+    void set_parent(std::shared_ptr<i_storage_write_container> const parent) override;
     std::uint64_t fill(void const* data) override;
     void commit() override;
 
   private:
-    std::shared_ptr<TFile> m_tfile;
-    std::shared_ptr<ROOT_RNTuple_Write_ContainerImp> m_rntuple_parent;
+    std::shared_ptr<TFile> tfile_;
+    std::shared_ptr<root_rntuple_write_container_imp> rntuple_parent_;
 
-    bool m_force_streamer_field = false;
+    bool force_streamer_field_ = false;
   };
 }
 

--- a/form/root_storage/root_rntuple_write_container.cpp
+++ b/form/root_storage/root_rntuple_write_container.cpp
@@ -11,33 +11,33 @@
 #include <exception>
 
 namespace form::detail::experimental {
-  ROOT_RNTuple_Write_ContainerImp::ROOT_RNTuple_Write_ContainerImp(std::string const& name) :
-    Storage_Write_Association(name), m_model(ROOT::RNTupleModel::Create())
+  root_rntuple_write_container_imp::root_rntuple_write_container_imp(std::string const& name) :
+    storage_write_association(name), model_(ROOT::RNTupleModel::Create())
   {
   }
 
-  ROOT_RNTuple_Write_ContainerImp::~ROOT_RNTuple_Write_ContainerImp()
+  root_rntuple_write_container_imp::~root_rntuple_write_container_imp()
   {
-    if (m_writer) {
-      m_writer->CommitDataset();
+    if (writer_) {
+      writer_->CommitDataset();
     }
   }
 
-  void ROOT_RNTuple_Write_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
+  void root_rntuple_write_container_imp::set_file(std::shared_ptr<i_storage_file> file)
   {
-    Storage_Write_Container::setFile(file);
+    storage_write_container::set_file(file);
     return;
   }
 
-  std::uint64_t ROOT_RNTuple_Write_ContainerImp::fill(void const* /*data*/)
+  std::uint64_t root_rntuple_write_container_imp::fill(void const* /*data*/)
   {
-    throw std::runtime_error("ROOT_RNTuple_Write_ContainerImp::fill not implemented");
+    throw std::runtime_error("root_rntuple_write_container_imp::fill not implemented");
   }
 
-  void ROOT_RNTuple_Write_ContainerImp::commit()
+  void root_rntuple_write_container_imp::commit()
   {
-    throw std::runtime_error("ROOT_RNTuple_Write_ContainerImp::commit not implemented");
+    throw std::runtime_error("root_rntuple_write_container_imp::commit not implemented");
   }
 
-  void ROOT_RNTuple_Write_ContainerImp::setupWrite(std::type_info const& /*type*/) { return; }
+  void root_rntuple_write_container_imp::setup_write(std::type_info const& /*type*/) { return; }
 }

--- a/form/root_storage/root_rntuple_write_container.cpp
+++ b/form/root_storage/root_rntuple_write_container.cpp
@@ -1,4 +1,4 @@
-//A ROOT_RNTuple_Write_Container reads data products of a single type from vectors stored in an RNTuple field on disk.
+//A root_rntuple_write_container_imp is a storage_write_association that coordinates the RNTuple-specific, file-based resources (writer, model, entry) shared by several root_rfield_write_container_imps; it does not itself write a data product (see root_rfield_write_container_imp for the per-field write path).
 
 #include "root_rntuple_write_container.hpp"
 #include "root_tfile.hpp"

--- a/form/root_storage/root_rntuple_write_container.hpp
+++ b/form/root_storage/root_rntuple_write_container.hpp
@@ -1,4 +1,4 @@
-//A root_rntuple_container_imp is a storage_write_association (and therefore a storage_container) that coordinates the file accesses shared by several root_rfield_container_imps.  It only coordinates RNTuple-specific file-based resources and doesn't actually implement write() or read() for example.  This matches the early design of the TTree associative container.
+//A root_rntuple_write_container_imp is a storage_write_association (and therefore a storage_container) that coordinates the file accesses shared by several root_rfield_write_container_imps.  It only coordinates RNTuple-specific file-based resources and doesn't actually implement write() or read() for example.  This matches the early design of the TTree associative container.
 
 #ifndef FORM_ROOT_STORAGE_ROOT_RNTUPLE_WRITE_CONTAINER_HPP
 #define FORM_ROOT_STORAGE_ROOT_RNTUPLE_WRITE_CONTAINER_HPP
@@ -55,7 +55,7 @@ namespace form::detail::experimental {
     std::uint64_t fill(void const* data) override;
     void commit() override;
 
-    //State shared by root_rfield_container_imps
+    //State shared by root_rfield_write_container_imps
     std::unique_ptr<ROOT::RNTupleWriter> writer_;
     std::unique_ptr<ROOT::RNTupleModel> model_;
     std::unique_ptr<RRawPtrWriteEntry> entry_;

--- a/form/root_storage/root_rntuple_write_container.hpp
+++ b/form/root_storage/root_rntuple_write_container.hpp
@@ -1,4 +1,4 @@
-//A ROOT_RNTuple_ContainerImp is a Storage_Write_Association (and therefore a Storage_Container) that coordinates the file accesses shared by several ROOT_RField_ContainerImps.  It only coordinates RNTuple-specific file-based resources and doesn't actually implement write() or read() for example.  This matches the early design of the TTree associative container.
+//A root_rntuple_container_imp is a storage_write_association (and therefore a storage_container) that coordinates the file accesses shared by several root_rfield_container_imps.  It only coordinates RNTuple-specific file-based resources and doesn't actually implement write() or read() for example.  This matches the early design of the TTree associative container.
 
 #ifndef FORM_ROOT_STORAGE_ROOT_RNTUPLE_WRITE_CONTAINER_HPP
 #define FORM_ROOT_STORAGE_ROOT_RNTUPLE_WRITE_CONTAINER_HPP
@@ -38,27 +38,27 @@ namespace form::detail::experimental {
   using RRawPtrWriteEntry = ROOT::Experimental::Detail::RRawPtrWriteEntry;
 #endif
 
-  class ROOT_RNTuple_Write_ContainerImp : public Storage_Write_Association {
+  class root_rntuple_write_container_imp : public storage_write_association {
   public:
-    ROOT_RNTuple_Write_ContainerImp(std::string const& name);
-    ~ROOT_RNTuple_Write_ContainerImp() override;
+    root_rntuple_write_container_imp(std::string const& name);
+    ~root_rntuple_write_container_imp() override;
 
     //Rule of five
-    ROOT_RNTuple_Write_ContainerImp(ROOT_RNTuple_Write_ContainerImp const& other) = delete;
-    ROOT_RNTuple_Write_ContainerImp(ROOT_RNTuple_Write_ContainerImp&& other) = delete;
-    ROOT_RNTuple_Write_ContainerImp& operator=(ROOT_RNTuple_Write_ContainerImp const& other) =
+    root_rntuple_write_container_imp(root_rntuple_write_container_imp const& other) = delete;
+    root_rntuple_write_container_imp(root_rntuple_write_container_imp&& other) = delete;
+    root_rntuple_write_container_imp& operator=(root_rntuple_write_container_imp const& other) =
       delete;
-    ROOT_RNTuple_Write_ContainerImp& operator=(ROOT_RNTuple_Write_ContainerImp&& other) = delete;
+    root_rntuple_write_container_imp& operator=(root_rntuple_write_container_imp&& other) = delete;
 
-    void setFile(std::shared_ptr<IStorage_File> file) override;
-    void setupWrite(std::type_info const& type) override;
+    void set_file(std::shared_ptr<i_storage_file> file) override;
+    void setup_write(std::type_info const& type) override;
     std::uint64_t fill(void const* data) override;
     void commit() override;
 
-    //State shared by ROOT_RField_ContainerImps
-    std::unique_ptr<ROOT::RNTupleWriter> m_writer;
-    std::unique_ptr<ROOT::RNTupleModel> m_model;
-    std::unique_ptr<RRawPtrWriteEntry> m_entry;
+    //State shared by root_rfield_container_imps
+    std::unique_ptr<ROOT::RNTupleWriter> writer_;
+    std::unique_ptr<ROOT::RNTupleModel> model_;
+    std::unique_ptr<RRawPtrWriteEntry> entry_;
   };
 }
 

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -106,8 +106,9 @@ bool root_tbranch_read_container_imp::read(int id, void const** data, std::type_
   int branch_status = 0;
 
   if (!dict_info) {
-    throw std::runtime_error(std::string{"ROOT_TBranch_ContainerImp::read unsupported type: "} +
-                             demangle_name(type));
+    throw std::runtime_error(
+      std::string{"root_tbranch_read_container_imp::read unsupported type: "} +
+      demangle_name(type));
   }
 
   if (dict_info->Property() & EProperty::kIsFundamental) {
@@ -155,7 +156,7 @@ bool root_tbranch_read_container_imp::read(int id, void const** data, std::type_
       break;
     default:
       throw std::runtime_error(
-        std::string{"ROOT_TBranch_ContainerImp::read unsupported fundamental type: "} +
+        std::string{"root_tbranch_read_container_imp::read unsupported fundamental type: "} +
         demangle_name(type));
     };
     branch_status = tree_->SetBranchAddress(
@@ -163,7 +164,7 @@ bool root_tbranch_read_container_imp::read(int id, void const** data, std::type_
   } else {
     auto* klass = TClass::GetClass(type);
     if (!klass) {
-      throw std::runtime_error(std::string{"ROOT_TBranch_ContainerImp::read missing TClass"} +
+      throw std::runtime_error(std::string{"root_tbranch_read_container_imp::read missing TClass"} +
                                " (col_name='" + col_name() + "', type='" + demangle_name(type) +
                                "')");
     }
@@ -179,8 +180,8 @@ bool root_tbranch_read_container_imp::read(int id, void const** data, std::type_
 
   if (branch_status < 0) {
     throw std::runtime_error(
-      std::string{"ROOT_TBranch_ContainerImp::read SetBranchAddress() failed"} + " (col_name='" +
-      col_name() + "', type='" + demangle_name(type) + "')" + " with error code " +
+      std::string{"root_tbranch_read_container_imp::read SetBranchAddress() failed"} +
+      " (col_name='" + col_name() + "', type='" + demangle_name(type) + "')" + " with error code " +
       std::to_string(branch_status));
   }
 

--- a/form/root_storage/root_tbranch_read_container.cpp
+++ b/form/root_storage/root_tbranch_read_container.cpp
@@ -24,191 +24,195 @@ namespace {
   }
 }
 
-ROOT_TBranch_Read_ContainerImp::ROOT_TBranch_Read_ContainerImp(std::string const& name) :
-  Storage_Read_Container(name)
+root_tbranch_read_container_imp::root_tbranch_read_container_imp(std::string const& name) :
+  storage_read_container(name)
 {
 }
 
-void ROOT_TBranch_Read_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
+void root_tbranch_read_container_imp::set_file(std::shared_ptr<i_storage_file> file)
 {
-  auto* root_tfile_imp = dynamic_cast<ROOT_TFileImp*>(file.get());
-  if (root_tfile_imp == nullptr) {
+  auto* root_file = dynamic_cast<root_tfile_imp*>(file.get());
+  if (root_file == nullptr) {
     throw std::runtime_error(
-      "ROOT_TBranch_Read_ContainerImp::setFile can't attach to non-ROOT file");
+      "root_tbranch_read_container_imp::set_file can't attach to non-ROOT file");
   }
-  m_tfile = root_tfile_imp->getTFile();
+  tfile_ = root_file->get_tfile();
 }
 
-void ROOT_TBranch_Read_ContainerImp::prime(std::type_info const& type)
+void root_tbranch_read_container_imp::prime(std::type_info const& type)
 {
   std::scoped_lock guard(root_tbranch_read_mutex());
 
-  if (m_tfile == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::prime no file attached");
+  if (tfile_ == nullptr) {
+    throw std::runtime_error("root_tbranch_read_container_imp::prime no file attached");
   }
-  if (m_tree == nullptr) {
-    m_tree = m_tfile->Get<TTree>(top_name().c_str());
+  if (tree_ == nullptr) {
+    tree_ = tfile_->Get<TTree>(top_name().c_str());
   }
-  if (m_tree == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::prime no tree found with name " +
+  if (tree_ == nullptr) {
+    throw std::runtime_error("root_tbranch_read_container_imp::prime no tree found with name " +
                              top_name());
   }
-  if (m_branch == nullptr) {
-    m_branch = m_tree->GetBranch(col_name().c_str());
+  if (branch_ == nullptr) {
+    branch_ = tree_->GetBranch(col_name().c_str());
   }
-  if (m_branch == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::prime no branch found");
+  if (branch_ == nullptr) {
+    throw std::runtime_error("root_tbranch_read_container_imp::prime no branch found");
   }
 
-  auto* dictInfo = TDictionary::GetDictionary(type);
-  if (!dictInfo) {
+  auto* dict_info = TDictionary::GetDictionary(type);
+  if (!dict_info) {
     throw std::runtime_error(
-      std::string{"ROOT_TBranch_Read_ContainerImp::prime unsupported type: "} + DemangleName(type));
+      std::string{"root_tbranch_read_container_imp::prime unsupported type: "} +
+      demangle_name(type));
   }
 
-  if (!(dictInfo->Property() & EProperty::kIsFundamental)) {
+  if (!(dict_info->Property() & EProperty::kIsFundamental)) {
     auto* klass = TClass::GetClass(type);
     if (!klass) {
       throw std::runtime_error(
-        std::string{"ROOT_TBranch_Read_ContainerImp::prime missing TClass for type: "} +
-        DemangleName(type));
+        std::string{"root_tbranch_read_container_imp::prime missing TClass for type: "} +
+        demangle_name(type));
     }
   }
 }
 
-bool ROOT_TBranch_Read_ContainerImp::read(int id, void const** data, std::type_info const& type)
+bool root_tbranch_read_container_imp::read(int id, void const** data, std::type_info const& type)
 {
   std::scoped_lock guard(root_tbranch_read_mutex());
 
-  if (m_tfile == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::read no file attached");
+  if (tfile_ == nullptr) {
+    throw std::runtime_error("root_tbranch_read_container_imp::read no file attached");
   }
-  if (m_tree == nullptr) {
-    m_tree = m_tfile->Get<TTree>(top_name().c_str());
+  if (tree_ == nullptr) {
+    tree_ = tfile_->Get<TTree>(top_name().c_str());
   }
-  if (m_tree == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::read no tree found with name " +
+  if (tree_ == nullptr) {
+    throw std::runtime_error("root_tbranch_read_container_imp::read no tree found with name " +
                              top_name());
   }
-  if (m_branch == nullptr) {
-    m_branch = m_tree->GetBranch(col_name().c_str());
+  if (branch_ == nullptr) {
+    branch_ = tree_->GetBranch(col_name().c_str());
   }
-  if (m_branch == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::read no branch found");
+  if (branch_ == nullptr) {
+    throw std::runtime_error("root_tbranch_read_container_imp::read no branch found");
   }
-  if (id >= m_tree->GetEntries()) {
+  if (id >= tree_->GetEntries()) {
     return false;
   }
 
-  gsl::owner<void*> branchBuffer = nullptr;
-  auto* dictInfo = TDictionary::GetDictionary(type);
-  int branchStatus = 0;
+  gsl::owner<void*> branch_buffer = nullptr;
+  auto* dict_info = TDictionary::GetDictionary(type);
+  int branch_status = 0;
 
-  if (!dictInfo) {
+  if (!dict_info) {
     throw std::runtime_error(std::string{"ROOT_TBranch_ContainerImp::read unsupported type: "} +
-                             DemangleName(type));
+                             demangle_name(type));
   }
 
-  if (dictInfo->Property() & EProperty::kIsFundamental) {
+  if (dict_info->Property() & EProperty::kIsFundamental) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-    auto* fundInfo = static_cast<TDataType*>(dictInfo); // Already checked to be fundamental
-    switch (fundInfo->GetType()) {
+    auto* fund_info = static_cast<TDataType*>(dict_info); // Already checked to be fundamental
+    switch (fund_info->GetType()) {
     case kChar_t:
-      branchBuffer = new Char_t;
+      branch_buffer = new Char_t;
       break;
     case kUChar_t:
-      branchBuffer = new UChar_t;
+      branch_buffer = new UChar_t;
       break;
     case kShort_t:
-      branchBuffer = new Short_t;
+      branch_buffer = new Short_t;
       break;
     case kUShort_t:
-      branchBuffer = new UShort_t;
+      branch_buffer = new UShort_t;
       break;
     case kInt_t:
-      branchBuffer = new Int_t;
+      branch_buffer = new Int_t;
       break;
     case kUInt_t:
-      branchBuffer = new UInt_t;
+      branch_buffer = new UInt_t;
       break;
     case kLong_t:
-      branchBuffer = new Long_t;
+      branch_buffer = new Long_t;
       break;
     case kULong_t:
-      branchBuffer = new ULong_t;
+      branch_buffer = new ULong_t;
       break;
     case kLong64_t:
-      branchBuffer = new Long64_t;
+      branch_buffer = new Long64_t;
       break;
     case kULong64_t:
-      branchBuffer = new ULong64_t;
+      branch_buffer = new ULong64_t;
       break;
     case kFloat_t:
-      branchBuffer = new Float_t;
+      branch_buffer = new Float_t;
       break;
     case kDouble_t:
-      branchBuffer = new Double_t;
+      branch_buffer = new Double_t;
       break;
     case kBool_t:
-      branchBuffer = new Bool_t;
+      branch_buffer = new Bool_t;
       break;
     default:
       throw std::runtime_error(
         std::string{"ROOT_TBranch_ContainerImp::read unsupported fundamental type: "} +
-        DemangleName(type));
+        demangle_name(type));
     };
-    branchStatus = m_tree->SetBranchAddress(
-      col_name().c_str(), branchBuffer, nullptr, EDataType(fundInfo->GetType()), false);
+    branch_status = tree_->SetBranchAddress(
+      col_name().c_str(), branch_buffer, nullptr, EDataType(fund_info->GetType()), false);
   } else {
     auto* klass = TClass::GetClass(type);
     if (!klass) {
       throw std::runtime_error(std::string{"ROOT_TBranch_ContainerImp::read missing TClass"} +
-                               " (col_name='" + col_name() + "', type='" + DemangleName(type) +
+                               " (col_name='" + col_name() + "', type='" + demangle_name(type) +
                                "')");
     }
     // ROOT returns ownership of dynamically created branch payload objects here.
     // NOLINTNEXTLINE(readability-redundant-casting)
-    branchBuffer = gsl::owner<void*>{klass->New()};
-    branchStatus = m_tree->SetBranchAddress(
-      col_name().c_str(), reinterpret_cast<void*>(&branchBuffer), klass, EDataType::kOther_t, true);
+    branch_buffer = gsl::owner<void*>{klass->New()};
+    branch_status = tree_->SetBranchAddress(col_name().c_str(),
+                                            reinterpret_cast<void*>(&branch_buffer),
+                                            klass,
+                                            EDataType::kOther_t,
+                                            true);
   }
 
-  if (branchStatus < 0) {
+  if (branch_status < 0) {
     throw std::runtime_error(
       std::string{"ROOT_TBranch_ContainerImp::read SetBranchAddress() failed"} + " (col_name='" +
-      col_name() + "', type='" + DemangleName(type) + "')" + " with error code " +
-      std::to_string(branchStatus));
+      col_name() + "', type='" + demangle_name(type) + "')" + " with error code " +
+      std::to_string(branch_status));
   }
 
-  Long64_t tentry = m_tree->LoadTree(id);
-  m_branch->GetEntry(tentry);
-  *data = branchBuffer;
+  Long64_t tentry = tree_->LoadTree(id);
+  branch_->GetEntry(tentry);
+  *data = branch_buffer;
 
   // Reset the branch address to avoid unwanted ownership issues.
-  m_branch->ResetAddress();
+  branch_->ResetAddress();
 
   return true;
 }
 
-int ROOT_TBranch_Read_ContainerImp::entries()
+int root_tbranch_read_container_imp::entries()
 {
   std::scoped_lock guard(root_tbranch_read_mutex());
 
-  if (m_tfile == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::entries no file attached");
+  if (tfile_ == nullptr) {
+    throw std::runtime_error("root_tbranch_read_container_imp::entries no file attached");
   }
-  if (m_tree == nullptr) {
-    m_tree = m_tfile->Get<TTree>(top_name().c_str());
+  if (tree_ == nullptr) {
+    tree_ = tfile_->Get<TTree>(top_name().c_str());
   }
-  if (m_tree == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::entries no tree found with name " +
+  if (tree_ == nullptr) {
+    throw std::runtime_error("root_tbranch_read_container_imp::entries no tree found with name " +
                              top_name());
   }
-  if (m_branch == nullptr) {
-    m_branch = m_tree->GetBranch(col_name().c_str());
+  if (branch_ == nullptr) {
+    branch_ = tree_->GetBranch(col_name().c_str());
   }
-  if (m_branch == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Read_ContainerImp::entries no branch found");
+  if (branch_ == nullptr) {
+    throw std::runtime_error("root_tbranch_read_container_imp::entries no branch found");
   }
-  return static_cast<int>(m_tree->GetEntries());
+  return static_cast<int>(tree_->GetEntries());
 }

--- a/form/root_storage/root_tbranch_read_container.hpp
+++ b/form/root_storage/root_tbranch_read_container.hpp
@@ -14,21 +14,21 @@ class TBranch;
 
 namespace form::detail::experimental {
 
-  class ROOT_TBranch_Read_ContainerImp : public Storage_Read_Container {
+  class root_tbranch_read_container_imp : public storage_read_container {
   public:
-    explicit ROOT_TBranch_Read_ContainerImp(std::string const& name);
-    ~ROOT_TBranch_Read_ContainerImp() override = default;
+    explicit root_tbranch_read_container_imp(std::string const& name);
+    ~root_tbranch_read_container_imp() override = default;
 
-    void setFile(std::shared_ptr<IStorage_File> file) override;
+    void set_file(std::shared_ptr<i_storage_file> file) override;
     void prime(std::type_info const& type) override;
 
     bool read(int id, void const** data, std::type_info const& type) override;
     int entries() override;
 
   private:
-    std::shared_ptr<TFile> m_tfile;
-    TTree* m_tree{nullptr};
-    TBranch* m_branch{nullptr};
+    std::shared_ptr<TFile> tfile_;
+    TTree* tree_{nullptr};
+    TBranch* branch_{nullptr};
   };
 
 } // namespace form::detail::experimental

--- a/form/root_storage/root_tbranch_write_container.cpp
+++ b/form/root_storage/root_tbranch_write_container.cpp
@@ -25,7 +25,7 @@ void root_tbranch_write_container_imp::set_attribute(std::string const& key,
   if (key == "auto_flush") {
     tree_->SetAutoFlush(std::stol(value));
   } else {
-    throw std::runtime_error("root_ttree_write_container_imp accepts some attributes, but not " +
+    throw std::runtime_error("root_tbranch_write_container_imp accepts some attributes, but not " +
                              key);
   }
 }

--- a/form/root_storage/root_tbranch_write_container.cpp
+++ b/form/root_storage/root_tbranch_write_container.cpp
@@ -14,43 +14,44 @@
 
 using namespace form::detail::experimental;
 
-ROOT_TBranch_Write_ContainerImp::ROOT_TBranch_Write_ContainerImp(std::string const& name) :
-  Storage_Associative_Write_Container(name)
+root_tbranch_write_container_imp::root_tbranch_write_container_imp(std::string const& name) :
+  storage_associative_write_container(name)
 {
 }
 
-void ROOT_TBranch_Write_ContainerImp::setAttribute(std::string const& key, std::string const& value)
+void root_tbranch_write_container_imp::set_attribute(std::string const& key,
+                                                     std::string const& value)
 {
   if (key == "auto_flush") {
-    m_tree->SetAutoFlush(std::stol(value));
+    tree_->SetAutoFlush(std::stol(value));
   } else {
-    throw std::runtime_error("ROOT_TTree_Write_ContainerImp accepts some attributes, but not " +
+    throw std::runtime_error("root_ttree_write_container_imp accepts some attributes, but not " +
                              key);
   }
 }
 
-void ROOT_TBranch_Write_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
+void root_tbranch_write_container_imp::set_file(std::shared_ptr<i_storage_file> file)
 {
-  this->Storage_Associative_Write_Container::setFile(file);
-  auto* root_tfile_imp = dynamic_cast<ROOT_TFileImp*>(file.get());
-  if (root_tfile_imp == nullptr) {
+  this->storage_associative_write_container::set_file(file);
+  auto* root_file = dynamic_cast<root_tfile_imp*>(file.get());
+  if (root_file == nullptr) {
     throw std::runtime_error(
-      "ROOT_TBranch_Write_ContainerImp::setFile can't attach to non-ROOT file");
+      "root_tbranch_write_container_imp::set_file can't attach to non-ROOT file");
   }
-  m_tfile = root_tfile_imp->getTFile();
+  tfile_ = root_file->get_tfile();
 }
 
-void ROOT_TBranch_Write_ContainerImp::setParent(std::shared_ptr<IStorage_Write_Container> parent)
+void root_tbranch_write_container_imp::set_parent(std::shared_ptr<i_storage_write_container> parent)
 {
-  this->Storage_Associative_Write_Container::setParent(parent);
-  auto* root_ttree_imp = dynamic_cast<ROOT_TTree_Write_ContainerImp*>(parent.get());
+  this->storage_associative_write_container::set_parent(parent);
+  auto* root_ttree_imp = dynamic_cast<root_ttree_write_container_imp*>(parent.get());
   if (root_ttree_imp == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::setParent");
+    throw std::runtime_error("root_tbranch_write_container_imp::set_parent");
   }
-  m_tree = root_ttree_imp->getTTree();
+  tree_ = root_ttree_imp->get_ttree();
 }
 
-void ROOT_TBranch_Write_ContainerImp::setupWrite(std::type_info const& type)
+void root_tbranch_write_container_imp::setup_write(std::type_info const& type)
 {
   //Type name conversion based on https://root.cern.ch/doc/master/classTTree.html#ac1fa9466ce018d4aa739b357f981c615
   //An empty leaf list (i.e. for a type not in this map) defaults to Float_t; this is intentional.
@@ -68,33 +69,34 @@ void ROOT_TBranch_Write_ContainerImp::setupWrite(std::type_info const& type)
                                                                 {kULong64_t, "/l"},
                                                                 {kBool_t, "/O"}};
 
-  if (m_tree == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::setupWrite no tree found");
+  if (tree_ == nullptr) {
+    throw std::runtime_error("root_tbranch_write_container_imp::setup_write no tree found");
   }
 
-  auto* dictInfo = TDictionary::GetDictionary(type);
-  if (m_branch == nullptr) {
-    if (!dictInfo) {
-      throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::setupWrite unsupported type: " +
-                               DemangleName(type));
+  auto* dict_info = TDictionary::GetDictionary(type);
+  if (branch_ == nullptr) {
+    if (!dict_info) {
+      throw std::runtime_error("root_tbranch_write_container_imp::setup_write unsupported type: " +
+                               demangle_name(type));
     }
-    if (dictInfo->Property() & EProperty::kIsFundamental) {
-      m_branch = m_tree->Branch(
+    if (dict_info->Property() & EProperty::kIsFundamental) {
+      branch_ = tree_->Branch(
         col_name().c_str(),
         static_cast<void*>(nullptr), // Overload selection
         //NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-        (col_name() + type_name_to_leaf_list[static_cast<TDataType*>(dictInfo)->GetType()]).c_str(),
+        (col_name() + type_name_to_leaf_list[static_cast<TDataType*>(dict_info)->GetType()])
+          .c_str(),
         4096);
     } else {
-      m_branch = m_tree->Branch(col_name().c_str(), dictInfo->GetName(), nullptr);
+      branch_ = tree_->Branch(col_name().c_str(), dict_info->GetName(), nullptr);
     }
   }
-  if (m_branch == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::setupWrite no branch created");
+  if (branch_ == nullptr) {
+    throw std::runtime_error("root_tbranch_write_container_imp::setup_write no branch created");
   }
 }
 
-std::uint64_t ROOT_TBranch_Write_ContainerImp::fill(void const* data)
+std::uint64_t root_tbranch_write_container_imp::fill(void const* data)
 {
   // NOTE: incoming parameter `data` is `const` due to the constraints on how we
   // expect users to interact with the data; however, ROOT's SetBranchAddress
@@ -102,45 +104,45 @@ std::uint64_t ROOT_TBranch_Write_ContainerImp::fill(void const* data)
   // it. We will ensure that we do not modify the data through this pointer, and
   // we will reset the branch address after reading to avoid any unintended
   // consequences of casting away the `const`ness.
-  if (m_branch == nullptr) {
-    throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::fill no branch found");
+  if (branch_ == nullptr) {
+    throw std::runtime_error("root_tbranch_write_container_imp::fill no branch found");
   }
-  TLeaf* leaf = m_branch->GetLeaf(col_name().c_str());
+  TLeaf* leaf = branch_->GetLeaf(col_name().c_str());
   if (leaf != nullptr &&
       TDictionary::GetDictionary(leaf->GetTypeName())->Property() & EProperty::kIsFundamental) {
-    m_branch->SetAddress(const_cast<void*>(data));
+    branch_->SetAddress(const_cast<void*>(data));
   } else {
-    m_branch->SetAddress(reinterpret_cast<void*>(&data));
+    branch_->SetAddress(reinterpret_cast<void*>(&data));
   }
   // TBranch::Fill() returns the number of bytes committed, or a negative value on a write error.
   // ROOT increments entry count before a basket write can fail, so check return value first
-  Int_t const nbytes = m_branch->Fill();
-  m_branch->ResetAddress();
+  Int_t const nbytes = branch_->Fill();
+  branch_->ResetAddress();
   if (nbytes < 0) {
-    throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::fill TBranch::Fill() failed for " +
+    throw std::runtime_error("root_tbranch_write_container_imp::fill TBranch::Fill() failed for " +
                              col_name());
   }
 
   // 0-based entries: GetEntries() is the total count after this Fill(); row = count - 1.
   // GetEntries() >= 1 here (Fill() succeeded), so the row is non-negative.
-  return static_cast<std::uint64_t>(m_branch->GetEntries() - 1);
+  return static_cast<std::uint64_t>(branch_->GetEntries() - 1);
 }
 
-void ROOT_TBranch_Write_ContainerImp::commit()
+void root_tbranch_write_container_imp::commit()
 {
   // Forward the tree
-  if (!m_tree) {
-    throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::commit no tree attached");
+  if (!tree_) {
+    throw std::runtime_error("root_tbranch_write_container_imp::commit no tree attached");
   }
 
-  if (!m_branch) {
-    throw std::runtime_error("ROOT_TBranch_Write_ContainerImp::commit no branch found");
+  if (!branch_) {
+    throw std::runtime_error("root_tbranch_write_container_imp::commit no branch found");
   }
 
-  if (m_branch->GetEntries() == m_tree->GetEntries()) {
+  if (branch_->GetEntries() == tree_->GetEntries()) {
     throw std::runtime_error(
-      "ROOT_TBranch_Write_ContainerImp::commit called without new entries since last fill/commit");
+      "root_tbranch_write_container_imp::commit called without new entries since last fill/commit");
   }
 
-  m_tree->SetEntries(m_branch->GetEntries());
+  tree_->SetEntries(branch_->GetEntries());
 }

--- a/form/root_storage/root_tbranch_write_container.hpp
+++ b/form/root_storage/root_tbranch_write_container.hpp
@@ -14,24 +14,24 @@ class TBranch;
 
 namespace form::detail::experimental {
 
-  class ROOT_TBranch_Write_ContainerImp : public Storage_Associative_Write_Container {
+  class root_tbranch_write_container_imp : public storage_associative_write_container {
   public:
-    explicit ROOT_TBranch_Write_ContainerImp(std::string const& name);
-    ~ROOT_TBranch_Write_ContainerImp() override = default;
+    explicit root_tbranch_write_container_imp(std::string const& name);
+    ~root_tbranch_write_container_imp() override = default;
 
-    void setAttribute(std::string const& key, std::string const& value) override;
+    void set_attribute(std::string const& key, std::string const& value) override;
 
-    void setFile(std::shared_ptr<IStorage_File> file) override;
-    void setParent(std::shared_ptr<IStorage_Write_Container> parent) override;
+    void set_file(std::shared_ptr<i_storage_file> file) override;
+    void set_parent(std::shared_ptr<i_storage_write_container> parent) override;
 
-    void setupWrite(std::type_info const& type = typeid(void)) override;
+    void setup_write(std::type_info const& type = typeid(void)) override;
     std::uint64_t fill(void const* data) override;
     void commit() override;
 
   private:
-    std::shared_ptr<TFile> m_tfile;
-    TTree* m_tree{nullptr};
-    TBranch* m_branch{nullptr};
+    std::shared_ptr<TFile> tfile_;
+    TTree* tree_{nullptr};
+    TBranch* branch_{nullptr};
   };
 
 } // namespace form::detail::experimental

--- a/form/root_storage/root_tfile.cpp
+++ b/form/root_storage/root_tfile.cpp
@@ -5,19 +5,19 @@
 #include "TFile.h"
 
 using namespace form::detail::experimental;
-ROOT_TFileImp::ROOT_TFileImp(std::string const& name, char mode) :
-  Storage_File(name, mode), m_file(nullptr)
+root_tfile_imp::root_tfile_imp(std::string const& name, char mode) :
+  storage_file(name, mode), file_(nullptr)
 {
   if (mode == 'c' || mode == 'r' || mode == 'o') {
-    m_file.reset(TFile::Open(name.c_str(), "RECREATE"));
+    file_.reset(TFile::Open(name.c_str(), "RECREATE"));
   } else {
-    m_file.reset(TFile::Open(name.c_str(), "READ"));
+    file_.reset(TFile::Open(name.c_str(), "READ"));
   }
 }
 
-ROOT_TFileImp::~ROOT_TFileImp() = default;
+root_tfile_imp::~root_tfile_imp() = default;
 
-void ROOT_TFileImp::setAttribute(std::string const& key, std::string const& value)
+void root_tfile_imp::set_attribute(std::string const& key, std::string const& value)
 {
   if (key == "compression") {
     using RComp = ROOT::RCompressionSetting::EAlgorithm;
@@ -35,10 +35,10 @@ void ROOT_TFileImp::setAttribute(std::string const& key, std::string const& valu
     } else { // leave compression as kUndefined, which will use ROOT's default
     }
 
-    m_file->SetCompressionAlgorithm(compression);
+    file_->SetCompressionAlgorithm(compression);
   } else {
-    throw std::runtime_error("ROOT_TFileImp does not recognize an attribute named " + key);
+    throw std::runtime_error("root_tfile_imp does not recognize an attribute named " + key);
   }
 }
 
-std::shared_ptr<TFile> ROOT_TFileImp::getTFile() { return m_file; }
+std::shared_ptr<TFile> root_tfile_imp::get_tfile() { return file_; }

--- a/form/root_storage/root_tfile.hpp
+++ b/form/root_storage/root_tfile.hpp
@@ -12,17 +12,17 @@ class TFile;
 
 namespace form::detail::experimental {
 
-  class ROOT_TFileImp : public Storage_File {
+  class root_tfile_imp : public storage_file {
   public:
-    ROOT_TFileImp(std::string const& name, char mode);
-    ~ROOT_TFileImp() override;
+    root_tfile_imp(std::string const& name, char mode);
+    ~root_tfile_imp() override;
 
-    void setAttribute(std::string const& key, std::string const& value) override;
+    void set_attribute(std::string const& key, std::string const& value) override;
 
-    std::shared_ptr<TFile> getTFile();
+    std::shared_ptr<TFile> get_tfile();
 
   private:
-    std::shared_ptr<TFile> m_file;
+    std::shared_ptr<TFile> file_;
   };
 
 } // namespace form::detail::experimental

--- a/form/root_storage/root_ttree_write_container.cpp
+++ b/form/root_storage/root_ttree_write_container.cpp
@@ -10,54 +10,54 @@
 
 using namespace form::detail::experimental;
 
-ROOT_TTree_Write_ContainerImp::ROOT_TTree_Write_ContainerImp(std::string const& name) :
-  Storage_Write_Association(name)
+root_ttree_write_container_imp::root_ttree_write_container_imp(std::string const& name) :
+  storage_write_association(name)
 {
 }
 
-void ROOT_TTree_Write_ContainerImp::setFile(std::shared_ptr<IStorage_File> file)
+void root_ttree_write_container_imp::set_file(std::shared_ptr<i_storage_file> file)
 {
-  this->Storage_Write_Association::setFile(file);
-  auto* root_tfile_imp = dynamic_cast<ROOT_TFileImp*>(file.get());
-  if (root_tfile_imp == nullptr) {
+  this->storage_write_association::set_file(file);
+  auto* root_file = dynamic_cast<root_tfile_imp*>(file.get());
+  if (root_file == nullptr) {
     throw std::runtime_error(
-      "ROOT_TTree_Write_ContainerImp::setFile can't attach to non-ROOT file");
+      "root_ttree_write_container_imp::set_file can't attach to non-ROOT file");
   }
-  m_tfile = root_tfile_imp->getTFile();
+  tfile_ = root_file->get_tfile();
 }
 
-void ROOT_TTree_Write_ContainerImp::setupWrite(std::type_info const& /* type*/)
+void root_ttree_write_container_imp::setup_write(std::type_info const& /* type*/)
 {
-  if (m_tfile == nullptr) {
-    throw std::runtime_error("ROOT_TTree_Write_ContainerImp::setupWrite no file attached");
+  if (tfile_ == nullptr) {
+    throw std::runtime_error("root_ttree_write_container_imp::setup_write no file attached");
   }
-  if (m_tree == nullptr) {
-    m_tree.reset(m_tfile->Get<TTree>(name().c_str()));
+  if (tree_ == nullptr) {
+    tree_.reset(tfile_->Get<TTree>(name().c_str()));
   }
-  if (m_tree == nullptr) {
+  if (tree_ == nullptr) {
     // Mark the raw allocation as an owning pointer before transferring it.
     // NOLINTNEXTLINE(readability-redundant-casting)
-    m_tree.reset(gsl::owner<TTree*>{new TTree(name().c_str(), name().c_str())});
-    m_tree->SetDirectory(m_tfile.get());
+    tree_.reset(gsl::owner<TTree*>{new TTree(name().c_str(), name().c_str())});
+    tree_->SetDirectory(tfile_.get());
   }
-  if (m_tree == nullptr) {
-    throw std::runtime_error("ROOT_TTree_Write_ContainerImp::setupWrite no tree created");
+  if (tree_ == nullptr) {
+    throw std::runtime_error("root_ttree_write_container_imp::setup_write no tree created");
   }
 }
 
-std::uint64_t ROOT_TTree_Write_ContainerImp::fill(void const* /* data*/)
+std::uint64_t root_ttree_write_container_imp::fill(void const* /* data*/)
 {
-  throw std::runtime_error("ROOT_TTree_Write_ContainerImp::fill not implemented");
+  throw std::runtime_error("root_ttree_write_container_imp::fill not implemented");
 }
 
-void ROOT_TTree_Write_ContainerImp::commit()
+void root_ttree_write_container_imp::commit()
 {
-  throw std::runtime_error("ROOT_TTree_Write_ContainerImp::commit not implemented");
+  throw std::runtime_error("root_ttree_write_container_imp::commit not implemented");
 }
 
-TTree* ROOT_TTree_Write_ContainerImp::getTTree() { return m_tree.get(); }
+TTree* root_ttree_write_container_imp::get_ttree() { return tree_.get(); }
 
-void ROOT_TTree_Write_ContainerImp::TTreeDeleter::operator()(gsl::owner<TTree*> t) const
+void root_ttree_write_container_imp::ttree_deleter::operator()(gsl::owner<TTree*> t) const
 {
   if (t) {
     t->GetDirectory()->WriteTObject(t);

--- a/form/root_storage/root_ttree_write_container.hpp
+++ b/form/root_storage/root_ttree_write_container.hpp
@@ -13,22 +13,22 @@ class TTree;
 
 namespace form::detail::experimental {
 
-  class ROOT_TTree_Write_ContainerImp : public Storage_Write_Association {
+  class root_ttree_write_container_imp : public storage_write_association {
   public:
-    explicit ROOT_TTree_Write_ContainerImp(std::string const& name);
-    ~ROOT_TTree_Write_ContainerImp() override = default;
+    explicit root_ttree_write_container_imp(std::string const& name);
+    ~root_ttree_write_container_imp() override = default;
 
-    ROOT_TTree_Write_ContainerImp(ROOT_TTree_Write_ContainerImp const&) = delete;
-    ROOT_TTree_Write_ContainerImp& operator=(ROOT_TTree_Write_ContainerImp const&) = delete;
-    ROOT_TTree_Write_ContainerImp(ROOT_TTree_Write_ContainerImp&&) = delete;
-    ROOT_TTree_Write_ContainerImp& operator=(ROOT_TTree_Write_ContainerImp&&) = delete;
+    root_ttree_write_container_imp(root_ttree_write_container_imp const&) = delete;
+    root_ttree_write_container_imp& operator=(root_ttree_write_container_imp const&) = delete;
+    root_ttree_write_container_imp(root_ttree_write_container_imp&&) = delete;
+    root_ttree_write_container_imp& operator=(root_ttree_write_container_imp&&) = delete;
 
-    void setFile(std::shared_ptr<IStorage_File> file) override;
-    void setupWrite(std::type_info const& type) override;
+    void set_file(std::shared_ptr<i_storage_file> file) override;
+    void setup_write(std::type_info const& type) override;
     std::uint64_t fill(void const* data) override;
     void commit() override;
 
-    TTree* getTTree();
+    TTree* get_ttree();
 
   private:
     // Be absolutely explicit about the ownership semantics of TTree*,
@@ -36,14 +36,14 @@ namespace form::detail::experimental {
     // practice we need to ensure objects are written to the TTree—and
     // the TTree itself is deleted—at the right time i.e. before its
     //  containing TFile is deleted.
-    struct TTreeDeleter {
+    struct ttree_deleter {
       void operator()(TTree* t) const;
     };
 
     // Ordering of members is critical here:
     // the TTree must be deleted before the TFile.
-    std::shared_ptr<TFile> m_tfile;
-    std::unique_ptr<TTree, TTreeDeleter> m_tree;
+    std::shared_ptr<TFile> tfile_;
+    std::unique_ptr<TTree, ttree_deleter> tree_;
   };
 
 } //namespace form::detail::experimental

--- a/form/storage/factories.cpp
+++ b/form/storage/factories.cpp
@@ -24,42 +24,42 @@
 
 namespace form::detail::experimental {
 
-  using Major = form::technology::Major;
+  using major = form::technology::major;
 
-  std::shared_ptr<IStorage_File> createFile(form::technology::Id tech,
-                                            std::string const& name,
-                                            char mode)
+  std::shared_ptr<i_storage_file> create_file(form::technology::id tech,
+                                              std::string const& name,
+                                              char mode)
   {
     switch (tech.major) {
-    case Major::generic:
+    case major::generic:
       // No technology specified: generic storage.
-      return std::make_shared<Storage_File>(name, mode);
-    case Major::root:
+      return std::make_shared<storage_file>(name, mode);
+    case major::root:
 #ifdef USE_ROOT_STORAGE
-      return std::make_shared<ROOT_TFileImp>(name, mode);
+      return std::make_shared<root_tfile_imp>(name, mode);
 #else
       throw std::runtime_error("FORM: ROOT support is not compiled into this build");
 #endif
-    case Major::hdf5:
+    case major::hdf5:
       throw std::runtime_error("FORM: HDF5 storage is recognized but not yet implemented");
     }
     throw std::runtime_error("FORM: unsupported storage technology requested");
   }
 
-  std::shared_ptr<IStorage_Write_Container> createWriteAssociation(form::technology::Id tech,
-                                                                   std::string const& name)
+  std::shared_ptr<i_storage_write_container> create_write_association(form::technology::id tech,
+                                                                      std::string const& name)
   {
     switch (tech.major) {
-    case Major::generic:
+    case major::generic:
       // No technology specified: generic storage.
-      return std::make_shared<Storage_Write_Association>(name);
-    case Major::root:
+      return std::make_shared<storage_write_association>(name);
+    case major::root:
 #ifdef USE_ROOT_STORAGE
-      if (tech == form::technology::ROOT_TTREE) {
-        return std::make_shared<ROOT_TTree_Write_ContainerImp>(name);
-      } else if (tech == form::technology::ROOT_RNTUPLE) {
+      if (tech == form::technology::root_ttree) {
+        return std::make_shared<root_ttree_write_container_imp>(name);
+      } else if (tech == form::technology::root_rntuple) {
 #ifdef USE_RNTUPLE_STORAGE
-        return std::make_shared<ROOT_RNTuple_Write_ContainerImp>(name);
+        return std::make_shared<root_rntuple_write_container_imp>(name);
 #else
         throw std::runtime_error("FORM: ROOT RNTUPLE support is not compiled into this build");
 #endif
@@ -69,26 +69,26 @@ namespace form::detail::experimental {
 #else
       throw std::runtime_error("FORM: ROOT support is not compiled into this build");
 #endif
-    case Major::hdf5:
+    case major::hdf5:
       throw std::runtime_error("FORM: HDF5 storage is recognized but not yet implemented");
     }
     throw std::runtime_error("FORM: unsupported storage technology requested");
   }
 
-  std::shared_ptr<IStorage_Read_Container> createReadContainer(form::technology::Id tech,
-                                                               std::string const& name)
+  std::shared_ptr<i_storage_read_container> create_read_container(form::technology::id tech,
+                                                                  std::string const& name)
   {
     switch (tech.major) {
-    case Major::generic:
+    case major::generic:
       // No technology specified: generic storage.
-      return std::make_shared<Storage_Read_Container>(name);
-    case Major::root:
+      return std::make_shared<storage_read_container>(name);
+    case major::root:
 #ifdef USE_ROOT_STORAGE
-      if (tech == form::technology::ROOT_TTREE) {
-        return std::make_shared<ROOT_TBranch_Read_ContainerImp>(name);
-      } else if (tech == form::technology::ROOT_RNTUPLE) {
+      if (tech == form::technology::root_ttree) {
+        return std::make_shared<root_tbranch_read_container_imp>(name);
+      } else if (tech == form::technology::root_rntuple) {
 #ifdef USE_RNTUPLE_STORAGE
-        return std::make_shared<ROOT_RField_Read_ContainerImp>(name);
+        return std::make_shared<root_rfield_read_container_imp>(name);
 #else
         throw std::runtime_error("FORM: ROOT RNTUPLE support is not compiled into this build");
 #endif
@@ -98,26 +98,26 @@ namespace form::detail::experimental {
 #else
       throw std::runtime_error("FORM: ROOT support is not compiled into this build");
 #endif
-    case Major::hdf5:
+    case major::hdf5:
       throw std::runtime_error("FORM: HDF5 storage is recognized but not yet implemented");
     }
     throw std::runtime_error("FORM: unsupported storage technology requested");
   }
 
-  std::shared_ptr<IStorage_Write_Container> createWriteContainer(form::technology::Id tech,
-                                                                 std::string const& name)
+  std::shared_ptr<i_storage_write_container> create_write_container(form::technology::id tech,
+                                                                    std::string const& name)
   {
     switch (tech.major) {
-    case Major::generic:
+    case major::generic:
       // No technology specified: generic storage.
-      return std::make_shared<Storage_Write_Container>(name);
-    case Major::root:
+      return std::make_shared<storage_write_container>(name);
+    case major::root:
 #ifdef USE_ROOT_STORAGE
-      if (tech == form::technology::ROOT_TTREE) {
-        return std::make_shared<ROOT_TBranch_Write_ContainerImp>(name);
-      } else if (tech == form::technology::ROOT_RNTUPLE) {
+      if (tech == form::technology::root_ttree) {
+        return std::make_shared<root_tbranch_write_container_imp>(name);
+      } else if (tech == form::technology::root_rntuple) {
 #ifdef USE_RNTUPLE_STORAGE
-        return std::make_shared<ROOT_RField_Write_ContainerImp>(name);
+        return std::make_shared<root_rfield_write_container_imp>(name);
 #else
         throw std::runtime_error("FORM: ROOT RNTUPLE support is not compiled into this build");
 #endif
@@ -127,7 +127,7 @@ namespace form::detail::experimental {
 #else
       throw std::runtime_error("FORM: ROOT support is not compiled into this build");
 #endif
-    case Major::hdf5:
+    case major::hdf5:
       throw std::runtime_error("FORM: HDF5 storage is recognized but not yet implemented");
     }
     throw std::runtime_error("FORM: unsupported storage technology requested");

--- a/form/storage/factories.hpp
+++ b/form/storage/factories.hpp
@@ -11,18 +11,18 @@
 
 namespace form::detail::experimental {
 
-  std::shared_ptr<IStorage_File> createFile(form::technology::Id tech,
-                                            std::string const& name,
-                                            char mode);
+  std::shared_ptr<i_storage_file> create_file(form::technology::id tech,
+                                              std::string const& name,
+                                              char mode);
 
-  std::shared_ptr<IStorage_Write_Container> createWriteAssociation(form::technology::Id tech,
-                                                                   std::string const& name);
+  std::shared_ptr<i_storage_write_container> create_write_association(form::technology::id tech,
+                                                                      std::string const& name);
 
-  std::shared_ptr<IStorage_Read_Container> createReadContainer(form::technology::Id tech,
-                                                               std::string const& name);
+  std::shared_ptr<i_storage_read_container> create_read_container(form::technology::id tech,
+                                                                  std::string const& name);
 
-  std::shared_ptr<IStorage_Write_Container> createWriteContainer(form::technology::Id tech,
-                                                                 std::string const& name);
+  std::shared_ptr<i_storage_write_container> create_write_container(form::technology::id tech,
+                                                                    std::string const& name);
 
 } // namespace form::detail::experimental
 #endif // FORM_STORAGE_FACTORIES_HPP

--- a/form/storage/istorage.hpp
+++ b/form/storage/istorage.hpp
@@ -18,86 +18,87 @@ namespace form::detail::experimental {
 
   // Sentinel returned by the write chain when no addressable row was written
   // (e.g. the generic no-op container). A real row is always < this value.
-  inline constexpr std::uint64_t kInvalidRowId = std::numeric_limits<std::uint64_t>::max();
+  inline constexpr std::uint64_t invalid_row_id = std::numeric_limits<std::uint64_t>::max();
 
-  class IStorageReader {
+  class i_storage_reader {
   public:
-    IStorageReader() = default;
-    virtual ~IStorageReader() = default;
+    i_storage_reader() = default;
+    virtual ~i_storage_reader() = default;
 
-    virtual int getIndex(Token const& token,
-                         std::string const& id,
-                         form::experimental::config::tech_setting_config const& settings) = 0;
-    virtual void prime(Token const& token,
+    virtual int get_index(token const& token,
+                          std::string const& id,
+                          form::experimental::config::tech_setting_config const& settings) = 0;
+    virtual void prime(token const& token,
                        std::type_info const& type,
                        form::experimental::config::tech_setting_config const& settings) = 0;
-    virtual std::vector<std::string> listIndices(
-      Token const& token, form::experimental::config::tech_setting_config const& settings) = 0;
-    virtual void readContainer(Token const& token,
-                               void const** data,
-                               std::type_info const& type,
-                               form::experimental::config::tech_setting_config const& settings) = 0;
-  };
-
-  class IStorageWriter {
-  public:
-    IStorageWriter() = default;
-    virtual ~IStorageWriter() = default;
-
-    virtual void createContainers(
-      std::map<std::unique_ptr<Placement>, std::type_info const*> const& containers,
+    virtual std::vector<std::string> list_indices(
+      token const& token, form::experimental::config::tech_setting_config const& settings) = 0;
+    virtual void read_container(
+      token const& token,
+      void const** data,
+      std::type_info const& type,
       form::experimental::config::tech_setting_config const& settings) = 0;
-    // Returns the 0-based row (entry) number written, or kInvalidRowId if no rows
-    virtual std::uint64_t fillContainer(Placement const& plcmnt,
-                                        void const* data,
-                                        std::type_info const& type) = 0;
-    virtual void commitContainers(Placement const& plcmnt) = 0;
   };
 
-  class IStorage_File {
+  class i_storage_writer {
   public:
-    IStorage_File() = default;
-    virtual ~IStorage_File() = default;
+    i_storage_writer() = default;
+    virtual ~i_storage_writer() = default;
+
+    virtual void create_containers(
+      std::map<std::unique_ptr<placement>, std::type_info const*> const& containers,
+      form::experimental::config::tech_setting_config const& settings) = 0;
+    // Returns the 0-based row (entry) number written, or invalid_row_id if no rows
+    virtual std::uint64_t fill_container(placement const& plcmnt,
+                                         void const* data,
+                                         std::type_info const& type) = 0;
+    virtual void commit_containers(placement const& plcmnt) = 0;
+  };
+
+  class i_storage_file {
+  public:
+    i_storage_file() = default;
+    virtual ~i_storage_file() = default;
 
     virtual std::string const& name() = 0;
     virtual char mode() = 0;
 
-    virtual void setAttribute(std::string const& name, std::string const& value) = 0;
+    virtual void set_attribute(std::string const& name, std::string const& value) = 0;
   };
 
-  class IStorage_Write_Container {
+  class i_storage_write_container {
   public:
-    IStorage_Write_Container() = default;
-    virtual ~IStorage_Write_Container() = default;
+    i_storage_write_container() = default;
+    virtual ~i_storage_write_container() = default;
 
     virtual std::string const& name() = 0;
 
-    virtual void setFile(std::shared_ptr<IStorage_File> file) = 0;
-    virtual void setupWrite(std::type_info const& type = typeid(void)) = 0;
-    // Returns the 0-based row (entry) number written, or kInvalidRowId if no rows
+    virtual void set_file(std::shared_ptr<i_storage_file> file) = 0;
+    virtual void setup_write(std::type_info const& type = typeid(void)) = 0;
+    // Returns the 0-based row (entry) number written, or invalid_row_id if no rows
     virtual std::uint64_t fill(void const* data) = 0;
     virtual void commit() = 0;
 
-    virtual void setAttribute(std::string const& name, std::string const& value) = 0;
+    virtual void set_attribute(std::string const& name, std::string const& value) = 0;
   };
 
-  class IStorage_Read_Container {
+  class i_storage_read_container {
   public:
-    IStorage_Read_Container() = default;
-    virtual ~IStorage_Read_Container() = default;
+    i_storage_read_container() = default;
+    virtual ~i_storage_read_container() = default;
 
     virtual std::string const& name() = 0;
 
-    virtual void setFile(std::shared_ptr<IStorage_File> file) = 0;
+    virtual void set_file(std::shared_ptr<i_storage_file> file) = 0;
     virtual void prime(std::type_info const& type) = 0;
     virtual bool read(int id, void const** data, std::type_info const& type) = 0;
     virtual int entries() = 0;
 
-    virtual void setAttribute(std::string const& name, std::string const& value) = 0;
+    virtual void set_attribute(std::string const& name, std::string const& value) = 0;
   };
 
-  std::unique_ptr<IStorageReader> createStorageReader();
-  std::unique_ptr<IStorageWriter> createStorageWriter();
+  std::unique_ptr<i_storage_reader> create_storage_reader();
+  std::unique_ptr<i_storage_writer> create_storage_writer();
 
 } // namespace form::detail::experimental
 

--- a/form/storage/storage_associative_write_container.cpp
+++ b/form/storage/storage_associative_write_container.cpp
@@ -6,27 +6,27 @@
 
 using namespace form::detail::experimental;
 
-Storage_Associative_Write_Container::Storage_Associative_Write_Container(std::string const& name) :
-  Storage_Write_Container::Storage_Write_Container(name), m_parent(nullptr)
+storage_associative_write_container::storage_associative_write_container(std::string const& name) :
+  storage_write_container::storage_write_container(name), parent_(nullptr)
 {
   auto del_pos = name.find('/');
   if (del_pos != std::string::npos) {
-    m_tName = name.substr(0, del_pos);
-    m_cName = name.substr(del_pos + 1);
+    t_name_ = name.substr(0, del_pos);
+    c_name_ = name.substr(del_pos + 1);
   } else {
-    m_tName = name;
-    m_cName = "Main";
+    t_name_ = name;
+    c_name_ = "Main";
   }
 }
 
-Storage_Associative_Write_Container::~Storage_Associative_Write_Container() = default;
+storage_associative_write_container::~storage_associative_write_container() = default;
 
-std::string const& Storage_Associative_Write_Container::top_name() { return m_tName; }
+std::string const& storage_associative_write_container::top_name() { return t_name_; }
 
-std::string const& Storage_Associative_Write_Container::col_name() { return m_cName; }
+std::string const& storage_associative_write_container::col_name() { return c_name_; }
 
-void Storage_Associative_Write_Container::setParent(
-  std::shared_ptr<IStorage_Write_Container> parent)
+void storage_associative_write_container::set_parent(
+  std::shared_ptr<i_storage_write_container> parent)
 {
-  m_parent = std::move(parent);
+  parent_ = std::move(parent);
 }

--- a/form/storage/storage_associative_write_container.hpp
+++ b/form/storage/storage_associative_write_container.hpp
@@ -9,21 +9,21 @@
 
 namespace form::detail::experimental {
 
-  class Storage_Associative_Write_Container : public Storage_Write_Container {
+  class storage_associative_write_container : public storage_write_container {
   public:
-    explicit Storage_Associative_Write_Container(std::string const& name);
-    ~Storage_Associative_Write_Container() override;
+    explicit storage_associative_write_container(std::string const& name);
+    ~storage_associative_write_container() override;
 
     std::string const& top_name();
     std::string const& col_name();
 
-    virtual void setParent(std::shared_ptr<IStorage_Write_Container> parent);
+    virtual void set_parent(std::shared_ptr<i_storage_write_container> parent);
 
   private:
-    std::string m_tName;
-    std::string m_cName;
+    std::string t_name_;
+    std::string c_name_;
 
-    std::shared_ptr<IStorage_Write_Container> m_parent;
+    std::shared_ptr<i_storage_write_container> parent_;
   };
 
 } // namespace form::detail::experimental

--- a/form/storage/storage_file.cpp
+++ b/form/storage/storage_file.cpp
@@ -6,14 +6,14 @@
 
 using namespace form::detail::experimental;
 
-Storage_File::Storage_File(std::string name, char mode) : m_name(std::move(name)), m_mode(mode) {}
+storage_file::storage_file(std::string name, char mode) : name_(std::move(name)), mode_(mode) {}
 
-std::string const& Storage_File::name() { return m_name; }
+std::string const& storage_file::name() { return name_; }
 
-char Storage_File::mode() { return m_mode; }
+char storage_file::mode() { return mode_; }
 
-void Storage_File::setAttribute(std::string const& /*name*/, std::string const& /*value*/)
+void storage_file::set_attribute(std::string const& /*name*/, std::string const& /*value*/)
 {
   throw std::runtime_error(
-    "StorageFile::setAttribute does not accept any attributes for a file named " + m_name);
+    "StorageFile::set_attribute does not accept any attributes for a file named " + name_);
 }

--- a/form/storage/storage_file.cpp
+++ b/form/storage/storage_file.cpp
@@ -15,5 +15,5 @@ char storage_file::mode() { return mode_; }
 void storage_file::set_attribute(std::string const& /*name*/, std::string const& /*value*/)
 {
   throw std::runtime_error(
-    "StorageFile::set_attribute does not accept any attributes for a file named " + name_);
+    "storage_file::set_attribute does not accept any attributes for a file named " + name_);
 }

--- a/form/storage/storage_file.hpp
+++ b/form/storage/storage_file.hpp
@@ -8,19 +8,19 @@
 #include <string>
 
 namespace form::detail::experimental {
-  class Storage_File : public IStorage_File {
+  class storage_file : public i_storage_file {
   public:
-    Storage_File(std::string name, char mode);
-    ~Storage_File() override = default;
+    storage_file(std::string name, char mode);
+    ~storage_file() override = default;
 
     std::string const& name() override;
     char mode() override;
 
-    void setAttribute(std::string const& name, std::string const& value) override;
+    void set_attribute(std::string const& name, std::string const& value) override;
 
   private:
-    std::string m_name;
-    char m_mode;
+    std::string name_;
+    char mode_;
   };
 } // namespace form::detail::experimental
 

--- a/form/storage/storage_read_container.cpp
+++ b/form/storage/storage_read_container.cpp
@@ -5,41 +5,42 @@
 
 using namespace form::detail::experimental;
 
-Storage_Read_Container::Storage_Read_Container(std::string const& name) :
-  m_name(name), m_file(nullptr)
+storage_read_container::storage_read_container(std::string const& name) :
+  name_(name), file_(nullptr)
 {
   auto del_pos = name.find('/');
   if (del_pos != std::string::npos) {
-    m_tName = name.substr(0, del_pos);
-    m_cName = name.substr(del_pos + 1);
+    t_name_ = name.substr(0, del_pos);
+    c_name_ = name.substr(del_pos + 1);
   } else {
-    m_tName = name;
-    m_cName = "Main";
+    t_name_ = name;
+    c_name_ = "Main";
   }
 }
 
-std::string const& Storage_Read_Container::name() { return m_name; }
+std::string const& storage_read_container::name() { return name_; }
 
-std::string const& Storage_Read_Container::top_name() { return m_tName; }
+std::string const& storage_read_container::top_name() { return t_name_; }
 
-std::string const& Storage_Read_Container::col_name() { return m_cName; }
+std::string const& storage_read_container::col_name() { return c_name_; }
 
-void Storage_Read_Container::setFile(std::shared_ptr<IStorage_File> file) { m_file = file; }
+void storage_read_container::set_file(std::shared_ptr<i_storage_file> file) { file_ = file; }
 
-void Storage_Read_Container::prime(std::type_info const& /*type*/) {}
+void storage_read_container::prime(std::type_info const& /*type*/) {}
 
-bool Storage_Read_Container::read(int /* id*/,
+bool storage_read_container::read(int /* id*/,
                                   void const** /*data*/,
                                   std::type_info const& /* type*/)
 {
   return false;
 }
 
-int Storage_Read_Container::entries() { return 0; }
+int storage_read_container::entries() { return 0; }
 
-void Storage_Read_Container::setAttribute(std::string const& /*name*/, std::string const& /*value*/)
+void storage_read_container::set_attribute(std::string const& /*name*/,
+                                           std::string const& /*value*/)
 {
   throw std::runtime_error(
-    "Storage_Read_Container::setAttribute does not accept any attributes for a container named " +
-    m_name);
+    "storage_read_container::set_attribute does not accept any attributes for a container named " +
+    name_);
 }

--- a/form/storage/storage_read_container.hpp
+++ b/form/storage/storage_read_container.hpp
@@ -10,10 +10,10 @@
 
 namespace form::detail::experimental {
 
-  class Storage_Read_Container : public IStorage_Read_Container {
+  class storage_read_container : public i_storage_read_container {
   public:
-    explicit Storage_Read_Container(std::string const& name);
-    ~Storage_Read_Container() override = default;
+    explicit storage_read_container(std::string const& name);
+    ~storage_read_container() override = default;
 
     std::string const& name() override;
 
@@ -21,19 +21,19 @@ namespace form::detail::experimental {
 
     std::string const& col_name();
 
-    void setFile(std::shared_ptr<IStorage_File> file) override;
+    void set_file(std::shared_ptr<i_storage_file> file) override;
     void prime(std::type_info const& type) override;
 
     bool read(int id, void const** data, std::type_info const& type) override;
     int entries() override;
 
-    void setAttribute(std::string const& name, std::string const& value) override;
+    void set_attribute(std::string const& name, std::string const& value) override;
 
   private:
-    std::string m_name;
-    std::string m_tName;
-    std::string m_cName;
-    std::shared_ptr<IStorage_File> m_file;
+    std::string name_;
+    std::string t_name_;
+    std::string c_name_;
+    std::shared_ptr<i_storage_file> file_;
   };
 } // namespace form::detail::experimental
 

--- a/form/storage/storage_reader.cpp
+++ b/form/storage/storage_reader.cpp
@@ -17,7 +17,7 @@ using namespace form::detail::experimental;
 namespace {
   form::experimental::config::tech_setting_config::table_t get_file_table(
     form::experimental::config::tech_setting_config const& settings,
-    form::technology::Id technology,
+    form::technology::id technology,
     std::string const& file_name)
   {
     auto const per_tech = settings.file_settings.find(technology);
@@ -33,7 +33,7 @@ namespace {
 
   form::experimental::config::tech_setting_config::table_t get_container_table(
     form::experimental::config::tech_setting_config const& settings,
-    form::technology::Id technology,
+    form::technology::id technology,
     std::string const& container_name)
   {
     auto const per_tech = settings.container_settings.find(technology);
@@ -186,69 +186,71 @@ namespace {
 }
 // Factory function implementation
 namespace form::detail::experimental {
-  std::unique_ptr<IStorageReader> createStorageReader()
+  std::unique_ptr<i_storage_reader> create_storage_reader()
   {
-    return std::unique_ptr<IStorageReader>(new StorageReader());
+    return std::unique_ptr<i_storage_reader>(new storage_reader());
   }
 }
 
-int StorageReader::getIndex(Token const& token,
-                            std::string const& id,
-                            form::experimental::config::tech_setting_config const& settings)
+int storage_reader::get_index(token const& token,
+                              std::string const& id,
+                              form::experimental::config::tech_setting_config const& settings)
 {
   if (auto row = sequential_row_from_index_id(id)) {
     return *row;
   }
 
-  if (m_indexMaps[token.containerName()].empty()) {
-    auto contKey = std::make_pair(token.fileName(), token.containerName());
-    auto cont = m_read_containers.find(contKey);
-    if (cont == m_read_containers.end()) {
-      auto file = m_files.find(token.fileName());
-      if (file == m_files.end()) {
+  if (index_maps_[token.container_name()].empty()) {
+    auto cont_key = std::make_pair(token.file_name(), token.container_name());
+    auto cont = read_containers_.find(cont_key);
+    if (cont == read_containers_.end()) {
+      auto file = files_.find(token.file_name());
+      if (file == files_.end()) {
         file =
-          m_files.insert({token.fileName(), createFile(token.technology(), token.fileName(), 'i')})
+          files_
+            .insert({token.file_name(), create_file(token.technology(), token.file_name(), 'i')})
             .first;
         for (auto const& [key, value] :
-             get_file_table(settings, token.technology(), token.fileName())) {
-          file->second->setAttribute(key, value);
+             get_file_table(settings, token.technology(), token.file_name())) {
+          file->second->set_attribute(key, value);
         }
       }
-      cont = m_read_containers
-               .insert({contKey, createReadContainer(token.technology(), token.containerName())})
-               .first;
+      cont =
+        read_containers_
+          .insert({cont_key, create_read_container(token.technology(), token.container_name())})
+          .first;
       for (auto const& [key, value] :
-           get_container_table(settings, token.technology(), token.containerName())) {
-        cont->second->setAttribute(key, value);
+           get_container_table(settings, token.technology(), token.container_name())) {
+        cont->second->set_attribute(key, value);
       }
-      cont->second->setFile(file->second);
+      cont->second->set_file(file->second);
     }
     auto const& type = typeid(std::string);
     int entry = 0;
-    void const* rawData = nullptr;
-    while (cont->second->read(entry, &rawData, type)) {
-      std::unique_ptr<std::string const> data(static_cast<std::string const*>(rawData));
-      m_indexMaps[token.containerName()].insert(std::make_pair(*data, entry));
+    void const* raw_data = nullptr;
+    while (cont->second->read(entry, &raw_data, type)) {
+      std::unique_ptr<std::string const> data(static_cast<std::string const*>(raw_data));
+      index_maps_[token.container_name()].insert(std::make_pair(*data, entry));
       entry++;
     }
 
-    if (m_indexMaps[token.containerName()].empty()) {
+    if (index_maps_[token.container_name()].empty()) {
       if (!is_structured_index_id(id)) {
         return 0;
       }
       throw std::runtime_error("Unable to read index data from container: " +
-                               token.containerName());
+                               token.container_name());
     }
   }
 
-  auto const found = m_indexMaps[token.containerName()].find(id);
-  if (found != m_indexMaps[token.containerName()].end()) {
+  auto const found = index_maps_[token.container_name()].find(id);
+  if (found != index_maps_[token.container_name()].end()) {
     return found->second;
   }
 
   auto const normalized_query = normalize_structured_index(id);
   if (normalized_query) {
-    for (auto const& [existing_id, entry] : m_indexMaps[token.containerName()]) {
+    for (auto const& [existing_id, entry] : index_maps_[token.container_name()]) {
       auto const normalized_existing = normalize_structured_index(existing_id);
       if (normalized_existing && *normalized_existing == *normalized_query) {
         return entry;
@@ -256,8 +258,8 @@ int StorageReader::getIndex(Token const& token,
     }
 
     if (all_components_zero(*normalized_query)) {
-      auto const empty_key = m_indexMaps[token.containerName()].find("");
-      if (empty_key != m_indexMaps[token.containerName()].end()) {
+      auto const empty_key = index_maps_[token.container_name()].find("");
+      if (empty_key != index_maps_[token.container_name()].end()) {
         return 0;
       }
 
@@ -271,83 +273,86 @@ int StorageReader::getIndex(Token const& token,
     return 0;
   }
 
-  throw std::runtime_error("Index id not found: " + id + " in container: " + token.containerName());
+  throw std::runtime_error("Index id not found: " + id +
+                           " in container: " + token.container_name());
 }
 
-void StorageReader::prime(Token const& token,
-                          std::type_info const& type,
-                          form::experimental::config::tech_setting_config const& settings)
+void storage_reader::prime(token const& token,
+                           std::type_info const& type,
+                           form::experimental::config::tech_setting_config const& settings)
 {
-  auto contKey = std::make_pair(token.fileName(), token.containerName());
-  auto cont = m_read_containers.find(contKey);
-  if (cont == m_read_containers.end()) {
-    auto file = m_files.find(token.fileName());
-    if (file == m_files.end()) {
+  auto cont_key = std::make_pair(token.file_name(), token.container_name());
+  auto cont = read_containers_.find(cont_key);
+  if (cont == read_containers_.end()) {
+    auto file = files_.find(token.file_name());
+    if (file == files_.end()) {
       file =
-        m_files.insert({token.fileName(), createFile(token.technology(), token.fileName(), 'i')})
+        files_.insert({token.file_name(), create_file(token.technology(), token.file_name(), 'i')})
           .first;
       for (auto const& [key, value] :
-           get_file_table(settings, token.technology(), token.fileName())) {
-        file->second->setAttribute(key, value);
+           get_file_table(settings, token.technology(), token.file_name())) {
+        file->second->set_attribute(key, value);
       }
     }
-    cont = m_read_containers
-             .insert({contKey, createReadContainer(token.technology(), token.containerName())})
+    cont = read_containers_
+             .insert({cont_key, create_read_container(token.technology(), token.container_name())})
              .first;
-    cont->second->setFile(file->second);
+    cont->second->set_file(file->second);
     for (auto const& [key, value] :
-         get_container_table(settings, token.technology(), token.containerName())) {
-      cont->second->setAttribute(key, value);
+         get_container_table(settings, token.technology(), token.container_name())) {
+      cont->second->set_attribute(key, value);
     }
   }
   cont->second->prime(type);
 }
 
-std::vector<std::string> StorageReader::listIndices(
-  Token const& token, form::experimental::config::tech_setting_config const& settings)
+std::vector<std::string> storage_reader::list_indices(
+  token const& token, form::experimental::config::tech_setting_config const& settings)
 {
-  if (m_indexMaps[token.containerName()].empty()) {
-    auto contKey = std::make_pair(token.fileName(), token.containerName());
-    auto cont = m_read_containers.find(contKey);
-    if (cont == m_read_containers.end()) {
-      auto file = m_files.find(token.fileName());
-      if (file == m_files.end()) {
+  if (index_maps_[token.container_name()].empty()) {
+    auto cont_key = std::make_pair(token.file_name(), token.container_name());
+    auto cont = read_containers_.find(cont_key);
+    if (cont == read_containers_.end()) {
+      auto file = files_.find(token.file_name());
+      if (file == files_.end()) {
         file =
-          m_files.insert({token.fileName(), createFile(token.technology(), token.fileName(), 'i')})
+          files_
+            .insert({token.file_name(), create_file(token.technology(), token.file_name(), 'i')})
             .first;
         for (auto const& [key, value] :
-             get_file_table(settings, token.technology(), token.fileName())) {
-          file->second->setAttribute(key, value);
+             get_file_table(settings, token.technology(), token.file_name())) {
+          file->second->set_attribute(key, value);
         }
       }
-      cont = m_read_containers
-               .insert({contKey, createReadContainer(token.technology(), token.containerName())})
-               .first;
+      cont =
+        read_containers_
+          .insert({cont_key, create_read_container(token.technology(), token.container_name())})
+          .first;
       for (auto const& [key, value] :
-           get_container_table(settings, token.technology(), token.containerName())) {
-        cont->second->setAttribute(key, value);
+           get_container_table(settings, token.technology(), token.container_name())) {
+        cont->second->set_attribute(key, value);
       }
-      cont->second->setFile(file->second);
+      cont->second->set_file(file->second);
     }
 
     auto const& type = typeid(std::string);
     int entry = 0;
-    void const* rawData = nullptr;
-    while (cont->second->read(entry, &rawData, type)) {
-      std::unique_ptr<std::string const> data(static_cast<std::string const*>(rawData));
-      m_indexMaps[token.containerName()].insert(std::make_pair(*data, entry));
+    void const* raw_data = nullptr;
+    while (cont->second->read(entry, &raw_data, type)) {
+      std::unique_ptr<std::string const> data(static_cast<std::string const*>(raw_data));
+      index_maps_[token.container_name()].insert(std::make_pair(*data, entry));
       entry++;
     }
 
-    if (m_indexMaps[token.containerName()].empty()) {
+    if (index_maps_[token.container_name()].empty()) {
       throw std::runtime_error("Unable to enumerate indices from container: " +
-                               token.containerName());
+                               token.container_name());
     }
   }
 
   std::vector<std::pair<int, std::string>> ordered;
-  ordered.reserve(m_indexMaps[token.containerName()].size());
-  for (auto const& [index_string, entry] : m_indexMaps[token.containerName()]) {
+  ordered.reserve(index_maps_[token.container_name()].size());
+  for (auto const& [index_string, entry] : index_maps_[token.container_name()]) {
     ordered.emplace_back(entry, index_string);
   }
   std::ranges::sort(ordered,
@@ -361,33 +366,33 @@ std::vector<std::string> StorageReader::listIndices(
   return result;
 }
 
-void StorageReader::readContainer(Token const& token,
-                                  void const** data,
-                                  std::type_info const& type,
-                                  form::experimental::config::tech_setting_config const& settings)
+void storage_reader::read_container(token const& token,
+                                    void const** data,
+                                    std::type_info const& type,
+                                    form::experimental::config::tech_setting_config const& settings)
 {
-  auto contKey = std::make_pair(token.fileName(), token.containerName());
-  auto cont = m_read_containers.find(contKey);
-  if (cont == m_read_containers.end()) {
-    auto file = m_files.find(token.fileName());
-    if (file == m_files.end()) {
+  auto cont_key = std::make_pair(token.file_name(), token.container_name());
+  auto cont = read_containers_.find(cont_key);
+  if (cont == read_containers_.end()) {
+    auto file = files_.find(token.file_name());
+    if (file == files_.end()) {
       file =
-        m_files.insert({token.fileName(), createFile(token.technology(), token.fileName(), 'i')})
+        files_.insert({token.file_name(), create_file(token.technology(), token.file_name(), 'i')})
           .first;
       for (auto const& [key, value] :
-           get_file_table(settings, token.technology(), token.fileName())) {
-        file->second->setAttribute(key, value);
+           get_file_table(settings, token.technology(), token.file_name())) {
+        file->second->set_attribute(key, value);
       }
     }
-    cont = m_read_containers
-             .insert({contKey, createReadContainer(token.technology(), token.containerName())})
+    cont = read_containers_
+             .insert({cont_key, create_read_container(token.technology(), token.container_name())})
              .first;
-    cont->second->setFile(file->second);
+    cont->second->set_file(file->second);
     for (auto const& [key, value] :
-         get_container_table(settings, token.technology(), token.containerName())) {
-      cont->second->setAttribute(key, value);
+         get_container_table(settings, token.technology(), token.container_name())) {
+      cont->second->set_attribute(key, value);
     }
   }
-  // TODO: Token::id() is a 64-bit row; the read container interface still takes an int entry. Narrow explicitly here (exact for all realistic row counts). Widening the read path to 64-bit is a follow-up PR.
+  // TODO: token::id() is a 64-bit row; the read container interface still takes an int entry. Narrow explicitly here (exact for all realistic row counts). Widening the read path to 64-bit is a follow-up PR.
   cont->second->read(static_cast<int>(token.id()), data, type);
 }

--- a/form/storage/storage_reader.hpp
+++ b/form/storage/storage_reader.hpp
@@ -14,33 +14,33 @@
 
 namespace form::detail::experimental {
 
-  class StorageReader : public IStorageReader {
+  class storage_reader : public i_storage_reader {
   public:
-    StorageReader() = default;
-    ~StorageReader() override = default;
+    storage_reader() = default;
+    ~storage_reader() override = default;
 
     using table_t = form::experimental::config::tech_setting_config::table_t;
 
-    int getIndex(Token const& token,
-                 std::string const& id,
-                 form::experimental::config::tech_setting_config const& settings) override;
-    void prime(Token const& token,
+    int get_index(token const& token,
+                  std::string const& id,
+                  form::experimental::config::tech_setting_config const& settings) override;
+    void prime(token const& token,
                std::type_info const& type,
                form::experimental::config::tech_setting_config const& settings) override;
-    std::vector<std::string> listIndices(
-      Token const& token, form::experimental::config::tech_setting_config const& settings) override;
-    void readContainer(Token const& token,
-                       void const** data,
-                       std::type_info const& type,
-                       form::experimental::config::tech_setting_config const& settings) override;
+    std::vector<std::string> list_indices(
+      token const& token, form::experimental::config::tech_setting_config const& settings) override;
+    void read_container(token const& token,
+                        void const** data,
+                        std::type_info const& type,
+                        form::experimental::config::tech_setting_config const& settings) override;
 
   private:
-    std::map<std::string, std::shared_ptr<IStorage_File>> m_files;
+    std::map<std::string, std::shared_ptr<i_storage_file>> files_;
     std::unordered_map<std::pair<std::string, std::string>,
-                       std::shared_ptr<IStorage_Read_Container>,
+                       std::shared_ptr<i_storage_read_container>,
                        pair_hash>
-      m_read_containers;
-    std::map<std::string, std::map<std::string, int>> m_indexMaps;
+      read_containers_;
+    std::map<std::string, std::map<std::string, int>> index_maps_;
   };
 
 } // namespace form::detail::experimental

--- a/form/storage/storage_write_association.cpp
+++ b/form/storage/storage_write_association.cpp
@@ -15,12 +15,12 @@ namespace {
   }
 }
 
-Storage_Write_Association::Storage_Write_Association(std::string const& name) :
-  Storage_Write_Container::Storage_Write_Container(maybe_remove_suffix(name))
+storage_write_association::storage_write_association(std::string const& name) :
+  storage_write_container::storage_write_container(maybe_remove_suffix(name))
 {
 }
 
-void Storage_Write_Association::setAttribute(std::string const& /*key*/,
-                                             std::string const& /*value*/)
+void storage_write_association::set_attribute(std::string const& /*key*/,
+                                              std::string const& /*value*/)
 {
 }

--- a/form/storage/storage_write_association.hpp
+++ b/form/storage/storage_write_association.hpp
@@ -9,12 +9,12 @@
 
 namespace form::detail::experimental {
 
-  class Storage_Write_Association : public Storage_Write_Container {
+  class storage_write_association : public storage_write_container {
   public:
-    explicit Storage_Write_Association(std::string const& name);
-    ~Storage_Write_Association() override = default;
+    explicit storage_write_association(std::string const& name);
+    ~storage_write_association() override = default;
 
-    void setAttribute(std::string const& key, std::string const& value) override;
+    void set_attribute(std::string const& key, std::string const& value) override;
   };
 
 } // namespace form::detail::experimental

--- a/form/storage/storage_write_container.cpp
+++ b/form/storage/storage_write_container.cpp
@@ -7,25 +7,25 @@
 
 using namespace form::detail::experimental;
 
-Storage_Write_Container::Storage_Write_Container(std::string name) :
-  m_name(std::move(name)), m_file(nullptr)
+storage_write_container::storage_write_container(std::string name) :
+  name_(std::move(name)), file_(nullptr)
 {
 }
 
-std::string const& Storage_Write_Container::name() { return m_name; }
+std::string const& storage_write_container::name() { return name_; }
 
-void Storage_Write_Container::setFile(std::shared_ptr<IStorage_File> file) { m_file = file; }
+void storage_write_container::set_file(std::shared_ptr<i_storage_file> file) { file_ = file; }
 
-void Storage_Write_Container::setupWrite(std::type_info const& /* type*/) {}
+void storage_write_container::setup_write(std::type_info const& /* type*/) {}
 
-std::uint64_t Storage_Write_Container::fill(void const* /* data*/) { return kInvalidRowId; }
+std::uint64_t storage_write_container::fill(void const* /* data*/) { return invalid_row_id; }
 
-void Storage_Write_Container::commit() {}
+void storage_write_container::commit() {}
 
-void Storage_Write_Container::setAttribute(std::string const& /*name*/,
-                                           std::string const& /*value*/)
+void storage_write_container::set_attribute(std::string const& /*name*/,
+                                            std::string const& /*value*/)
 {
   throw std::runtime_error(
-    "Storage_Write_Container::setAttribute does not accept any attributes for a container named " +
-    m_name);
+    "storage_write_container::set_attribute does not accept any attributes for a container named " +
+    name_);
 }

--- a/form/storage/storage_write_container.hpp
+++ b/form/storage/storage_write_container.hpp
@@ -10,24 +10,24 @@
 
 namespace form::detail::experimental {
 
-  class Storage_Write_Container : public IStorage_Write_Container {
+  class storage_write_container : public i_storage_write_container {
   public:
-    explicit Storage_Write_Container(std::string name);
-    ~Storage_Write_Container() override = default;
+    explicit storage_write_container(std::string name);
+    ~storage_write_container() override = default;
 
     std::string const& name() override;
 
-    void setFile(std::shared_ptr<IStorage_File> file) override;
+    void set_file(std::shared_ptr<i_storage_file> file) override;
 
-    void setupWrite(std::type_info const& type = typeid(void)) override;
+    void setup_write(std::type_info const& type = typeid(void)) override;
     std::uint64_t fill(void const* data) override;
     void commit() override;
 
-    void setAttribute(std::string const& name, std::string const& value) override;
+    void set_attribute(std::string const& name, std::string const& value) override;
 
   private:
-    std::string m_name;
-    std::shared_ptr<IStorage_File> m_file;
+    std::string name_;
+    std::shared_ptr<i_storage_file> file_;
   };
 } // namespace form::detail::experimental
 

--- a/form/storage/storage_writer.cpp
+++ b/form/storage/storage_writer.cpp
@@ -12,7 +12,7 @@ using namespace form::detail::experimental;
 namespace {
   form::experimental::config::tech_setting_config::table_t get_file_table(
     form::experimental::config::tech_setting_config const& settings,
-    form::technology::Id technology,
+    form::technology::id technology,
     std::string const& file_name)
   {
     auto const per_tech = settings.file_settings.find(technology);
@@ -28,7 +28,7 @@ namespace {
 
   form::experimental::config::tech_setting_config::table_t get_container_table(
     form::experimental::config::tech_setting_config const& settings,
-    form::technology::Id technology,
+    form::technology::id technology,
     std::string const& container_name)
   {
     auto const per_tech = settings.container_settings.find(technology);
@@ -45,82 +45,82 @@ namespace {
 
 // Factory function implementation
 namespace form::detail::experimental {
-  std::unique_ptr<IStorageWriter> createStorageWriter()
+  std::unique_ptr<i_storage_writer> create_storage_writer()
   {
-    return std::unique_ptr<IStorageWriter>(new StorageWriter());
+    return std::unique_ptr<i_storage_writer>(new storage_writer());
   }
 }
 
-void StorageWriter::createContainers(
-  std::map<std::unique_ptr<Placement>, std::type_info const*> const& containers,
+void storage_writer::create_containers(
+  std::map<std::unique_ptr<placement>, std::type_info const*> const& containers,
   form::experimental::config::tech_setting_config const& settings)
 {
   for (auto const& [plcmnt, type] : containers) {
     // Use file+container as composite key
-    auto contKey = std::make_pair(plcmnt->fileName(), plcmnt->containerName());
-    auto cont = m_write_containers.find(contKey);
-    if (cont == m_write_containers.end()) {
+    auto cont_key = std::make_pair(plcmnt->file_name(), plcmnt->container_name());
+    auto cont = write_containers_.find(cont_key);
+    if (cont == write_containers_.end()) {
       // Ensure the file exists
-      auto file = m_files.find(plcmnt->fileName());
-      if (file == m_files.end()) {
-        file =
-          m_files
-            .insert({plcmnt->fileName(), createFile(plcmnt->technology(), plcmnt->fileName(), 'o')})
-            .first;
+      auto file = files_.find(plcmnt->file_name());
+      if (file == files_.end()) {
+        file = files_
+                 .insert({plcmnt->file_name(),
+                          create_file(plcmnt->technology(), plcmnt->file_name(), 'o')})
+                 .first;
         for (auto const& [key, value] :
-             get_file_table(settings, plcmnt->technology(), plcmnt->fileName())) {
-          file->second->setAttribute(key, value);
+             get_file_table(settings, plcmnt->technology(), plcmnt->file_name())) {
+          file->second->set_attribute(key, value);
         }
       }
       // Create and bind container to file
-      auto container = createWriteContainer(plcmnt->technology(), plcmnt->containerName());
-      m_write_containers.insert({contKey, container});
+      auto container = create_write_container(plcmnt->technology(), plcmnt->container_name());
+      write_containers_.insert({cont_key, container});
       // For associative container, create association layer
       auto associative_container =
-        dynamic_pointer_cast<Storage_Associative_Write_Container>(container);
+        dynamic_pointer_cast<storage_associative_write_container>(container);
       if (associative_container) {
-        auto parent_key = std::make_pair(plcmnt->fileName(), associative_container->top_name());
-        auto parent = m_write_containers.find(parent_key);
-        if (parent == m_write_containers.end()) {
+        auto parent_key = std::make_pair(plcmnt->file_name(), associative_container->top_name());
+        auto parent = write_containers_.find(parent_key);
+        if (parent == write_containers_.end()) {
           auto parent_cont =
-            createWriteAssociation(plcmnt->technology(), associative_container->top_name());
-          m_write_containers.insert({parent_key, parent_cont});
-          parent_cont->setFile(file->second);
-          parent_cont->setupWrite();
-          associative_container->setParent(parent_cont);
+            create_write_association(plcmnt->technology(), associative_container->top_name());
+          write_containers_.insert({parent_key, parent_cont});
+          parent_cont->set_file(file->second);
+          parent_cont->setup_write();
+          associative_container->set_parent(parent_cont);
         } else {
-          associative_container->setParent(parent->second);
+          associative_container->set_parent(parent->second);
         }
       }
 
       for (auto const& [key, value] :
-           get_container_table(settings, plcmnt->technology(), plcmnt->containerName())) {
-        container->setAttribute(key, value);
+           get_container_table(settings, plcmnt->technology(), plcmnt->container_name())) {
+        container->set_attribute(key, value);
       }
-      container->setFile(file->second);
-      container->setupWrite(*type);
+      container->set_file(file->second);
+      container->setup_write(*type);
     }
   }
 }
 
-std::uint64_t StorageWriter::fillContainer(Placement const& plcmnt,
-                                           void const* data,
-                                           std::type_info const& /* type*/)
+std::uint64_t storage_writer::fill_container(placement const& plcmnt,
+                                             void const* data,
+                                             std::type_info const& /* type*/)
 {
   // Use file+container as composite key
-  auto contKey = std::make_pair(plcmnt.fileName(), plcmnt.containerName());
-  auto cont = m_write_containers.find(contKey);
-  if (cont == m_write_containers.end()) {
+  auto cont_key = std::make_pair(plcmnt.file_name(), plcmnt.container_name());
+  auto cont = write_containers_.find(cont_key);
+  if (cont == write_containers_.end()) {
     // FIXME: For now throw an exception here, but in future, we may have storage technology do that.
-    throw std::runtime_error("StorageWriter::fillContainer Container doesn't exist: " +
-                             plcmnt.containerName());
+    throw std::runtime_error("storage_writer::fill_container Container doesn't exist: " +
+                             plcmnt.container_name());
   }
   return cont->second->fill(data);
 }
 
-void StorageWriter::commitContainers(Placement const& plcmnt)
+void storage_writer::commit_containers(placement const& plcmnt)
 {
-  auto contKey = std::make_pair(plcmnt.fileName(), plcmnt.containerName());
-  auto cont = m_write_containers.find(contKey);
+  auto cont_key = std::make_pair(plcmnt.file_name(), plcmnt.container_name());
+  auto cont = write_containers_.find(cont_key);
   cont->second->commit();
 }

--- a/form/storage/storage_writer.hpp
+++ b/form/storage/storage_writer.hpp
@@ -14,27 +14,27 @@
 
 namespace form::detail::experimental {
 
-  class StorageWriter : public IStorageWriter {
+  class storage_writer : public i_storage_writer {
   public:
-    StorageWriter() = default;
-    ~StorageWriter() override = default;
+    storage_writer() = default;
+    ~storage_writer() override = default;
 
     using table_t = form::experimental::config::tech_setting_config::table_t;
-    void createContainers(
-      std::map<std::unique_ptr<Placement>, std::type_info const*> const& containers,
+    void create_containers(
+      std::map<std::unique_ptr<placement>, std::type_info const*> const& containers,
       form::experimental::config::tech_setting_config const& settings) override;
-    std::uint64_t fillContainer(Placement const& plcmnt,
-                                void const* data,
-                                std::type_info const& type) override;
-    void commitContainers(Placement const& plcmnt) override;
+    std::uint64_t fill_container(placement const& plcmnt,
+                                 void const* data,
+                                 std::type_info const& type) override;
+    void commit_containers(placement const& plcmnt) override;
 
   private:
-    std::map<std::string, std::shared_ptr<IStorage_File>> m_files;
+    std::map<std::string, std::shared_ptr<i_storage_file>> files_;
     std::unordered_map<std::pair<std::string, std::string>,
-                       std::shared_ptr<IStorage_Write_Container>,
+                       std::shared_ptr<i_storage_write_container>,
                        pair_hash>
-      m_write_containers;
-    std::map<std::string, std::map<std::string, int>> m_indexMaps;
+      write_containers_;
+    std::map<std::string, std::map<std::string, int>> index_maps_;
   };
 
 } // namespace form::detail::experimental

--- a/test/form/data_products/LinkDef.h
+++ b/test/form/data_products/LinkDef.h
@@ -1,4 +1,4 @@
 #ifdef __CLING__
-#pragma link C++ class TrackStart + ;
-#pragma link C++ class std::vector < TrackStart> + ;
+#pragma link C++ class track_start + ;
+#pragma link C++ class std::vector < track_start> + ;
 #endif

--- a/test/form/data_products/classes_def.xml
+++ b/test/form/data_products/classes_def.xml
@@ -1,4 +1,4 @@
 <lcgdict>
-  <class name="TrackStart"/>
-  <class name="std::vector<TrackStart>"/>
+  <class name="track_start"/>
+  <class name="std::vector<track_start>"/>
 </lcgdict>

--- a/test/form/data_products/extra_member/classes_def.xml
+++ b/test/form/data_products/extra_member/classes_def.xml
@@ -1,4 +1,4 @@
 <lcgdict>
-  <class name="TrackStart"/>
-  <class name="std::vector<TrackStart>"/>
+  <class name="track_start"/>
+  <class name="std::vector<track_start>"/>
 </lcgdict>

--- a/test/form/data_products/extra_member/track_start.cpp
+++ b/test/form/data_products/extra_member/track_start.cpp
@@ -1,49 +1,48 @@
 #include "track_start.hpp"
 
-TrackStart::TrackStart() : m_x(0), m_y(0), m_z(0), m_index(0) {}
+track_start::track_start() : x_(0), y_(0), z_(0), index_(0) {}
 
-TrackStart::TrackStart(float x, float y, float z, int index) :
-  m_x(x), m_y(y), m_z(z), m_index(index)
+track_start::track_start(float x, float y, float z, int index) : x_(x), y_(y), z_(z), index_(index)
 {
 }
 
-float TrackStart::getX() const { return m_x; }
+float track_start::get_x() const { return x_; }
 
-float TrackStart::getY() const { return m_y; }
+float track_start::get_y() const { return y_; }
 
-float TrackStart::getZ() const { return m_z; }
+float track_start::get_z() const { return z_; }
 
-int TrackStart::getIndex() const { return m_index; }
+int track_start::get_index() const { return index_; }
 
-void TrackStart::setX(float x) { m_x = x; }
+void track_start::set_x(float x) { x_ = x; }
 
-void TrackStart::setY(float y) { m_y = y; }
+void track_start::set_y(float y) { y_ = y; }
 
-void TrackStart::setZ(float z) { m_z = z; }
+void track_start::set_z(float z) { z_ = z; }
 
-void TrackStart::setIndex(int index) { m_index = index; }
+void track_start::set_index(int index) { index_ = index; }
 
-TrackStart TrackStart::operator+(TrackStart const& other) const
+track_start track_start::operator+(track_start const& other) const
 {
-  return {m_x + other.m_x, m_y + other.m_y, m_z + other.m_z, m_index + other.m_index};
+  return {x_ + other.x_, y_ + other.y_, z_ + other.z_, index_ + other.index_};
 }
 
-TrackStart& TrackStart::operator+=(TrackStart const& other)
+track_start& track_start::operator+=(track_start const& other)
 {
-  m_x += other.m_x;
-  m_y += other.m_y;
-  m_z += other.m_z;
-  m_index += other.m_index;
+  x_ += other.x_;
+  y_ += other.y_;
+  z_ += other.z_;
+  index_ += other.index_;
   return *this;
 }
 
-TrackStart TrackStart::operator-(TrackStart const& other) const
+track_start track_start::operator-(track_start const& other) const
 {
-  return {m_x - other.m_x, m_y - other.m_y, m_z - other.m_z, m_index - other.m_index};
+  return {x_ - other.x_, y_ - other.y_, z_ - other.z_, index_ - other.index_};
 }
 
-std::ostream& operator<<(std::ostream& os, TrackStart const& track)
+std::ostream& operator<<(std::ostream& os, track_start const& track)
 {
-  os << "TrackStart{" << track.getX() << ", " << track.getY() << ", " << track.getZ() << "}";
+  os << "track_start{" << track.get_x() << ", " << track.get_y() << ", " << track.get_z() << "}";
   return os;
 }

--- a/test/form/data_products/extra_member/track_start.hpp
+++ b/test/form/data_products/extra_member/track_start.hpp
@@ -1,4 +1,4 @@
-//A TrackStart is a 3-vector of position components.
+//A track_start is a 3-vector of position components.
 //This is a simple test data product for demonstrating the features of FORM.
 
 #include <iostream>
@@ -6,34 +6,34 @@
 #ifndef TEST_FORM_DATA_PRODUCTS_EXTRA_MEMBER_TRACK_START_HPP
 #define TEST_FORM_DATA_PRODUCTS_EXTRA_MEMBER_TRACK_START_HPP
 
-class TrackStart {
+class track_start {
 public:
-  TrackStart();
-  TrackStart(float x, float y, float z, int index);
-  ~TrackStart() = default;
+  track_start();
+  track_start(float x, float y, float z, int index);
+  ~track_start() = default;
 
-  float getX() const;
-  float getY() const;
-  float getZ() const;
-  int getIndex() const;
+  float get_x() const;
+  float get_y() const;
+  float get_z() const;
+  int get_index() const;
 
-  void setX(float x);
-  void setY(float y);
-  void setZ(float z);
-  void setIndex(int index);
+  void set_x(float x);
+  void set_y(float y);
+  void set_z(float z);
+  void set_index(int index);
 
-  TrackStart operator+(TrackStart const& other) const;
-  TrackStart& operator+=(TrackStart const& other);
-  TrackStart operator-(TrackStart const& other) const;
+  track_start operator+(track_start const& other) const;
+  track_start& operator+=(track_start const& other);
+  track_start operator-(track_start const& other) const;
 
 private:
-  float m_x;
-  float m_y;
-  float m_z;
+  float x_;
+  float y_;
+  float z_;
 
-  int m_index;
+  int index_;
 };
 
-std::ostream& operator<<(std::ostream& os, TrackStart const& track);
+std::ostream& operator<<(std::ostream& os, track_start const& track);
 
 #endif // TEST_FORM_DATA_PRODUCTS_EXTRA_MEMBER_TRACK_START_HPP

--- a/test/form/data_products/track_start.cpp
+++ b/test/form/data_products/track_start.cpp
@@ -1,35 +1,35 @@
 #include "track_start.hpp"
 
-TrackStart::TrackStart() : m_x(0), m_y(0), m_z(0) {}
+track_start::track_start() : x_(0), y_(0), z_(0) {}
 
-TrackStart::TrackStart(float x, float y, float z) : m_x(x), m_y(y), m_z(z) {}
+track_start::track_start(float x, float y, float z) : x_(x), y_(y), z_(z) {}
 
-float TrackStart::getX() const { return m_x; }
+float track_start::get_x() const { return x_; }
 
-float TrackStart::getY() const { return m_y; }
+float track_start::get_y() const { return y_; }
 
-float TrackStart::getZ() const { return m_z; }
+float track_start::get_z() const { return z_; }
 
-TrackStart TrackStart::operator+(TrackStart const& other) const
+track_start track_start::operator+(track_start const& other) const
 {
-  return {m_x + other.m_x, m_y + other.m_y, m_z + other.m_z};
+  return {x_ + other.x_, y_ + other.y_, z_ + other.z_};
 }
 
-TrackStart& TrackStart::operator+=(TrackStart const& other)
+track_start& track_start::operator+=(track_start const& other)
 {
-  m_x += other.m_x;
-  m_y += other.m_y;
-  m_z += other.m_z;
+  x_ += other.x_;
+  y_ += other.y_;
+  z_ += other.z_;
   return *this;
 }
 
-TrackStart TrackStart::operator-(TrackStart const& other) const
+track_start track_start::operator-(track_start const& other) const
 {
-  return {m_x - other.m_x, m_y - other.m_y, m_z - other.m_z};
+  return {x_ - other.x_, y_ - other.y_, z_ - other.z_};
 }
 
-std::ostream& operator<<(std::ostream& os, TrackStart const& track)
+std::ostream& operator<<(std::ostream& os, track_start const& track)
 {
-  os << "TrackStart{" << track.getX() << ", " << track.getY() << ", " << track.getZ() << "}";
+  os << "track_start{" << track.get_x() << ", " << track.get_y() << ", " << track.get_z() << "}";
   return os;
 }

--- a/test/form/data_products/track_start.hpp
+++ b/test/form/data_products/track_start.hpp
@@ -1,4 +1,4 @@
-//A TrackStart is a 3-vector of position components.
+//A track_start is a 3-vector of position components.
 //This is a simple test data product for demonstrating the features of FORM.
 
 #include <iostream>
@@ -6,26 +6,26 @@
 #ifndef TEST_FORM_DATA_PRODUCTS_TRACK_START_HPP
 #define TEST_FORM_DATA_PRODUCTS_TRACK_START_HPP
 
-class TrackStart {
+class track_start {
 public:
-  TrackStart();
-  TrackStart(float x, float y, float z);
-  ~TrackStart() = default;
+  track_start();
+  track_start(float x, float y, float z);
+  ~track_start() = default;
 
-  float getX() const;
-  float getY() const;
-  float getZ() const;
+  float get_x() const;
+  float get_y() const;
+  float get_z() const;
 
-  TrackStart operator+(TrackStart const& other) const;
-  TrackStart& operator+=(TrackStart const& other);
-  TrackStart operator-(TrackStart const& other) const;
+  track_start operator+(track_start const& other) const;
+  track_start& operator+=(track_start const& other);
+  track_start operator-(track_start const& other) const;
 
 private:
-  float m_x;
-  float m_y;
-  float m_z;
+  float x_;
+  float y_;
+  float z_;
 };
 
-std::ostream& operator<<(std::ostream& os, TrackStart const& track);
+std::ostream& operator<<(std::ostream& os, track_start const& track);
 
 #endif // TEST_FORM_DATA_PRODUCTS_TRACK_START_HPP

--- a/test/form/form_basics_test.cpp
+++ b/test/form/form_basics_test.cpp
@@ -31,296 +31,299 @@
 
 using namespace form::detail::experimental;
 
-TEST_CASE("Token default constructor", "[form]")
+TEST_CASE("token default constructor", "[form]")
 {
-  Token t;
-  CHECK(t.fileName().empty());
-  CHECK(t.containerName().empty());
-  CHECK(t.technology() == form::technology::Id{});
+  token t;
+  CHECK(t.file_name().empty());
+  CHECK(t.container_name().empty());
+  CHECK(t.technology() == form::technology::id{});
   // Default-constructed token has no id set
-  CHECK_FALSE(t.hasId());
+  CHECK_FALSE(t.has_id());
 }
 
-TEST_CASE("Token basics", "[form]")
+TEST_CASE("token basics", "[form]")
 {
-  Token t("file.root", "container", form::technology::ROOT_TTREE, 42);
-  CHECK(t.fileName() == "file.root");
-  CHECK(t.containerName() == "container");
-  CHECK(t.technology() == form::technology::ROOT_TTREE);
-  CHECK(t.hasId());
+  token t("file.root", "container", form::technology::root_ttree, 42);
+  CHECK(t.file_name() == "file.root");
+  CHECK(t.container_name() == "container");
+  CHECK(t.technology() == form::technology::root_ttree);
+  CHECK(t.has_id());
   CHECK(t.id() == 42u);
 }
 
-TEST_CASE("technology::Id string conversions", "[form]")
+TEST_CASE("technology::id string conversions", "[form]")
 {
   using namespace form::technology;
 
   // Round-trip the implemented backends through from_string / to_string
-  CHECK(from_string("ROOT_TTREE") == ROOT_TTREE);
-  CHECK(from_string("ROOT_RNTUPLE") == ROOT_RNTUPLE);
+  CHECK(from_string("ROOT_TTREE") == root_ttree);
+  CHECK(from_string("ROOT_RNTUPLE") == root_rntuple);
 
-  CHECK(to_string(ROOT_TTREE) == "ROOT_TTREE");
-  CHECK(to_string(ROOT_RNTUPLE) == "ROOT_RNTUPLE");
-  CHECK(to_string(HDF5) == "HDF5"); // reserved: still names itself for diagnostics
+  CHECK(to_string(root_ttree) == "ROOT_TTREE");
+  CHECK(to_string(root_rntuple) == "ROOT_RNTUPLE");
+  CHECK(to_string(hdf5) == "HDF5"); // reserved: still names itself for diagnostics
 
   // HDF5 is reserved but unimplemented: reject it at parse time rather than
   // silently falling back to a different storage.
   CHECK_THROWS_AS(from_string("HDF5"), std::runtime_error);
 
-  // An unknown name throws; an unknown Id stringifies to the sentinel
+  // An unknown name throws; an unknown id stringifies to the sentinel
   CHECK_THROWS_AS(from_string("NOT_A_TECH"), std::runtime_error);
-  CHECK(to_string(Id{}) == "UNKNOWN");
+  CHECK(to_string(id{}) == "UNKNOWN");
 }
 
-TEST_CASE("technology::Id members and ordering", "[form]")
+TEST_CASE("technology::id members and ordering", "[form]")
 {
   using namespace form::technology;
 
   // (major, minor) decomposition
-  CHECK(ROOT_TTREE.major == Major::root);
-  CHECK(ROOT_TTREE.minor == 1);
-  CHECK(ROOT_RNTUPLE.major == Major::root);
-  CHECK(ROOT_RNTUPLE.minor == 2);
-  CHECK(HDF5.major == Major::hdf5);
-  CHECK(Id{}.major == Major::generic);
+  CHECK(root_ttree.major == major::root);
+  CHECK(root_ttree.minor == 1);
+  CHECK(root_rntuple.major == major::root);
+  CHECK(root_rntuple.minor == 2);
+  CHECK(hdf5.major == major::hdf5);
+  CHECK(id{}.major == major::generic);
 
   // operator<=> compares BOTH parts: same major, different minor stay distinct
-  CHECK(ROOT_TTREE != ROOT_RNTUPLE);
-  CHECK(ROOT_TTREE < ROOT_RNTUPLE);
-  CHECK(Id{} == Id{Major::generic, 0});
+  CHECK(root_ttree != root_rntuple);
+  CHECK(root_ttree < root_rntuple);
+  CHECK(id{} == id{major::generic, 0});
 }
 
-TEST_CASE("Storage_File basics", "[form]")
+TEST_CASE("storage_file basics", "[form]")
 {
-  Storage_File f("test.root", 'o');
+  storage_file f("test.root", 'o');
   CHECK(f.name() == "test.root");
   CHECK(f.mode() == 'o');
-  CHECK_THROWS_AS(f.setAttribute("key", "value"), std::runtime_error);
+  CHECK_THROWS_AS(f.set_attribute("key", "value"), std::runtime_error);
 }
 
-TEST_CASE("Storage_Read_Container basics", "[form]")
+TEST_CASE("storage_read_container basics", "[form]")
 {
-  Storage_Read_Container c("my_container");
+  storage_read_container c("my_container");
   CHECK(c.name() == "my_container");
 
-  auto f = std::make_shared<Storage_File>("test.root", 'o');
-  c.setFile(f);
+  auto f = std::make_shared<storage_file>("test.root", 'o');
+  c.set_file(f);
 
   void const* data = nullptr;
   CHECK_FALSE(c.read(1, &data, typeid(int)));
   c.prime(typeid(int));
   CHECK(c.entries() == 0);
 
-  CHECK_THROWS_AS(c.setAttribute("key", "value"), std::runtime_error);
+  CHECK_THROWS_AS(c.set_attribute("key", "value"), std::runtime_error);
 
   SECTION("With slash")
   {
-    Storage_Read_Container c("parent/child");
+    storage_read_container c("parent/child");
     CHECK(c.top_name() == "parent");
     CHECK(c.col_name() == "child");
   }
   SECTION("Without slash")
   {
-    Storage_Read_Container c("no_slash");
+    storage_read_container c("no_slash");
     CHECK(c.top_name() == "no_slash");
     CHECK(c.col_name() == "Main");
   }
 }
 
-TEST_CASE("Storage_Write_Container basics", "[form]")
+TEST_CASE("storage_write_container basics", "[form]")
 {
-  Storage_Write_Container c("my_container");
+  storage_write_container c("my_container");
   CHECK(c.name() == "my_container");
 
-  auto f = std::make_shared<Storage_File>("test.root", 'o');
-  c.setFile(f);
+  auto f = std::make_shared<storage_file>("test.root", 'o');
+  c.set_file(f);
 
-  c.setupWrite(typeid(int));
+  c.setup_write(typeid(int));
   int value = 0;
   c.fill(&value);
   c.commit();
 
-  CHECK_THROWS_AS(c.setAttribute("key", "value"), std::runtime_error);
+  CHECK_THROWS_AS(c.set_attribute("key", "value"), std::runtime_error);
 }
 
-TEST_CASE("Storage_Write_Association basics", "[form]")
+TEST_CASE("storage_write_association basics", "[form]")
 {
-  Storage_Write_Association a("my_assoc/extra");
+  storage_write_association a("my_assoc/extra");
   CHECK(a.name() == "my_assoc"); // maybe_remove_suffix should remove /extra
 
-  a.setAttribute("key", "value"); // Storage_Write_Association overrides setAttribute to do nothing
+  a.set_attribute("key",
+                  "value"); // storage_write_association overrides set_attribute to do nothing
 }
 
-TEST_CASE("Storage_Associative_Write_Container basics", "[form]")
+TEST_CASE("storage_associative_write_container basics", "[form]")
 {
   SECTION("With slash")
   {
-    Storage_Associative_Write_Container c("parent/child");
+    storage_associative_write_container c("parent/child");
     CHECK(c.top_name() == "parent");
     CHECK(c.col_name() == "child");
   }
   SECTION("Without slash")
   {
-    Storage_Associative_Write_Container c("no_slash");
+    storage_associative_write_container c("no_slash");
     CHECK(c.top_name() == "no_slash");
     CHECK(c.col_name() == "Main");
   }
 
-  Storage_Associative_Write_Container c("p/c");
-  auto parent = std::make_shared<Storage_Write_Container>("p");
-  c.setParent(parent);
+  storage_associative_write_container c("p/c");
+  auto parent = std::make_shared<storage_write_container>("p");
+  c.set_parent(parent);
 }
 
 TEST_CASE("Factories fallback", "[form]")
 {
-  auto f = createFile(form::technology::Id{}, "test.root", 'o');
-  CHECK(dynamic_cast<Storage_File*>(f.get()) != nullptr);
+  auto f = create_file(form::technology::id{}, "test.root", 'o');
+  CHECK(dynamic_cast<storage_file*>(f.get()) != nullptr);
 
-  auto rc = createReadContainer(form::technology::Id{}, "cont");
-  CHECK(dynamic_cast<Storage_Read_Container*>(rc.get()) != nullptr);
+  auto rc = create_read_container(form::technology::id{}, "cont");
+  CHECK(dynamic_cast<storage_read_container*>(rc.get()) != nullptr);
 
-  auto wa = createWriteAssociation(form::technology::Id{}, "assoc");
-  CHECK(dynamic_cast<Storage_Write_Association*>(wa.get()) != nullptr);
+  auto wa = create_write_association(form::technology::id{}, "assoc");
+  CHECK(dynamic_cast<storage_write_association*>(wa.get()) != nullptr);
 
-  auto wc = createWriteContainer(form::technology::Id{}, "cont");
-  CHECK(dynamic_cast<Storage_Write_Container*>(wc.get()) != nullptr);
+  auto wc = create_write_container(form::technology::id{}, "cont");
+  CHECK(dynamic_cast<storage_write_container*>(wc.get()) != nullptr);
 
   // HDF5 is reserved but unimplemented: every factory must fail loudly on the
   // hdf5 dispatch branch rather than silently return generic storage.
-  CHECK_THROWS_AS(createFile(form::technology::HDF5, "test.h5", 'o'), std::runtime_error);
-  CHECK_THROWS_AS(createReadContainer(form::technology::HDF5, "cont"), std::runtime_error);
-  CHECK_THROWS_AS(createWriteAssociation(form::technology::HDF5, "assoc"), std::runtime_error);
-  CHECK_THROWS_AS(createWriteContainer(form::technology::HDF5, "cont"), std::runtime_error);
+  CHECK_THROWS_AS(create_file(form::technology::hdf5, "test.h5", 'o'), std::runtime_error);
+  CHECK_THROWS_AS(create_read_container(form::technology::hdf5, "cont"), std::runtime_error);
+  CHECK_THROWS_AS(create_write_association(form::technology::hdf5, "assoc"), std::runtime_error);
+  CHECK_THROWS_AS(create_write_container(form::technology::hdf5, "cont"), std::runtime_error);
 
   // A major FORM doesn't recognize at all must also fail loudly
-  // Major has a fixed underlying type, so an out-of-range value is legal at runtime
+  // major has a fixed underlying type, so an out-of-range value is legal at runtime
   auto const unknown_major =
     // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
-    form::technology::Id{.major = static_cast<form::technology::Major>(99), .minor = 0};
-  CHECK_THROWS_AS(createFile(unknown_major, "test.dat", 'o'), std::runtime_error);
-  CHECK_THROWS_AS(createReadContainer(unknown_major, "cont"), std::runtime_error);
-  CHECK_THROWS_AS(createWriteAssociation(unknown_major, "assoc"), std::runtime_error);
-  CHECK_THROWS_AS(createWriteContainer(unknown_major, "cont"), std::runtime_error);
+    form::technology::id{.major = static_cast<form::technology::major>(99), .minor = 0};
+  CHECK_THROWS_AS(create_file(unknown_major, "test.dat", 'o'), std::runtime_error);
+  CHECK_THROWS_AS(create_read_container(unknown_major, "cont"), std::runtime_error);
+  CHECK_THROWS_AS(create_write_association(unknown_major, "assoc"), std::runtime_error);
+  CHECK_THROWS_AS(create_write_container(unknown_major, "cont"), std::runtime_error);
 }
 
 TEST_CASE("Factories ROOT storage dispatch", "[form]")
 {
 #ifdef USE_ROOT_STORAGE
-  auto rc_ttree = createReadContainer(form::technology::ROOT_TTREE, "cont");
-  CHECK(dynamic_cast<ROOT_TBranch_Read_ContainerImp*>(rc_ttree.get()) != nullptr);
+  auto rc_ttree = create_read_container(form::technology::root_ttree, "cont");
+  CHECK(dynamic_cast<root_tbranch_read_container_imp*>(rc_ttree.get()) != nullptr);
 
-  auto wa_ttree = createWriteAssociation(form::technology::ROOT_TTREE, "assoc");
-  CHECK(dynamic_cast<ROOT_TTree_Write_ContainerImp*>(wa_ttree.get()) != nullptr);
+  auto wa_ttree = create_write_association(form::technology::root_ttree, "assoc");
+  CHECK(dynamic_cast<root_ttree_write_container_imp*>(wa_ttree.get()) != nullptr);
 
-  auto wc_ttree = createWriteContainer(form::technology::ROOT_TTREE, "cont");
-  CHECK(dynamic_cast<ROOT_TBranch_Write_ContainerImp*>(wc_ttree.get()) != nullptr);
+  auto wc_ttree = create_write_container(form::technology::root_ttree, "cont");
+  CHECK(dynamic_cast<root_tbranch_write_container_imp*>(wc_ttree.get()) != nullptr);
 
   auto const unsupported_root =
-    form::technology::Id{.major = form::technology::Major::root, .minor = 99};
-  CHECK_THROWS_AS(createReadContainer(unsupported_root, "cont"), std::runtime_error);
-  CHECK_THROWS_AS(createWriteAssociation(unsupported_root, "assoc"), std::runtime_error);
-  CHECK_THROWS_AS(createWriteContainer(unsupported_root, "cont"), std::runtime_error);
+    form::technology::id{.major = form::technology::major::root, .minor = 99};
+  CHECK_THROWS_AS(create_read_container(unsupported_root, "cont"), std::runtime_error);
+  CHECK_THROWS_AS(create_write_association(unsupported_root, "assoc"), std::runtime_error);
+  CHECK_THROWS_AS(create_write_container(unsupported_root, "cont"), std::runtime_error);
 #else
-  CHECK_THROWS_AS(createReadContainer(form::technology::ROOT_TTREE, "cont"), std::runtime_error);
-  CHECK_THROWS_AS(createWriteAssociation(form::technology::ROOT_TTREE, "assoc"),
+  CHECK_THROWS_AS(create_read_container(form::technology::root_ttree, "cont"), std::runtime_error);
+  CHECK_THROWS_AS(create_write_association(form::technology::root_ttree, "assoc"),
                   std::runtime_error);
-  CHECK_THROWS_AS(createWriteContainer(form::technology::ROOT_TTREE, "cont"), std::runtime_error);
+  CHECK_THROWS_AS(create_write_container(form::technology::root_ttree, "cont"), std::runtime_error);
 #endif
 }
 
 TEST_CASE("Factories RNTuple storage dispatch", "[form]")
 {
 #ifdef USE_RNTUPLE_STORAGE
-  auto rc_rntuple = createReadContainer(form::technology::ROOT_RNTUPLE, "cont");
-  CHECK(dynamic_cast<ROOT_RField_Read_ContainerImp*>(rc_rntuple.get()) != nullptr);
+  auto rc_rntuple = create_read_container(form::technology::root_rntuple, "cont");
+  CHECK(dynamic_cast<root_rfield_read_container_imp*>(rc_rntuple.get()) != nullptr);
 
-  auto wa_rntuple = createWriteAssociation(form::technology::ROOT_RNTUPLE, "assoc");
-  CHECK(dynamic_cast<ROOT_RNTuple_Write_ContainerImp*>(wa_rntuple.get()) != nullptr);
+  auto wa_rntuple = create_write_association(form::technology::root_rntuple, "assoc");
+  CHECK(dynamic_cast<root_rntuple_write_container_imp*>(wa_rntuple.get()) != nullptr);
 
-  auto wc_rntuple = createWriteContainer(form::technology::ROOT_RNTUPLE, "cont");
-  CHECK(dynamic_cast<ROOT_RField_Write_ContainerImp*>(wc_rntuple.get()) != nullptr);
+  auto wc_rntuple = create_write_container(form::technology::root_rntuple, "cont");
+  CHECK(dynamic_cast<root_rfield_write_container_imp*>(wc_rntuple.get()) != nullptr);
 #else
-  CHECK_THROWS_AS(createReadContainer(form::technology::ROOT_RNTUPLE, "cont"), std::runtime_error);
-  CHECK_THROWS_AS(createWriteAssociation(form::technology::ROOT_RNTUPLE, "assoc"),
+  CHECK_THROWS_AS(create_read_container(form::technology::root_rntuple, "cont"),
                   std::runtime_error);
-  CHECK_THROWS_AS(createWriteContainer(form::technology::ROOT_RNTUPLE, "cont"), std::runtime_error);
+  CHECK_THROWS_AS(create_write_association(form::technology::root_rntuple, "assoc"),
+                  std::runtime_error);
+  CHECK_THROWS_AS(create_write_container(form::technology::root_rntuple, "cont"),
+                  std::runtime_error);
 #endif
 }
 
-TEST_CASE("StorageReader basic operations", "[form]")
+TEST_CASE("storage_reader basic operations", "[form]")
 {
-  auto storage = createStorageReader();
+  auto storage = create_storage_reader();
   REQUIRE(storage != nullptr);
 
   form::experimental::config::tech_setting_config settings;
 
-  Token token("file.root", "cont", form::technology::Id{}, 1);
+  token product_token("file.root", "cont", form::technology::id{}, 1);
   void const* read_data = nullptr;
-  storage->readContainer(token, &read_data, typeid(int), settings);
+  storage->read_container(product_token, &read_data, typeid(int), settings);
 
-  int index = storage->getIndex(token, "some_id", settings);
+  int index = storage->get_index(product_token, "some_id", settings);
   CHECK(index == 0);
 }
 
-TEST_CASE("StorageWriter basic operations", "[form]")
+TEST_CASE("storage_writer basic operations", "[form]")
 {
-  auto storage = createStorageWriter();
+  auto storage = create_storage_writer();
   REQUIRE(storage != nullptr);
 
   form::experimental::config::tech_setting_config settings;
 
-  std::map<std::unique_ptr<Placement>, std::type_info const*> containers;
-  auto p = std::make_unique<Placement>("file.root", "cont", form::technology::Id{});
+  std::map<std::unique_ptr<placement>, std::type_info const*> containers;
+  auto p = std::make_unique<placement>("file.root", "cont", form::technology::id{});
   containers.emplace(std::move(p), &typeid(int));
 
-  storage->createContainers(containers, settings);
+  storage->create_containers(containers, settings);
 
-  Placement p2("file.root", "cont", form::technology::Id{});
+  placement p2("file.root", "cont", form::technology::id{});
   int data = 42;
-  storage->fillContainer(p2, &data, typeid(int));
-  storage->commitContainers(p2);
+  storage->fill_container(p2, &data, typeid(int));
+  storage->commit_containers(p2);
 }
 
-TEST_CASE("PersistenceReader basic operations", "[form]")
+TEST_CASE("persistence_reader basic operations", "[form]")
 {
-  auto p = createPersistenceReader();
+  auto p = create_persistence_reader();
   REQUIRE(p != nullptr);
 
   using namespace form::experimental::config;
-  ItemConfig out_cfg;
-  out_cfg.addItem("prod", "file.root", form::technology::Id{});
-  out_cfg.addItem("parent/child", "file.root", form::technology::Id{});
+  item_config out_cfg;
+  out_cfg.add_item("prod", "file.root", form::technology::id{});
+  out_cfg.add_item("parent/child", "file.root", form::technology::id{});
   p->configure(out_cfg);
 
   tech_setting_config tech_cfg;
-  p->configureTechSettings(tech_cfg);
+  p->configure_tech_settings(tech_cfg);
 
   SECTION("Full Lifecycle")
   {
     void const* data = nullptr;
-    // This will call getToken -> getIndex (returns 0 for Storage_Container) -> readContainer
+    // This will call get_token -> get_index (returns 0 for Storage_Container) -> read_container
     CHECK_NOTHROW(p->read("my_creator", "prod", "event_1", &data, typeid(int)));
   }
 }
 
-TEST_CASE("PersistenceWriter basic operations", "[form]")
+TEST_CASE("persistence_writer basic operations", "[form]")
 {
-  auto p = createPersistenceWriter();
+  auto p = create_persistence_writer();
   REQUIRE(p != nullptr);
 
   using namespace form::experimental::config;
-  ItemConfig out_cfg;
-  out_cfg.addItem("prod", "file.root", form::technology::Id{});
-  out_cfg.addItem("parent/child", "file.root", form::technology::Id{});
+  item_config out_cfg;
+  out_cfg.add_item("prod", "file.root", form::technology::id{});
+  out_cfg.add_item("parent/child", "file.root", form::technology::id{});
   p->configure(out_cfg);
 
   tech_setting_config tech_cfg;
-  p->configureTechSettings(tech_cfg);
+  p->configure_tech_settings(tech_cfg);
 
   SECTION("Errors")
   {
     int val = 42;
-    CHECK_THROWS_AS(p->registerWrite("my_creator", "unknown", &val, typeid(int)),
+    CHECK_THROWS_AS(p->register_write("my_creator", "unknown", &val, typeid(int)),
                     std::runtime_error);
   }
 }
@@ -329,31 +332,31 @@ TEST_CASE("form::experimental::config tests", "[form]")
 {
   using namespace form::experimental::config;
 
-  SECTION("ItemConfig")
+  SECTION("item_config")
   {
-    ItemConfig cfg;
-    cfg.addItem("prod1", "file1.root", form::technology::ROOT_TTREE);
+    item_config cfg;
+    cfg.add_item("prod1", "file1.root", form::technology::root_ttree);
 
-    auto item = cfg.findItem("prod1");
+    auto item = cfg.find_item("prod1");
     REQUIRE(item);
     // NOLINTNEXTLINE(bugprone-unchecked-optional-access) -- `REQUIRE` protects against incorrect access
     CHECK(item->product_name == "prod1");
 
-    CHECK_FALSE(cfg.findItem("nonexistent").has_value());
+    CHECK_FALSE(cfg.find_item("nonexistent").has_value());
   }
 
   SECTION("tech_setting_config")
   {
     tech_setting_config cfg;
-    cfg.file_settings[form::technology::ROOT_TTREE]["file1.root"] = {{"attr", "val"}};
-    cfg.container_settings[form::technology::ROOT_TTREE]["cont1"] = {{"cattr", "cval"}};
+    cfg.file_settings[form::technology::root_ttree]["file1.root"] = {{"attr", "val"}};
+    cfg.container_settings[form::technology::root_ttree]["cont1"] = {{"cattr", "cval"}};
 
-    auto ftable = cfg.getFileTable(form::technology::ROOT_TTREE, "file1.root");
+    auto ftable = cfg.get_file_table(form::technology::root_ttree, "file1.root");
     REQUIRE(ftable.size() == 1);
     CHECK(ftable[0].first == "attr");
     CHECK(ftable[0].second == "val");
 
-    auto ctable = cfg.getContainerTable(form::technology::ROOT_TTREE, "cont1");
+    auto ctable = cfg.get_container_table(form::technology::root_ttree, "cont1");
     REQUIRE(ctable.size() == 1);
     CHECK(ctable[0].first == "cattr");
     CHECK(ctable[0].second == "cval");
@@ -362,15 +365,15 @@ TEST_CASE("form::experimental::config tests", "[form]")
 
 TEST_CASE("FORM source registry prefers exact type matches", "[form]")
 {
-  struct LocalProduct {
+  struct local_product {
     int value{};
   };
 
-  constexpr char const* local_name = "std::vector<LocalProduct>";
+  constexpr char const* local_name = "std::vector<local_product>";
 
-  form::experimental::register_form_vector_product_type<LocalProduct>(local_name);
+  form::experimental::register_form_vector_product_type<local_product>(local_name);
 
-  auto const local_type = phlex::detail::make_type_id<std::vector<LocalProduct>>();
+  auto const local_type = phlex::detail::make_type_id<std::vector<local_product>>();
   auto const* resolved_name = form::experimental::find_form_product_type_name(local_type);
 
   REQUIRE(resolved_name != nullptr);
@@ -379,7 +382,7 @@ TEST_CASE("FORM source registry prefers exact type matches", "[form]")
   auto const* entry = form::experimental::find_form_product_type(*resolved_name);
   REQUIRE(entry != nullptr);
   REQUIRE(entry->cpp_type != nullptr);
-  CHECK(*entry->cpp_type == typeid(std::vector<LocalProduct>));
+  CHECK(*entry->cpp_type == typeid(std::vector<local_product>));
 }
 
 TEST_CASE("FORM source registry keeps builtin mappings", "[form]")
@@ -391,28 +394,28 @@ TEST_CASE("FORM source registry keeps builtin mappings", "[form]")
   CHECK(*resolved_name == "std::vector<bool>");
 }
 
-TEST_CASE("PersistenceReader: throws for missing product in config", "[form]")
+TEST_CASE("persistence_reader: throws for missing product in config", "[form]")
 {
   using namespace form::experimental::config;
 
-  auto reader = form::detail::experimental::createPersistenceReader();
+  auto reader = form::detail::experimental::create_persistence_reader();
   REQUIRE(reader != nullptr);
-  reader->configure(ItemConfig{});
-  reader->configureTechSettings(tech_setting_config{});
+  reader->configure(item_config{});
+  reader->configure_tech_settings(tech_setting_config{});
 
   CHECK_THROWS_AS(reader->prime("creator", "nonexistent", typeid(int)), std::runtime_error);
-  CHECK_THROWS_AS(reader->listIndices("creator", "nonexistent"), std::runtime_error);
+  CHECK_THROWS_AS(reader->list_indices("creator", "nonexistent"), std::runtime_error);
 }
 
-TEST_CASE("form_reader_interface::indices exercises persistence listIndices path", "[form]")
+TEST_CASE("form_reader_interface::indices exercises persistence list_indices path", "[form]")
 {
   using namespace form::experimental::config;
 
-  ItemConfig cfg;
-  cfg.addItem("prod", "dummy_reader_test.root", form::technology::Id{});
+  item_config cfg;
+  cfg.add_item("prod", "dummy_reader_test.root", form::technology::id{});
   form::experimental::form_reader_interface reader{cfg, tech_setting_config{}};
 
-  // indices() calls persistence listIndices; with tech=0 the index container is
+  // indices() calls persistence list_indices; with tech=0 the index container is
   // always empty, so it throws -- but the call itself covers form_reader.cpp L48.
   CHECK_THROWS_AS(reader.indices("creator", "prod"), std::runtime_error);
 }
@@ -421,8 +424,8 @@ TEST_CASE("form_reader_interface::read throws for missing product config", "[for
 {
   using namespace form::experimental::config;
 
-  ItemConfig cfg;
-  cfg.addItem("prod", "dummy_reader_test.root", form::technology::Id{});
+  item_config cfg;
+  cfg.add_item("prod", "dummy_reader_test.root", form::technology::id{});
   form::experimental::form_reader_interface reader{cfg, tech_setting_config{}};
 
   form::experimental::product_with_name product{
@@ -434,8 +437,8 @@ TEST_CASE("form_writer_interface handles missing product config without crashing
 {
   using namespace form::experimental::config;
 
-  ItemConfig cfg;
-  cfg.addItem("prod", "dummy_writer_test.root", form::technology::Id{});
+  item_config cfg;
+  cfg.add_item("prod", "dummy_writer_test.root", form::technology::id{});
   form::experimental::form_writer_interface writer{cfg, tech_setting_config{}};
 
   form::experimental::product_with_name product{
@@ -459,8 +462,8 @@ TEST_CASE("FORM source registry: unregistered type returns nullptr", "[form]")
 {
   // find_form_product_type_name returns nullptr for a type never registered.
   // Exercises the null-return path form_source::create_providers checks at L76-77.
-  struct NeverRegistered {};
-  auto const unknown_type = phlex::detail::make_type_id<NeverRegistered>();
+  struct never_registered {};
+  auto const unknown_type = phlex::detail::make_type_id<never_registered>();
   CHECK(form::experimental::find_form_product_type_name(unknown_type) == nullptr);
 }
 

--- a/test/form/form_root_schema_read_test.cpp
+++ b/test/form/form_root_schema_read_test.cpp
@@ -14,12 +14,12 @@ int main(int const argc, char const** argv)
   std::string const tech_string = (argc > 1) ? argv[1] : "ROOT_TTREE";
 
   try {
-    auto const technology = getTechnology(tech_string);
+    auto const technology = get_technology(tech_string);
 
-    auto const& [prods] = read<std::vector<TrackStart>>(technology);
-    std::ofstream outFile("form_root_schema_read_log_" + tech_string + ".txt");
+    auto const& [prods] = read<std::vector<track_start>>(technology);
+    std::ofstream out_file("form_root_schema_read_log_" + tech_string + ".txt");
     for (auto const& prod : *prods) {
-      outFile << prod << '\n';
+      out_file << prod << '\n';
     }
   } catch (std::exception const& e) {
     std::cerr << "Exception caught in main: " << e.what() << '\n';

--- a/test/form/form_root_schema_write_test.cpp
+++ b/test/form/form_root_schema_write_test.cpp
@@ -13,14 +13,14 @@ using namespace form::test;
 int main(int const argc, char const** argv)
 {
   std::string const tech_string = (argc > 1) ? argv[1] : "ROOT_TTREE";
-  auto const technology = getTechnology(tech_string);
+  auto const technology = get_technology(tech_string);
 
-  ToyTracker tracker(4 * 1024);
-  std::vector<TrackStart> const prods = tracker();
+  toy_tracker tracker(4 * 1024);
+  std::vector<track_start> const prods = tracker();
 
-  std::ofstream outFile("form_root_schema_write_log_" + tech_string + ".txt");
+  std::ofstream out_file("form_root_schema_write_log_" + tech_string + ".txt");
   for (auto const& prod : prods) {
-    outFile << prod << '\n';
+    out_file << prod << '\n';
   }
 
   write(technology, prods);

--- a/test/form/form_storage_test.cpp
+++ b/test/form/form_storage_test.cpp
@@ -27,7 +27,7 @@ using namespace form::detail::experimental;
 
 namespace {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-  form::technology::Id technology = form::technology::ROOT_TTREE; //Potentially overridden in main
+  form::technology::id technology = form::technology::root_ttree; //Potentially overridden in main
   //Non-const global variable required by limitations of Catch2
 }
 
@@ -42,146 +42,148 @@ int main(int const argc, char** const argv)
 
   session.cli(cli);
 
-  int const returnCode = session.applyCommandLine(argc, argv);
-  if (returnCode != 0) {
-    return returnCode;
+  int const return_code = session.applyCommandLine(argc, argv);
+  if (return_code != 0) {
+    return return_code;
   }
 
-  technology = form::test::getTechnology(tech_string);
+  technology = form::test::get_technology(tech_string);
 
   return session.run();
 }
 
-TEST_CASE("Storage_Container read wrong type", "[form]")
+TEST_CASE("storage_container read wrong type", "[form]")
 {
   std::vector<int> primes = {2, 3, 5, 7, 11, 13, 17, 19};
   form::test::write(technology, primes);
 
-  auto file = createFile(technology, form::test::testFileName, 'i');
+  auto file = create_file(technology, form::test::test_file_name, 'i');
   auto container =
-    createReadContainer(technology, form::test::makeTestBranchName<std::vector<int>>());
-  container->setFile(file);
-  void const* dataPtr = nullptr;
-  CHECK_THROWS_AS(container->read(0, &dataPtr, typeid(double)), std::runtime_error);
+    create_read_container(technology, form::test::make_test_branch_name<std::vector<int>>());
+  container->set_file(file);
+  void const* data_ptr = nullptr;
+  CHECK_THROWS_AS(container->read(0, &data_ptr, typeid(double)), std::runtime_error);
 }
 
-TEST_CASE("Storage_Container sharing an Association", "[form]")
+TEST_CASE("storage_container sharing an Association", "[form]")
 {
-  std::vector<float> piData(10, std::numbers::pi_v<float>);
-  std::string indexData = "[event:1, segment:1]";
+  std::vector<float> pi_data(10, std::numbers::pi_v<float>);
+  std::string index_data = "[event:1, segment:1]";
 
-  form::test::write(technology, piData, indexData);
+  form::test::write(technology, pi_data, index_data);
 
-  auto [piResult, indexResult] = form::test::read<std::vector<float>, std::string>(technology);
+  auto [pi_result, index_result] = form::test::read<std::vector<float>, std::string>(technology);
 
-  SECTION("float container") { CHECK(*piResult == piData); }
+  SECTION("float container") { CHECK(*pi_result == pi_data); }
 
-  SECTION("index") { CHECK(*indexResult == indexData); }
+  SECTION("index") { CHECK(*index_result == index_data); }
 }
 
-TEST_CASE("Storage_Container multiple containers in Association", "[form]")
+TEST_CASE("storage_container multiple containers in Association", "[form]")
 {
-  std::vector<float> piData(10, std::numbers::pi_v<float>);
-  std::vector<int> magicData(17);
-  std::ranges::iota(magicData, 42);
-  std::string indexData = "[event:1, segment:1]";
+  std::vector<float> pi_data(10, std::numbers::pi_v<float>);
+  std::vector<int> magic_data(17);
+  std::ranges::iota(magic_data, 42);
+  std::string index_data = "[event:1, segment:1]";
 
-  form::test::write(technology, piData, magicData, indexData);
+  form::test::write(technology, pi_data, magic_data, index_data);
 
-  auto [piResult, magicResult, indexResult] =
+  auto [pi_result, magic_result, index_result] =
     form::test::read<std::vector<float>, std::vector<int>, std::string>(technology);
 
-  SECTION("float container") { CHECK(*piResult == piData); }
+  SECTION("float container") { CHECK(*pi_result == pi_data); }
 
-  SECTION("int container") { CHECK(*magicResult == magicData); }
+  SECTION("int container") { CHECK(*magic_result == magic_data); }
 
-  SECTION("index data") { CHECK(*indexResult == indexData); }
+  SECTION("index data") { CHECK(*index_result == index_data); }
 }
 
 TEST_CASE("FORM Container setup error handling")
 {
-  auto file = createFile(technology, "testContainerErrorHandling.root", 'o');
-  auto writeContainer = createWriteContainer(technology, "test/testData");
+  auto file = create_file(technology, "testContainerErrorHandling.root", 'o');
+  auto write_container = create_write_container(technology, "test/test_data");
 
-  std::vector<float> testData;
-  void const* ptrTestData = &testData;
-  auto const& typeInfo = typeid(testData);
+  std::vector<float> test_data;
+  void const* ptr_test_data = &test_data;
+  auto const& type_info = typeid(test_data);
 
-  SECTION("fill() before setupWrite()")
+  SECTION("fill() before setup_write()")
   {
-    CHECK_THROWS_AS(writeContainer->fill(ptrTestData), std::runtime_error);
+    CHECK_THROWS_AS(write_container->fill(ptr_test_data), std::runtime_error);
   }
 
-  SECTION("commit() before setupWrite()")
+  SECTION("commit() before setup_write()")
   {
-    CHECK_THROWS_AS(writeContainer->commit(), std::runtime_error);
+    CHECK_THROWS_AS(write_container->commit(), std::runtime_error);
   }
 
-  auto writeAssocContainer =
-    dynamic_pointer_cast<Storage_Associative_Write_Container>(writeContainer);
-  if (writeAssocContainer) {
-    SECTION("fill() before setParent()")
+  auto write_assoc_container =
+    dynamic_pointer_cast<storage_associative_write_container>(write_container);
+  if (write_assoc_container) {
+    SECTION("fill() before set_parent()")
     {
-      CHECK_THROWS_AS(writeContainer->setupWrite(typeInfo), std::runtime_error);
-      CHECK_THROWS_AS(writeContainer->fill(ptrTestData), std::runtime_error);
+      CHECK_THROWS_AS(write_container->setup_write(type_info), std::runtime_error);
+      CHECK_THROWS_AS(write_container->fill(ptr_test_data), std::runtime_error);
     }
 
-    SECTION("commit() before setParent()")
+    SECTION("commit() before set_parent()")
     {
-      CHECK_THROWS_AS(writeContainer->commit(), std::runtime_error);
+      CHECK_THROWS_AS(write_container->commit(), std::runtime_error);
     }
 
-    SECTION("setupWrite() before setParent()")
+    SECTION("setup_write() before set_parent()")
     {
-      CHECK_THROWS_AS(writeContainer->setupWrite(typeInfo), std::runtime_error);
+      CHECK_THROWS_AS(write_container->setup_write(type_info), std::runtime_error);
     }
 
-    auto parent = createWriteAssociation(technology, "test");
-    parent->setFile(file);
-    parent->setupWrite(typeInfo);
-    SECTION("commit() before fill() without setupWrite()")
+    auto parent = create_write_association(technology, "test");
+    parent->set_file(file);
+    parent->setup_write(type_info);
+    SECTION("commit() before fill() without setup_write()")
     {
-      writeAssocContainer->setParent(parent);
-      CHECK_THROWS_AS(writeContainer->commit(), std::runtime_error);
+      write_assoc_container->set_parent(parent);
+      CHECK_THROWS_AS(write_container->commit(), std::runtime_error);
     }
 
-    SECTION("commit() before fill() with setupWrite()")
+    SECTION("commit() before fill() with setup_write()")
     {
-      writeAssocContainer->setParent(parent);
-      writeContainer->setupWrite(typeInfo);
-      CHECK_THROWS_AS(writeContainer->commit(), std::runtime_error);
+      write_assoc_container->set_parent(parent);
+      write_container->setup_write(type_info);
+      CHECK_THROWS_AS(write_container->commit(), std::runtime_error);
     }
   }
 
-  auto readContainer = createReadContainer(technology, "test/testData");
+  auto read_container = create_read_container(technology, "test/test_data");
 
-  SECTION("read() before setParent()")
+  SECTION("read() before set_parent()")
   {
-    CHECK_THROWS_AS(readContainer->read(0, &ptrTestData, typeInfo), std::runtime_error);
+    CHECK_THROWS_AS(read_container->read(0, &ptr_test_data, type_info), std::runtime_error);
   }
 
   SECTION("mismatched file type")
   {
-    std::shared_ptr<IStorage_File> wrongFile(
-      new Storage_File("testContainerErrorHandling.root", 'o'));
-    CHECK_THROWS_AS(readContainer->setFile(wrongFile), std::runtime_error);
-    CHECK_THROWS_AS(writeContainer->setFile(wrongFile), std::runtime_error);
+    std::shared_ptr<i_storage_file> wrong_file(
+      new storage_file("testContainerErrorHandling.root", 'o'));
+    CHECK_THROWS_AS(read_container->set_file(wrong_file), std::runtime_error);
+    CHECK_THROWS_AS(write_container->set_file(wrong_file), std::runtime_error);
   }
 
-  auto associativeWrite = dynamic_pointer_cast<Storage_Associative_Write_Container>(writeContainer);
-  if (associativeWrite) {
+  auto associative_write =
+    dynamic_pointer_cast<storage_associative_write_container>(write_container);
+  if (associative_write) {
     SECTION("mismatched parent type")
     {
-      std::shared_ptr<IStorage_Write_Container> badWriteParent(new Storage_Write_Container("bad"));
-      CHECK_THROWS_AS(associativeWrite->setParent(badWriteParent), std::runtime_error);
+      std::shared_ptr<i_storage_write_container> bad_write_parent(
+        new storage_write_container("bad"));
+      CHECK_THROWS_AS(associative_write->set_parent(bad_write_parent), std::runtime_error);
     }
   }
 }
 
 template <class T>
-void testFundamental(T const expected)
+void test_fundamental(T const expected)
 {
-  SECTION(form::test::getTypeName<T>())
+  SECTION(form::test::get_type_name<T>())
   {
     form::test::write(technology, expected);
     auto const [result] = form::test::read<T>(technology);
@@ -200,19 +202,19 @@ void testFundamental(T const expected)
 // current ROOT release and is therefore not tested here.
 TEST_CASE("Root branch read: fundamental scalar types round-trip", "[form]")
 {
-  testFundamental('r');
-  testFundamental(static_cast<unsigned char>(200));
-  testFundamental(static_cast<short>(-1000));
-  testFundamental(static_cast<unsigned short>(60000));
-  testFundamental(-42000);
-  testFundamental(3000000000u);
-  testFundamental(-9000000000L);
-  testFundamental(9000000000UL);
-  testFundamental(-4000000000LL);
-  testFundamental(8000000000ULL);
-  testFundamental(std::numbers::pi_v<float>);
-  testFundamental(std::numbers::e);
-  testFundamental(true);
+  test_fundamental('r');
+  test_fundamental(static_cast<unsigned char>(200));
+  test_fundamental(static_cast<short>(-1000));
+  test_fundamental(static_cast<unsigned short>(60000));
+  test_fundamental(-42000);
+  test_fundamental(3000000000u);
+  test_fundamental(-9000000000L);
+  test_fundamental(9000000000UL);
+  test_fundamental(-4000000000LL);
+  test_fundamental(8000000000ULL);
+  test_fundamental(std::numbers::pi_v<float>);
+  test_fundamental(std::numbers::e);
+  test_fundamental(true);
 }
 
 TEST_CASE("Root branch read: returns false when id exceeds entry count", "[form]")
@@ -220,14 +222,14 @@ TEST_CASE("Root branch read: returns false when id exceeds entry count", "[form]
   std::vector<int> data = {1, 2, 3};
   form::test::write(technology, data);
 
-  auto file = createFile(technology, form::test::testFileName, 'i');
+  auto file = create_file(technology, form::test::test_file_name, 'i');
   auto container =
-    createReadContainer(technology, form::test::makeTestBranchName<std::vector<int>>());
-  container->setFile(file);
-  void const* rawPtr = nullptr;
+    create_read_container(technology, form::test::make_test_branch_name<std::vector<int>>());
+  container->set_file(file);
+  void const* raw_ptr = nullptr;
 
   // One entry exists (id 0). id=2 strictly exceeds GetEntries()==1.
-  CHECK_FALSE(container->read(2, &rawPtr, typeid(std::vector<int>)));
+  CHECK_FALSE(container->read(2, &raw_ptr, typeid(std::vector<int>)));
 }
 
 TEST_CASE("Root branch read: throws when the named tree is absent from the file", "[form]")
@@ -235,11 +237,11 @@ TEST_CASE("Root branch read: throws when the named tree is absent from the file"
   std::vector<int> data = {42};
   form::test::write(technology, data);
 
-  auto file = createFile(technology, form::test::testFileName, 'i');
-  auto container = createReadContainer(technology, "NonExistentTree/someBranch");
-  container->setFile(file);
-  void const* rawPtr = nullptr;
-  CHECK_THROWS_AS(container->read(0, &rawPtr, typeid(std::vector<int>)), std::runtime_error);
+  auto file = create_file(technology, form::test::test_file_name, 'i');
+  auto container = create_read_container(technology, "NonExistentTree/someBranch");
+  container->set_file(file);
+  void const* raw_ptr = nullptr;
+  CHECK_THROWS_AS(container->read(0, &raw_ptr, typeid(std::vector<int>)), std::runtime_error);
 }
 
 TEST_CASE("Root branch read: throws when the named branch is absent from the tree", "[form]")
@@ -247,47 +249,47 @@ TEST_CASE("Root branch read: throws when the named branch is absent from the tre
   std::vector<int> data = {42};
   form::test::write(technology, data);
 
-  auto file = createFile(technology, form::test::testFileName, 'i');
-  auto container =
-    createReadContainer(technology, std::string(form::test::testTreeName) + "/NonExistentBranch");
-  container->setFile(file);
-  void const* rawPtr = nullptr;
-  CHECK_THROWS_AS(container->read(0, &rawPtr, typeid(std::vector<int>)), std::runtime_error);
+  auto file = create_file(technology, form::test::test_file_name, 'i');
+  auto container = create_read_container(
+    technology, std::string(form::test::test_tree_name) + "/NonExistentBranch");
+  container->set_file(file);
+  void const* raw_ptr = nullptr;
+  CHECK_THROWS_AS(container->read(0, &raw_ptr, typeid(std::vector<int>)), std::runtime_error);
 }
 
 TEST_CASE("Root branch read: throws for a type with no ROOT dictionary", "[form]")
 {
   // A locally-defined struct has no ROOT reflection dictionary.
-  // TDictionary::GetDictionary(typeid(LocalType)) returns nullptr, which
+  // TDictionary::GetDictionary(typeid(local_type)) returns nullptr, which
   // exercises the "unsupported type" error path in read().
-  struct LocalType {};
+  struct local_type {};
 
   std::vector<int> data = {42};
   form::test::write(technology, data);
 
-  auto file = createFile(technology, form::test::testFileName, 'i');
+  auto file = create_file(technology, form::test::test_file_name, 'i');
   auto container =
-    createReadContainer(technology, form::test::makeTestBranchName<std::vector<int>>());
-  container->setFile(file);
-  void const* rawPtr = nullptr;
-  CHECK_THROWS_AS(container->read(0, &rawPtr, typeid(LocalType)), std::runtime_error);
+    create_read_container(technology, form::test::make_test_branch_name<std::vector<int>>());
+  container->set_file(file);
+  void const* raw_ptr = nullptr;
+  CHECK_THROWS_AS(container->read(0, &raw_ptr, typeid(local_type)), std::runtime_error);
 }
 
 TEST_CASE("Root TTree write container: fill and commit are not implemented", "[form]")
 {
-  auto file = createFile(technology, "testTTreeWriteOps.root", 'o');
-  auto writeAssoc = createWriteAssociation(technology, "testTTreeWriteOpsTree");
-  writeAssoc->setFile(file);
-  writeAssoc->setupWrite();
+  auto file = create_file(technology, "testTTreeWriteOps.root", 'o');
+  auto write_assoc = create_write_association(technology, "testTTreeWriteOpsTree");
+  write_assoc->set_file(file);
+  write_assoc->setup_write();
 
   void const* dummy = nullptr;
-  CHECK_THROWS_AS(writeAssoc->fill(dummy), std::runtime_error);
-  CHECK_THROWS_AS(writeAssoc->commit(), std::runtime_error);
+  CHECK_THROWS_AS(write_assoc->fill(dummy), std::runtime_error);
+  CHECK_THROWS_AS(write_assoc->commit(), std::runtime_error);
 }
 
 TEST_CASE("Root TBranch fill: throws when TBranch::Fill() reports a write error", "[form]")
 {
-  // Exercises the defensive guard in ROOT_TBranch_Write_ContainerImp::fill():
+  // Exercises the defensive guard in root_tbranch_write_container_imp::fill():
   // TBranch::Fill() returns a negative value when a basket flush to disk fails, and
   // fill() must throw rather than hand back a row id for data that was never persisted.
   //
@@ -297,28 +299,28 @@ TEST_CASE("Root TBranch fill: throws when TBranch::Fill() reports a write error"
   // To provoke a deterministic write failure we (1) shrink the branch basket so that a
   // handful of fills force a basket flush to disk, and (2) mark the underlying TFile
   // non-writable so that flush fails and Fill() returns a negative value.
-  auto const tech = form::technology::ROOT_TTREE;
+  auto const tech = form::technology::root_ttree;
 
-  auto file = createFile(tech, "tbranch_fill_write_error.root", 'o');
-  auto tree = createWriteAssociation(tech, "faketree");
-  auto branch = createWriteContainer(tech, "faketree/fakebranch");
+  auto file = create_file(tech, "tbranch_fill_write_error.root", 'o');
+  auto tree = create_write_association(tech, "faketree");
+  auto branch = create_write_container(tech, "faketree/fakebranch");
 
-  tree->setFile(file);
-  tree->setupWrite(typeid(double));
+  tree->set_file(file);
+  tree->setup_write(typeid(double));
 
-  auto branchAssoc = dynamic_pointer_cast<Storage_Associative_Write_Container>(branch);
-  REQUIRE(branchAssoc != nullptr);
-  branchAssoc->setParent(tree);
-  branch->setFile(file);
-  branch->setupWrite(typeid(double));
+  auto branch_assoc = dynamic_pointer_cast<storage_associative_write_container>(branch);
+  REQUIRE(branch_assoc != nullptr);
+  branch_assoc->set_parent(tree);
+  branch->set_file(file);
+  branch->setup_write(typeid(double));
 
   // Reach the raw ROOT objects created through the factory wiring above.
-  auto root_file = dynamic_pointer_cast<ROOT_TFileImp>(file);
+  auto root_file = dynamic_pointer_cast<root_tfile_imp>(file);
   REQUIRE(root_file != nullptr);
-  auto* root_tree = dynamic_cast<ROOT_TTree_Write_ContainerImp*>(tree.get());
+  auto* root_tree = dynamic_cast<root_ttree_write_container_imp*>(tree.get());
   REQUIRE(root_tree != nullptr);
 
-  TTree* raw_tree = root_tree->getTTree();
+  TTree* raw_tree = root_tree->get_ttree();
   REQUIRE(raw_tree != nullptr);
   TBranch* raw_branch = raw_tree->GetBranch("fakebranch");
   REQUIRE(raw_branch != nullptr);
@@ -328,7 +330,7 @@ TEST_CASE("Root TBranch fill: throws when TBranch::Fill() reports a write error"
   raw_branch->SetBasketSize(100);
 
   // Make the file non-writable so the forced basket flush fails.
-  std::shared_ptr<TFile> raw_tfile = root_file->getTFile();
+  std::shared_ptr<TFile> raw_tfile = root_file->get_tfile();
   REQUIRE(raw_tfile != nullptr);
   raw_tfile->SetWritable(false);
 
@@ -355,8 +357,8 @@ TEST_CASE("Persistence round-trip: structured index normalization and listing", 
     "persistence_roundtrip_" + form::technology::to_string(technology) + ".root";
   std::string const creator = "norm_creator";
 
-  ItemConfig cfg;
-  cfg.addItem("prod", file_name, technology);
+  item_config cfg;
+  cfg.add_item("prod", file_name, technology);
 
   std::vector<int> first = {10, 20, 30};
   std::vector<int> second = {40, 50, 60};
@@ -365,39 +367,39 @@ TEST_CASE("Persistence round-trip: structured index normalization and listing", 
   std::string const second_id = "[event:3, segment:4]";
 
   {
-    auto writer = createPersistenceWriter();
+    auto writer = create_persistence_writer();
     REQUIRE(writer != nullptr);
     writer->configure(cfg);
-    writer->configureTechSettings(tech_setting_config{});
-    writer->createContainers(creator, {{"prod", &typeid(std::vector<int>)}});
+    writer->configure_tech_settings(tech_setting_config{});
+    writer->create_containers(creator, {{"prod", &typeid(std::vector<int>)}});
 
-    writer->registerWrite(creator, "prod", &first, typeid(std::vector<int>));
-    writer->commitOutput(creator, first_id);
+    writer->register_write(creator, "prod", &first, typeid(std::vector<int>));
+    writer->commit_output(creator, first_id);
 
-    writer->registerWrite(creator, "prod", &second, typeid(std::vector<int>));
-    writer->commitOutput(creator, second_id);
+    writer->register_write(creator, "prod", &second, typeid(std::vector<int>));
+    writer->commit_output(creator, second_id);
   }
 
-  auto reader = createPersistenceReader();
+  auto reader = create_persistence_reader();
   REQUIRE(reader != nullptr);
   reader->configure(cfg);
-  reader->configureTechSettings(tech_setting_config{});
+  reader->configure_tech_settings(tech_setting_config{});
 
   reader->prime(creator, "prod", typeid(std::vector<int>));
 
-  auto indices = reader->listIndices(creator, "prod");
+  auto indices = reader->list_indices(creator, "prod");
   REQUIRE_FALSE(indices.empty());
 
   void const* raw = nullptr;
   // Backends may canonicalize persisted index strings differently.
-  // Use an index emitted by listIndices() to verify readback.
+  // Use an index emitted by list_indices() to verify readback.
   reader->read(creator, "prod", indices.front(), &raw, typeid(std::vector<int>));
   auto const* read_first = static_cast<std::vector<int> const*>(raw);
   REQUIRE(read_first != nullptr);
   CHECK((*read_first == first || *read_first == second));
 }
 
-TEST_CASE("registerWrite returns a Token locating the written product", "[form]")
+TEST_CASE("register_write returns a token locating the written product", "[form]")
 {
   using namespace form::experimental::config;
 
@@ -406,79 +408,79 @@ TEST_CASE("registerWrite returns a Token locating the written product", "[form]"
   std::string const creator = "rowid_creator";
   std::string const container = creator + "/prod";
 
-  ItemConfig cfg;
-  cfg.addItem("prod", file_name, technology);
+  item_config cfg;
+  cfg.add_item("prod", file_name, technology);
 
   std::vector<int> const first = {11, 22, 33};
   std::vector<int> const second = {44, 55, 66};
 
-  Token token_first;
-  Token token_second;
+  token token_first;
+  token token_second;
   {
-    auto writer = createPersistenceWriter();
+    auto writer = create_persistence_writer();
     REQUIRE(writer != nullptr);
     writer->configure(cfg);
-    writer->configureTechSettings(tech_setting_config{});
-    writer->createContainers(creator, {{"prod", &typeid(std::vector<int>)}});
+    writer->configure_tech_settings(tech_setting_config{});
+    writer->create_containers(creator, {{"prod", &typeid(std::vector<int>)}});
 
-    token_first = writer->registerWrite(creator, "prod", &first, typeid(std::vector<int>));
-    writer->commitOutput(creator, "[event:1, segment:1]");
+    token_first = writer->register_write(creator, "prod", &first, typeid(std::vector<int>));
+    writer->commit_output(creator, "[event:1, segment:1]");
 
-    token_second = writer->registerWrite(creator, "prod", &second, typeid(std::vector<int>));
-    writer->commitOutput(creator, "[event:1, segment:2]");
+    token_second = writer->register_write(creator, "prod", &second, typeid(std::vector<int>));
+    writer->commit_output(creator, "[event:1, segment:2]");
   }
 
-  // The returned Token carries the placement and the 0-based, monotonically increasing row
-  CHECK(token_first.hasId());
+  // The returned token carries the placement and the 0-based, monotonically increasing row
+  CHECK(token_first.has_id());
   CHECK(token_first.id() == 0u);
-  CHECK(token_first.containerName() == container);
-  CHECK(token_second.hasId());
+  CHECK(token_first.container_name() == container);
+  CHECK(token_second.has_id());
   CHECK(token_second.id() == 1u);
 
-  // Token returned by the write is directly usable on the read side: no hand-buit Token or re-scan
-  StorageReader reader;
+  // token returned by the write is directly usable on the read side: no hand-buit token or re-scan
+  storage_reader reader;
   tech_setting_config const settings{};
 
-  // readContainer allocates the payload and transfers ownership to the caller.
+  // read_container allocates the payload and transfers ownership to the caller.
   void const* raw = nullptr;
-  reader.readContainer(token_first, &raw, typeid(std::vector<int>), settings);
+  reader.read_container(token_first, &raw, typeid(std::vector<int>), settings);
   std::unique_ptr<std::vector<int> const> const got_first(
     static_cast<std::vector<int> const*>(raw));
   REQUIRE(got_first != nullptr);
   CHECK(*got_first == first);
 
   raw = nullptr;
-  reader.readContainer(token_second, &raw, typeid(std::vector<int>), settings);
+  reader.read_container(token_second, &raw, typeid(std::vector<int>), settings);
   std::unique_ptr<std::vector<int> const> const got_second(
     static_cast<std::vector<int> const*>(raw));
   REQUIRE(got_second != nullptr);
   CHECK(*got_second == second);
 }
 
-TEST_CASE("registerWrite throws when the backend does not address rows", "[form]")
+TEST_CASE("register_write throws when the backend does not address rows", "[form]")
 {
   using namespace form::experimental::config;
 
   // The generic ("no technology specified") backend's write container is a no-op whose fill()
-  // returns kInvalidRowId, and its read side is a no-op too, so a product routed there could
-  // never be located on read. registerWrite must reject that rather than return an unusable
-  // Token whose row would later be used as the read-side navigation key.
-  form::technology::Id const generic{};
+  // returns invalid_row_id, and its read side is a no-op too, so a product routed there could
+  // never be located on read. register_write must reject that rather than return an unusable
+  // token whose row would later be used as the read-side navigation key.
+  form::technology::id const generic{};
   std::string const file_name = "registerwrite_notset_row.generic";
   std::string const creator = "notset_creator";
 
-  ItemConfig cfg;
-  cfg.addItem("prod", file_name, generic);
+  item_config cfg;
+  cfg.add_item("prod", file_name, generic);
 
   std::vector<int> const payload = {1, 2, 3};
 
-  auto writer = createPersistenceWriter();
+  auto writer = create_persistence_writer();
   REQUIRE(writer != nullptr);
   writer->configure(cfg);
-  writer->configureTechSettings(tech_setting_config{});
-  writer->createContainers(creator, {{"prod", &typeid(std::vector<int>)}});
+  writer->configure_tech_settings(tech_setting_config{});
+  writer->create_containers(creator, {{"prod", &typeid(std::vector<int>)}});
 
-  CHECK_THROWS_AS(writer->registerWrite(creator, "prod", &payload, typeid(std::vector<int>)),
+  CHECK_THROWS_AS(writer->register_write(creator, "prod", &payload, typeid(std::vector<int>)),
                   std::runtime_error);
 }
 
@@ -490,24 +492,24 @@ TEST_CASE("Persistence round-trip: all-zero structured id fallback", "[form]")
     "persistence_zero_index_" + form::technology::to_string(technology) + ".root";
   std::string const creator = "zero_creator";
 
-  ItemConfig cfg;
-  cfg.addItem("prod", file_name, technology);
+  item_config cfg;
+  cfg.add_item("prod", file_name, technology);
 
   std::vector<int> payload = {7, 8, 9};
   {
-    auto writer = createPersistenceWriter();
+    auto writer = create_persistence_writer();
     REQUIRE(writer != nullptr);
     writer->configure(cfg);
-    writer->configureTechSettings(tech_setting_config{});
-    writer->createContainers(creator, {{"prod", &typeid(std::vector<int>)}});
-    writer->registerWrite(creator, "prod", &payload, typeid(std::vector<int>));
-    writer->commitOutput(creator, "");
+    writer->configure_tech_settings(tech_setting_config{});
+    writer->create_containers(creator, {{"prod", &typeid(std::vector<int>)}});
+    writer->register_write(creator, "prod", &payload, typeid(std::vector<int>));
+    writer->commit_output(creator, "");
   }
 
-  auto reader = createPersistenceReader();
+  auto reader = create_persistence_reader();
   REQUIRE(reader != nullptr);
   reader->configure(cfg);
-  reader->configureTechSettings(tech_setting_config{});
+  reader->configure_tech_settings(tech_setting_config{});
 
   void const* raw = nullptr;
   reader->read(creator, "prod", "[event:0, segment:0]", &raw, typeid(std::vector<int>));
@@ -517,7 +519,7 @@ TEST_CASE("Persistence round-trip: all-zero structured id fallback", "[form]")
   CHECK(*read_payload == payload);
 }
 
-TEST_CASE("StorageReader getIndex: malformed ids and compatibility fallbacks", "[form]")
+TEST_CASE("storage_reader get_index: malformed ids and compatibility fallbacks", "[form]")
 {
   using namespace form::experimental::config;
 
@@ -526,103 +528,105 @@ TEST_CASE("StorageReader getIndex: malformed ids and compatibility fallbacks", "
   std::string const creator = "storage_reader_creator";
   std::string const index_container = creator + "/index";
 
-  ItemConfig cfg;
-  cfg.addItem("prod", file_name, technology);
+  item_config cfg;
+  cfg.add_item("prod", file_name, technology);
 
   std::vector<int> payload = {1, 2, 3};
   {
-    auto writer = createPersistenceWriter();
+    auto writer = create_persistence_writer();
     REQUIRE(writer != nullptr);
     writer->configure(cfg);
-    writer->configureTechSettings(tech_setting_config{});
-    writer->createContainers(creator, {{"prod", &typeid(std::vector<int>)}});
-    writer->registerWrite(creator, "prod", &payload, typeid(std::vector<int>));
-    writer->commitOutput(creator, "[event:1, segment:2]");
+    writer->configure_tech_settings(tech_setting_config{});
+    writer->create_containers(creator, {{"prod", &typeid(std::vector<int>)}});
+    writer->register_write(creator, "prod", &payload, typeid(std::vector<int>));
+    writer->commit_output(creator, "[event:1, segment:2]");
   }
 
-  StorageReader reader;
-  Token const index_token{file_name, index_container, technology};
+  storage_reader reader;
+  token const index_token{file_name, index_container, technology};
   tech_setting_config const settings{};
 
-  CHECK(reader.getIndex(index_token, "[]", settings) == 0);
-  CHECK(reader.getIndex(index_token, "plain-text-id", settings) == 0);
+  CHECK(reader.get_index(index_token, "[]", settings) == 0);
+  CHECK(reader.get_index(index_token, "plain-text-id", settings) == 0);
 
   // Malformed IDs must be rejected by the storage-layer index parser
-  CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT,SEG=1]", settings), std::runtime_error);
+  CHECK_THROWS_AS(reader.get_index(index_token, "[EVENT,SEG=1]", settings), std::runtime_error);
   CHECK_THROWS_AS(
-    reader.getIndex(index_token, "[EVENT=99999999999999999999999999999999]", settings),
+    reader.get_index(index_token, "[EVENT=99999999999999999999999999999999]", settings),
     std::runtime_error);
-  CHECK_THROWS_AS(reader.getIndex(index_token, "[=1]", settings), std::runtime_error);
-  CHECK_THROWS_AS(reader.getIndex(index_token, "[EVENT]", settings), std::runtime_error);
-  CHECK_THROWS_AS(reader.getIndex(index_token, "[    ]", settings), std::runtime_error);
+  CHECK_THROWS_AS(reader.get_index(index_token, "[=1]", settings), std::runtime_error);
+  CHECK_THROWS_AS(reader.get_index(index_token, "[EVENT]", settings), std::runtime_error);
+  CHECK_THROWS_AS(reader.get_index(index_token, "[    ]", settings), std::runtime_error);
 }
 
-TEST_CASE("StorageReader getIndex: empty container and tech-table branches", "[form]")
+TEST_CASE("storage_reader get_index: empty container and tech-table branches", "[form]")
 {
   using namespace form::experimental::config;
 
-  StorageReader reader;
-  Token const token{"storage_reader_hdf5_get_index.root", "creator/index", form::technology::HDF5};
+  storage_reader reader;
+  token const index_token{
+    "storage_reader_hdf5_get_index.root", "creator/index", form::technology::hdf5};
 
   tech_setting_config empty_settings;
-  CHECK_THROWS_AS(reader.getIndex(token, "[event:1, segment:1]", empty_settings),
+  CHECK_THROWS_AS(reader.get_index(index_token, "[event:1, segment:1]", empty_settings),
                   std::runtime_error);
 
   tech_setting_config tech_only_settings;
-  tech_only_settings.file_settings[form::technology::HDF5]["different_file"] = {};
-  tech_only_settings.container_settings[form::technology::HDF5]["different_container"] = {};
-  CHECK_THROWS_AS(reader.getIndex(token, "[event:1, segment:1]", tech_only_settings),
+  tech_only_settings.file_settings[form::technology::hdf5]["different_file"] = {};
+  tech_only_settings.container_settings[form::technology::hdf5]["different_container"] = {};
+  CHECK_THROWS_AS(reader.get_index(index_token, "[event:1, segment:1]", tech_only_settings),
                   std::runtime_error);
 
   std::string const file_name =
     "storage_reader_getindex_attr_" + form::technology::to_string(technology) + ".root";
   std::string const creator = "storage_reader_getindex_attr_creator";
-  ItemConfig cfg;
-  cfg.addItem("prod", file_name, technology);
+  item_config cfg;
+  cfg.add_item("prod", file_name, technology);
   std::vector<int> payload = {5, 6, 7};
   {
-    auto writer = createPersistenceWriter();
+    auto writer = create_persistence_writer();
     REQUIRE(writer != nullptr);
     writer->configure(cfg);
-    writer->configureTechSettings(tech_setting_config{});
-    writer->createContainers(creator, {{"prod", &typeid(std::vector<int>)}});
-    writer->registerWrite(creator, "prod", &payload, typeid(std::vector<int>));
-    writer->commitOutput(creator, "[event:5, segment:6]");
+    writer->configure_tech_settings(tech_setting_config{});
+    writer->create_containers(creator, {{"prod", &typeid(std::vector<int>)}});
+    writer->register_write(creator, "prod", &payload, typeid(std::vector<int>));
+    writer->commit_output(creator, "[event:5, segment:6]");
   }
 
   tech_setting_config attr_settings;
   attr_settings.file_settings[technology][file_name] = {{"compression", "1"}};
-  CHECK(reader.getIndex(
-          Token{file_name, creator + "/index", technology}, "missing-id", attr_settings) == 0);
+  CHECK(reader.get_index(
+          token{file_name, creator + "/index", technology}, "missing-id", attr_settings) == 0);
 
   tech_setting_config container_attr_settings;
   container_attr_settings.container_settings[technology][creator + "/index"] = {{"split", "0"}};
-  CHECK_NOTHROW(reader.getIndex(
-    Token{file_name, creator + "/index", technology}, "missing-id", container_attr_settings));
+  CHECK_NOTHROW(reader.get_index(
+    token{file_name, creator + "/index", technology}, "missing-id", container_attr_settings));
 }
 
-TEST_CASE("StorageReader prime/listIndices/readContainer: attribute and error branches", "[form]")
+TEST_CASE("storage_reader prime/list_indices/read_container: attribute and error branches",
+          "[form]")
 {
   using namespace form::experimental::config;
 
   std::string const file_name =
     "storage_reader_misc_attr_" + form::technology::to_string(technology) + ".root";
   std::string const creator = "storage_reader_misc_creator";
-  ItemConfig cfg;
-  cfg.addItem("prod", file_name, technology);
+  item_config cfg;
+  cfg.add_item("prod", file_name, technology);
   std::vector<int> payload = {9, 8, 7};
   {
-    auto writer = createPersistenceWriter();
+    auto writer = create_persistence_writer();
     REQUIRE(writer != nullptr);
     writer->configure(cfg);
-    writer->configureTechSettings(tech_setting_config{});
-    writer->createContainers(creator, {{"prod", &typeid(std::vector<int>)}});
-    writer->registerWrite(creator, "prod", &payload, typeid(std::vector<int>));
-    writer->commitOutput(creator, "[event:9, segment:8]");
+    writer->configure_tech_settings(tech_setting_config{});
+    writer->create_containers(creator, {{"prod", &typeid(std::vector<int>)}});
+    writer->register_write(creator, "prod", &payload, typeid(std::vector<int>));
+    writer->commit_output(creator, "[event:9, segment:8]");
   }
 
-  StorageReader reader;
-  Token const index_token{file_name, creator + "/index", technology};
+  storage_reader reader;
+  token const index_token{file_name, creator + "/index", technology};
 
   tech_setting_config file_attr_settings;
   file_attr_settings.file_settings[technology][file_name] = {{"compression", "1"}};
@@ -630,32 +634,32 @@ TEST_CASE("StorageReader prime/listIndices/readContainer: attribute and error br
   CHECK_NOTHROW(reader.prime(index_token, typeid(std::string), file_attr_settings));
 
   void const* raw = nullptr;
-  CHECK_NOTHROW(reader.readContainer(Token{file_name, creator + "/prod", technology, 0},
-                                     &raw,
-                                     typeid(std::vector<int>),
-                                     file_attr_settings));
+  CHECK_NOTHROW(reader.read_container(token{file_name, creator + "/prod", technology, 0},
+                                      &raw,
+                                      typeid(std::vector<int>),
+                                      file_attr_settings));
 
   tech_setting_config empty_settings;
-  CHECK_THROWS_AS(reader.listIndices(
-                    Token{"storage_reader_hdf5_misc.root", "creator/index", form::technology::HDF5},
+  CHECK_THROWS_AS(reader.list_indices(
+                    token{"storage_reader_hdf5_misc.root", "creator/index", form::technology::hdf5},
                     empty_settings),
                   std::runtime_error);
 
   tech_setting_config container_attr_settings;
   container_attr_settings.container_settings[technology][creator + "/index"] = {{"split", "0"}};
 
-  CHECK_NOTHROW(reader.listIndices(index_token, container_attr_settings));
-  CHECK_NOTHROW(reader.readContainer(Token{file_name, creator + "/prod", technology, 0},
-                                     &raw,
-                                     typeid(std::vector<int>),
-                                     container_attr_settings));
+  CHECK_NOTHROW(reader.list_indices(index_token, container_attr_settings));
+  CHECK_NOTHROW(reader.read_container(token{file_name, creator + "/prod", technology, 0},
+                                      &raw,
+                                      typeid(std::vector<int>),
+                                      container_attr_settings));
 }
 
 TEST_CASE("Root branch prime: error paths", "[form]")
 {
   SECTION("no file attached throws")
   {
-    auto container = createReadContainer(technology, "SomeTree/branch");
+    auto container = create_read_container(technology, "SomeTree/branch");
     CHECK_THROWS_AS(container->prime(typeid(std::vector<int>)), std::runtime_error);
   }
 
@@ -663,9 +667,9 @@ TEST_CASE("Root branch prime: error paths", "[form]")
   {
     std::vector<int> data = {1};
     form::test::write(technology, data);
-    auto file = createFile(technology, form::test::testFileName, 'i');
-    auto container = createReadContainer(technology, "NonExistentTreeForPrime/branch");
-    container->setFile(file);
+    auto file = create_file(technology, form::test::test_file_name, 'i');
+    auto container = create_read_container(technology, "NonExistentTreeForPrime/branch");
+    container->set_file(file);
     CHECK_THROWS_AS(container->prime(typeid(std::vector<int>)), std::runtime_error);
   }
 
@@ -673,23 +677,23 @@ TEST_CASE("Root branch prime: error paths", "[form]")
   {
     std::vector<int> data = {1};
     form::test::write(technology, data);
-    auto file = createFile(technology, form::test::testFileName, 'i');
-    auto container = createReadContainer(
-      technology, std::string(form::test::testTreeName) + "/NonExistentBranchForPrime");
-    container->setFile(file);
+    auto file = create_file(technology, form::test::test_file_name, 'i');
+    auto container = create_read_container(
+      technology, std::string(form::test::test_tree_name) + "/NonExistentBranchForPrime");
+    container->set_file(file);
     CHECK_THROWS_AS(container->prime(typeid(std::vector<int>)), std::runtime_error);
   }
 
   SECTION("unsupported type throws")
   {
-    struct LocalPrimeType {};
+    struct local_prime_type {};
     std::vector<int> data = {1};
     form::test::write(technology, data);
-    auto file = createFile(technology, form::test::testFileName, 'i');
+    auto file = create_file(technology, form::test::test_file_name, 'i');
     auto container =
-      createReadContainer(technology, form::test::makeTestBranchName<std::vector<int>>());
-    container->setFile(file);
-    CHECK_THROWS_AS(container->prime(typeid(LocalPrimeType)), std::runtime_error);
+      create_read_container(technology, form::test::make_test_branch_name<std::vector<int>>());
+    container->set_file(file);
+    CHECK_THROWS_AS(container->prime(typeid(local_prime_type)), std::runtime_error);
   }
 }
 
@@ -697,7 +701,7 @@ TEST_CASE("Root branch entries: success and error paths", "[form]")
 {
   SECTION("no file attached throws")
   {
-    auto container = createReadContainer(technology, "SomeTree/branch");
+    auto container = create_read_container(technology, "SomeTree/branch");
     CHECK_THROWS_AS(container->entries(), std::runtime_error);
   }
 
@@ -705,9 +709,9 @@ TEST_CASE("Root branch entries: success and error paths", "[form]")
   {
     std::vector<int> data = {1};
     form::test::write(technology, data);
-    auto file = createFile(technology, form::test::testFileName, 'i');
-    auto container = createReadContainer(technology, "NonExistentTreeForEntries/branch");
-    container->setFile(file);
+    auto file = create_file(technology, form::test::test_file_name, 'i');
+    auto container = create_read_container(technology, "NonExistentTreeForEntries/branch");
+    container->set_file(file);
     CHECK_THROWS_AS(container->entries(), std::runtime_error);
   }
 
@@ -715,10 +719,10 @@ TEST_CASE("Root branch entries: success and error paths", "[form]")
   {
     std::vector<int> data = {1};
     form::test::write(technology, data);
-    auto file = createFile(technology, form::test::testFileName, 'i');
-    auto container = createReadContainer(
-      technology, std::string(form::test::testTreeName) + "/NonExistentBranchForEntries");
-    container->setFile(file);
+    auto file = create_file(technology, form::test::test_file_name, 'i');
+    auto container = create_read_container(
+      technology, std::string(form::test::test_tree_name) + "/NonExistentBranchForEntries");
+    container->set_file(file);
     CHECK_THROWS_AS(container->entries(), std::runtime_error);
   }
 
@@ -726,10 +730,10 @@ TEST_CASE("Root branch entries: success and error paths", "[form]")
   {
     std::vector<int> data = {10, 20, 30};
     form::test::write(technology, data);
-    auto file = createFile(technology, form::test::testFileName, 'i');
+    auto file = create_file(technology, form::test::test_file_name, 'i');
     auto container =
-      createReadContainer(technology, form::test::makeTestBranchName<std::vector<int>>());
-    container->setFile(file);
+      create_read_container(technology, form::test::make_test_branch_name<std::vector<int>>());
+    container->set_file(file);
     CHECK(container->entries() == 1);
   }
 }

--- a/test/form/generate_vector.cpp
+++ b/test/form/generate_vector.cpp
@@ -10,27 +10,27 @@
 
 using namespace phlex;
 
-//A GaussianGenerator generates a vector<int> sampled from a Gaussian distribution
-class GaussianGenerator {
+//A gaussian_generator generates a vector<int> sampled from a Gaussian distribution
+class gaussian_generator {
 public:
-  GaussianGenerator(int const n_time_ticks, int const seed, float const mean, float const stddev) :
-    m_n_time_ticks(n_time_ticks), m_gen(seed), m_dist(mean, stddev)
+  gaussian_generator(int const n_time_ticks, int const seed, float const mean, float const stddev) :
+    n_time_ticks_(n_time_ticks), gen_(seed), dist_(mean, stddev)
   {
   }
 
   std::vector<int> operator()([[maybe_unused]] data_cell_index const& idx)
   {
-    std::vector<int> randoms(m_n_time_ticks);
+    std::vector<int> randoms(n_time_ticks_);
     for (auto& random : randoms) {
-      random = static_cast<int>(m_dist(m_gen));
+      random = static_cast<int>(dist_(gen_));
     }
     return randoms;
   }
 
 private:
-  int m_n_time_ticks;
-  std::mt19937 m_gen;
-  std::normal_distribution<float> m_dist;
+  int n_time_ticks_;
+  std::mt19937 gen_;
+  std::normal_distribution<float> dist_;
 };
 
 PHLEX_REGISTER_PROVIDERS(graph, config)
@@ -42,8 +42,8 @@ PHLEX_REGISTER_PROVIDERS(graph, config)
   auto const stddev = config.get<float>("stddev", 1);
   auto creator = config.get<std::string>("creator");
 
-  graph.make<GaussianGenerator>(n_time_ticks, seed, mean, stddev)
-    .provide("random_wires", &GaussianGenerator::operator())
+  graph.make<gaussian_generator>(n_time_ticks, seed, mean, stddev)
+    .provide("random_wires", &gaussian_generator::operator())
     .output_product(
       creator, phlex::experimental::identifier(creator), phlex::experimental::identifier("event"));
 }

--- a/test/form/reader.cpp
+++ b/test/form/reader.cpp
@@ -15,18 +15,18 @@
 #include <utility>
 #include <vector>
 
-static int const NUMBER_EVENT = 4;
-static int const NUMBER_SEGMENT = 15;
+static int const number_event = 4;
+static int const number_segment = 15;
 
-static float const TOLERANCE = 1e-3f;
+static float const tolerance = 1e-3f;
 
 // Structs to hold expected checksums
-struct SegChecksum {
+struct seg_checksum {
   float check;
   float cpx, cpy, cpz;
 };
 
-struct EvtChecksum {
+struct evt_checksum {
   float check;
 };
 
@@ -36,11 +36,11 @@ int main(int argc, char** argv)
 
   std::string const filename = (argc > 1) ? argv[1] : "toy.root";
   std::string const checksum_filename = (argc > 2) ? argv[2] : "toy_checksums.txt";
-  auto const technology = form::test::getTechnology((argc > 3) ? argv[3] : "ROOT_TTREE");
+  auto const technology = form::test::get_technology((argc > 3) ? argv[3] : "ROOT_TTREE");
 
   // Load expected checksums from file
-  std::map<std::pair<int, int>, SegChecksum> expected_seg;
-  std::map<int, EvtChecksum> expected_evt;
+  std::map<std::pair<int, int>, seg_checksum> expected_seg;
+  std::map<int, evt_checksum> expected_evt;
 
   std::ifstream checksum_file(checksum_filename);
   if (!checksum_file.is_open()) {
@@ -54,13 +54,13 @@ int main(int argc, char** argv)
     std::string type;
     iss >> type;
     if (type == "SEG") {
-      SegChecksum cs{};
+      seg_checksum cs{};
       int nevent{};
       int nseg{};
       iss >> nevent >> nseg >> cs.check >> cs.cpx >> cs.cpy >> cs.cpz;
       expected_seg[{nevent, nseg}] = cs;
     } else if (type == "EVT") {
-      EvtChecksum cs{};
+      evt_checksum cs{};
       int nevent{};
       iss >> nevent >> cs.check;
       expected_evt[nevent] = cs;
@@ -69,11 +69,11 @@ int main(int argc, char** argv)
   checksum_file.close();
 
   // TODO: Read configuration from config file instead of hardcoding
-  form::experimental::config::ItemConfig config_items;
-  config_items.addItem("trackStart", filename, technology);
-  config_items.addItem("trackNumberHits", filename, technology);
-  config_items.addItem("trackStartPoints", filename, technology);
-  config_items.addItem("trackStartX", filename, technology);
+  form::experimental::config::item_config config_items;
+  config_items.add_item("trackStart", filename, technology);
+  config_items.add_item("trackNumberHits", filename, technology);
+  config_items.add_item("trackStartPoints", filename, technology);
+  config_items.add_item("trackStartX", filename, technology);
 
   form::experimental::config::tech_setting_config tech_config;
 
@@ -81,14 +81,14 @@ int main(int argc, char** argv)
 
   bool all_passed = true;
 
-  for (int nevent = 0; nevent < NUMBER_EVENT; nevent++) {
+  for (int nevent = 0; nevent < number_event; nevent++) {
     std::cout << "PHLEX: Read Event No. " << nevent << '\n';
 
     std::unique_ptr<std::vector<float> const> track_x;
 
-    for (int nseg = 0; nseg < NUMBER_SEGMENT; nseg++) {
+    for (int nseg = 0; nseg < number_segment; nseg++) {
 
-      void const* rawPtr = nullptr;
+      void const* raw_ptr = nullptr;
       // Must match the canonical format emitted by writer.cpp (phlex data_cell_index format)
       std::string const seg_id_text = std::format("[event:{}, segment:{}]", nevent, nseg);
 
@@ -97,27 +97,27 @@ int main(int argc, char** argv)
       std::string const creator = "Toy_Tracker";
 
       form::experimental::product_with_name pb = {
-        .label = "trackStart", .data = rawPtr, .type = &typeid(std::vector<float>)};
+        .label = "trackStart", .data = raw_ptr, .type = &typeid(std::vector<float>)};
 
       form.read(creator, segment_id, pb);
       std::unique_ptr<std::vector<float> const> track_start_x(
         static_cast<std::vector<float> const*>(pb.data));
 
-      rawPtr = nullptr;
+      raw_ptr = nullptr;
       form::experimental::product_with_name pb_int = {
-        .label = "trackNumberHits", .data = rawPtr, .type = &typeid(std::vector<int>)};
+        .label = "trackNumberHits", .data = raw_ptr, .type = &typeid(std::vector<int>)};
 
       form.read(creator, segment_id, pb_int);
       std::unique_ptr<std::vector<int> const> track_n_hits(
         static_cast<std::vector<int> const*>(pb_int.data));
 
-      rawPtr = nullptr;
+      raw_ptr = nullptr;
       form::experimental::product_with_name pb_points = {
-        .label = "trackStartPoints", .data = rawPtr, .type = &typeid(std::vector<TrackStart>)};
+        .label = "trackStartPoints", .data = raw_ptr, .type = &typeid(std::vector<track_start>)};
 
       form.read(creator, segment_id, pb_points);
-      std::unique_ptr<std::vector<TrackStart> const> start_points(
-        static_cast<std::vector<TrackStart> const*>(pb_points.data));
+      std::unique_ptr<std::vector<track_start> const> start_points(
+        static_cast<std::vector<track_start> const*>(pb_points.data));
 
       float check = 0.0;
       for (float val : *track_start_x) {
@@ -126,31 +126,31 @@ int main(int argc, char** argv)
       for (int val : *track_n_hits) {
         check += static_cast<float>(val);
       }
-      TrackStart checkPoints;
-      for (TrackStart val : *start_points) {
-        checkPoints += val;
+      track_start check_points;
+      for (track_start val : *start_points) {
+        check_points += val;
       }
       std::cout << "PHLEX: Segment = " << nseg << ": seg_id_text = " << seg_id_text
                 << ", check = " << check << '\n';
       std::cout << "PHLEX: Segment = " << nseg << ": seg_id_text = " << seg_id_text
-                << ", checkPoints = " << checkPoints << '\n';
+                << ", check_points = " << check_points << '\n';
 
       // Verify segment checksums
       auto key = std::make_pair(nevent, nseg);
       if (expected_seg.contains(key)) {
         auto const& exp = expected_seg[key];
-        bool seg_ok = (std::fabs(check - exp.check) <= TOLERANCE) &&
-                      (std::fabs(checkPoints.getX() - exp.cpx) <= TOLERANCE) &&
-                      (std::fabs(checkPoints.getY() - exp.cpy) <= TOLERANCE) &&
-                      (std::fabs(checkPoints.getZ() - exp.cpz) <= TOLERANCE);
+        bool seg_ok = (std::fabs(check - exp.check) <= tolerance) &&
+                      (std::fabs(check_points.get_x() - exp.cpx) <= tolerance) &&
+                      (std::fabs(check_points.get_y() - exp.cpy) <= tolerance) &&
+                      (std::fabs(check_points.get_z() - exp.cpz) <= tolerance);
         if (seg_ok) {
           std::cout << "VERIFY PASS: event=" << nevent << " seg=" << nseg << '\n';
         } else {
           std::cerr << "VERIFY FAIL: event=" << nevent << " seg=" << nseg
                     << " expected check=" << exp.check << " got=" << check
-                    << " expected cpx=" << exp.cpx << " got=" << checkPoints.getX()
-                    << " expected cpy=" << exp.cpy << " got=" << checkPoints.getY()
-                    << " expected cpz=" << exp.cpz << " got=" << checkPoints.getZ() << '\n';
+                    << " expected cpx=" << exp.cpx << " got=" << check_points.get_x()
+                    << " expected cpy=" << exp.cpy << " got=" << check_points.get_y()
+                    << " expected cpz=" << exp.cpz << " got=" << check_points.get_z() << '\n';
           all_passed = false;
         }
       } else {
@@ -167,9 +167,9 @@ int main(int argc, char** argv)
 
     std::string const creator = "Toy_Tracker_Event";
 
-    void const* rawEvtPtr = nullptr;
+    void const* raw_evt_ptr = nullptr;
     form::experimental::product_with_name pb = {
-      .label = "trackStartX", .data = rawEvtPtr, .type = &typeid(std::vector<float>)};
+      .label = "trackStartX", .data = raw_evt_ptr, .type = &typeid(std::vector<float>)};
 
     form.read(creator, event_id, pb);
     track_x.reset(static_cast<std::vector<float> const*>(pb.data));
@@ -184,7 +184,7 @@ int main(int argc, char** argv)
     // Verify event checksum
     if (expected_evt.contains(nevent)) {
       auto const& exp = expected_evt[nevent];
-      bool evt_ok = (std::fabs(check - exp.check) <= TOLERANCE);
+      bool evt_ok = (std::fabs(check - exp.check) <= tolerance);
       if (evt_ok) {
         std::cout << "VERIFY PASS: event=" << nevent << '\n';
       } else {

--- a/test/form/test_utils.hpp
+++ b/test/form/test_utils.hpp
@@ -20,16 +20,16 @@ namespace form::test {
   inline constexpr char const* test_tree_name = "FORMTestTree";
   inline constexpr char const* test_file_name = "FORMTestFile.root";
 
-  template <class PROD>
+  template <class Prod>
   inline std::string get_type_name()
   {
-    return demangle_name(typeid(PROD));
+    return demangle_name(typeid(Prod));
   }
 
-  template <class PROD>
+  template <class Prod>
   inline std::string make_test_branch_name()
   {
-    auto branch_name = std::string(test_tree_name) + "/" + get_type_name<PROD>();
+    auto branch_name = std::string(test_tree_name) + "/" + get_type_name<Prod>();
     for (size_t first_space = branch_name.find_first_of(' '); first_space != std::string::npos;
          first_space = branch_name.find_first_of(' ')) {
       branch_name = branch_name.erase(first_space, 1);
@@ -45,22 +45,22 @@ namespace form::test {
     return {};
   }
 
-  template <class PROD, class... PRODS>
+  template <class Prod, class... Prods>
   inline std::vector<std::shared_ptr<i_storage_write_container>> do_write(
     std::shared_ptr<i_storage_file>& file,
     form::technology::id const technology,
     std::shared_ptr<i_storage_write_container>& parent,
-    PROD& prod,
-    PRODS&... prods)
+    Prod& prod,
+    Prods&... prods)
   {
-    auto const branch_name = make_test_branch_name<PROD>();
+    auto const branch_name = make_test_branch_name<Prod>();
     auto container = create_write_container(technology, branch_name);
     auto assoc = dynamic_pointer_cast<storage_associative_write_container>(container);
     if (assoc) {
       assoc->set_parent(parent);
     }
     container->set_file(file);
-    container->setup_write(typeid(PROD));
+    container->setup_write(typeid(Prod));
 
     auto result = do_write(file, technology, parent, prods...);
     container->fill(&prod); //This must happen after setup_write()
@@ -68,8 +68,8 @@ namespace form::test {
     return result;
   }
 
-  template <class... PRODS>
-  inline void write(form::technology::id const technology, PRODS&... prods)
+  template <class... Prods>
+  inline void write(form::technology::id const technology, Prods&... prods)
   {
     auto file = create_file(technology, std::string(test_file_name), 'o');
     auto parent = create_write_association(technology, std::string(test_tree_name));
@@ -81,27 +81,27 @@ namespace form::test {
       ->commit(); //Elements are in reverse order of container construction, so this makes sure container owner calls commit()
   }
 
-  template <class PROD>
-  inline std::unique_ptr<PROD const> do_read(std::shared_ptr<i_storage_file>& file,
+  template <class Prod>
+  inline std::unique_ptr<Prod const> do_read(std::shared_ptr<i_storage_file>& file,
                                              form::technology::id const technology)
   {
-    auto container = create_read_container(technology, make_test_branch_name<PROD>());
+    auto container = create_read_container(technology, make_test_branch_name<Prod>());
     container->set_file(file);
     void const* raw_ptr = nullptr;
 
-    if (!container->read(0, &raw_ptr, typeid(PROD))) {
-      throw std::runtime_error("Failed to read a " + get_type_name<PROD>());
+    if (!container->read(0, &raw_ptr, typeid(Prod))) {
+      throw std::runtime_error("Failed to read a " + get_type_name<Prod>());
     }
 
-    return std::unique_ptr<PROD const>(static_cast<PROD const*>(raw_ptr));
+    return std::unique_ptr<Prod const>(static_cast<Prod const*>(raw_ptr));
   }
 
-  template <class... PRODS>
-  inline std::tuple<std::unique_ptr<PRODS const>...> read(form::technology::id const technology)
+  template <class... Prods>
+  inline std::tuple<std::unique_ptr<Prods const>...> read(form::technology::id const technology)
   {
     auto file = create_file(technology, std::string(test_file_name), 'i');
 
-    return std::make_tuple(do_read<PRODS>(file, technology)...);
+    return std::make_tuple(do_read<Prods>(file, technology)...);
   }
 
   inline form::technology::id get_technology(std::string const& tech_string)

--- a/test/form/test_utils.hpp
+++ b/test/form/test_utils.hpp
@@ -17,94 +17,94 @@ using namespace form::detail::experimental;
 
 namespace form::test {
 
-  inline constexpr char const* testTreeName = "FORMTestTree";
-  inline constexpr char const* testFileName = "FORMTestFile.root";
+  inline constexpr char const* test_tree_name = "FORMTestTree";
+  inline constexpr char const* test_file_name = "FORMTestFile.root";
 
   template <class PROD>
-  inline std::string getTypeName()
+  inline std::string get_type_name()
   {
-    return DemangleName(typeid(PROD));
+    return demangle_name(typeid(PROD));
   }
 
   template <class PROD>
-  inline std::string makeTestBranchName()
+  inline std::string make_test_branch_name()
   {
-    auto branchName = std::string(testTreeName) + "/" + getTypeName<PROD>();
-    for (size_t firstSpace = branchName.find_first_of(' '); firstSpace != std::string::npos;
-         firstSpace = branchName.find_first_of(' ')) {
-      branchName = branchName.erase(firstSpace, 1);
+    auto branch_name = std::string(test_tree_name) + "/" + get_type_name<PROD>();
+    for (size_t first_space = branch_name.find_first_of(' '); first_space != std::string::npos;
+         first_space = branch_name.find_first_of(' ')) {
+      branch_name = branch_name.erase(first_space, 1);
     }
-    return branchName;
+    return branch_name;
   }
 
-  inline std::vector<std::shared_ptr<IStorage_Write_Container>> doWrite(
-    std::shared_ptr<IStorage_File>& /*file*/,
-    form::technology::Id const /*technology*/,
-    std::shared_ptr<IStorage_Write_Container>& /*parent*/)
+  inline std::vector<std::shared_ptr<i_storage_write_container>> do_write(
+    std::shared_ptr<i_storage_file>& /*file*/,
+    form::technology::id const /*technology*/,
+    std::shared_ptr<i_storage_write_container>& /*parent*/)
   {
     return {};
   }
 
   template <class PROD, class... PRODS>
-  inline std::vector<std::shared_ptr<IStorage_Write_Container>> doWrite(
-    std::shared_ptr<IStorage_File>& file,
-    form::technology::Id const technology,
-    std::shared_ptr<IStorage_Write_Container>& parent,
+  inline std::vector<std::shared_ptr<i_storage_write_container>> do_write(
+    std::shared_ptr<i_storage_file>& file,
+    form::technology::id const technology,
+    std::shared_ptr<i_storage_write_container>& parent,
     PROD& prod,
     PRODS&... prods)
   {
-    auto const branchName = makeTestBranchName<PROD>();
-    auto container = createWriteContainer(technology, branchName);
-    auto assoc = dynamic_pointer_cast<Storage_Associative_Write_Container>(container);
+    auto const branch_name = make_test_branch_name<PROD>();
+    auto container = create_write_container(technology, branch_name);
+    auto assoc = dynamic_pointer_cast<storage_associative_write_container>(container);
     if (assoc) {
-      assoc->setParent(parent);
+      assoc->set_parent(parent);
     }
-    container->setFile(file);
-    container->setupWrite(typeid(PROD));
+    container->set_file(file);
+    container->setup_write(typeid(PROD));
 
-    auto result = doWrite(file, technology, parent, prods...);
-    container->fill(&prod); //This must happen after setupWrite()
+    auto result = do_write(file, technology, parent, prods...);
+    container->fill(&prod); //This must happen after setup_write()
     result.push_back(container);
     return result;
   }
 
   template <class... PRODS>
-  inline void write(form::technology::Id const technology, PRODS&... prods)
+  inline void write(form::technology::id const technology, PRODS&... prods)
   {
-    auto file = createFile(technology, std::string(testFileName), 'o');
-    auto parent = createWriteAssociation(technology, std::string(testTreeName));
-    parent->setFile(file);
-    parent->setupWrite();
+    auto file = create_file(technology, std::string(test_file_name), 'o');
+    auto parent = create_write_association(technology, std::string(test_tree_name));
+    parent->set_file(file);
+    parent->setup_write();
 
-    auto keepContainersAlive = doWrite(file, technology, parent, prods...);
-    keepContainersAlive.back()
+    auto keep_containers_alive = do_write(file, technology, parent, prods...);
+    keep_containers_alive.back()
       ->commit(); //Elements are in reverse order of container construction, so this makes sure container owner calls commit()
   }
 
   template <class PROD>
-  inline std::unique_ptr<PROD const> doRead(std::shared_ptr<IStorage_File>& file,
-                                            form::technology::Id const technology)
+  inline std::unique_ptr<PROD const> do_read(std::shared_ptr<i_storage_file>& file,
+                                             form::technology::id const technology)
   {
-    auto container = createReadContainer(technology, makeTestBranchName<PROD>());
-    container->setFile(file);
-    void const* rawPtr = nullptr;
+    auto container = create_read_container(technology, make_test_branch_name<PROD>());
+    container->set_file(file);
+    void const* raw_ptr = nullptr;
 
-    if (!container->read(0, &rawPtr, typeid(PROD))) {
-      throw std::runtime_error("Failed to read a " + getTypeName<PROD>());
+    if (!container->read(0, &raw_ptr, typeid(PROD))) {
+      throw std::runtime_error("Failed to read a " + get_type_name<PROD>());
     }
 
-    return std::unique_ptr<PROD const>(static_cast<PROD const*>(rawPtr));
+    return std::unique_ptr<PROD const>(static_cast<PROD const*>(raw_ptr));
   }
 
   template <class... PRODS>
-  inline std::tuple<std::unique_ptr<PRODS const>...> read(form::technology::Id const technology)
+  inline std::tuple<std::unique_ptr<PRODS const>...> read(form::technology::id const technology)
   {
-    auto file = createFile(technology, std::string(testFileName), 'i');
+    auto file = create_file(technology, std::string(test_file_name), 'i');
 
-    return std::make_tuple(doRead<PRODS>(file, technology)...);
+    return std::make_tuple(do_read<PRODS>(file, technology)...);
   }
 
-  inline form::technology::Id getTechnology(std::string const& tech_string)
+  inline form::technology::id get_technology(std::string const& tech_string)
   {
     return form::technology::from_string(tech_string);
   }

--- a/test/form/toy_tracker.cpp
+++ b/test/form/toy_tracker.cpp
@@ -5,7 +5,7 @@
 #include <cassert>
 #include <chrono>
 
-ToyTracker::ToyTracker(int max_tracks) :
+toy_tracker::toy_tracker(int max_tracks) :
   gen_(std::chrono::system_clock().now().time_since_epoch().count()),
   size_dist_(0, max_tracks - 1),
   value_dist_(0, 1)
@@ -13,13 +13,13 @@ ToyTracker::ToyTracker(int max_tracks) :
   assert(max_tracks > 1);
 }
 
-std::vector<TrackStart> ToyTracker::operator()()
+std::vector<track_start> toy_tracker::operator()()
 {
   int32_t const npx = size_dist_(gen_);
-  std::vector<TrackStart> points;
+  std::vector<track_start> points;
   points.reserve(npx);
   std::generate_n(std::back_inserter(points), npx, [this] {
-    return TrackStart(value_dist_(gen_), value_dist_(gen_), value_dist_(gen_));
+    return track_start(value_dist_(gen_), value_dist_(gen_), value_dist_(gen_));
   });
 
   return points;

--- a/test/form/toy_tracker.hpp
+++ b/test/form/toy_tracker.hpp
@@ -5,14 +5,14 @@
 #include <random>
 #include <vector>
 
-class TrackStart;
+class track_start;
 
-class ToyTracker {
+class toy_tracker {
 public:
-  explicit ToyTracker(int max_tracks);
-  ~ToyTracker() = default;
+  explicit toy_tracker(int max_tracks);
+  ~toy_tracker() = default;
 
-  std::vector<TrackStart> operator()();
+  std::vector<track_start> operator()();
 
 private:
   std::mt19937 gen_;

--- a/test/form/writer.cpp
+++ b/test/form/writer.cpp
@@ -19,18 +19,18 @@
 #include <ranges>
 #include <vector>
 
-static int const NUMBER_EVENT = 4;
-static int const NUMBER_SEGMENT = 15;
+static int const number_event = 4;
+static int const number_segment = 15;
 
-struct Generator {
-  Generator() : gen_(std::chrono::system_clock::now().time_since_epoch().count()), dist_(0, 1) {}
+struct generator {
+  generator() : gen_(std::chrono::system_clock::now().time_since_epoch().count()), dist_(0, 1) {}
 
   void operator()(std::vector<float>& vrand, int size)
   {
     assert(size > 1);
     std::uniform_int_distribution size_dist(0, size - 1);
-    size_t const howMany = size_dist(gen_);
-    vrand.resize(howMany);
+    size_t const how_many = size_dist(gen_);
+    vrand.resize(how_many);
 
     for (auto& rand : vrand) {
       rand = dist_(gen_);
@@ -48,25 +48,25 @@ int main(int argc, char** argv)
 
   std::string const filename = (argc > 1) ? argv[1] : "toy.root";
   std::string const checksum_filename = (argc > 2) ? argv[2] : "toy_checksums.txt";
-  auto const technology = form::test::getTechnology((argc > 3) ? argv[3] : "ROOT_TTREE");
+  auto const technology = form::test::get_technology((argc > 3) ? argv[3] : "ROOT_TTREE");
 
   // TODO: Read configuration from config file instead of hardcoding
-  form::experimental::config::ItemConfig config_items;
-  config_items.addItem("trackStart", filename, technology);
-  config_items.addItem("trackNumberHits", filename, technology);
-  config_items.addItem("trackStartPoints", filename, technology);
-  config_items.addItem("trackStartX", filename, technology);
+  form::experimental::config::item_config config_items;
+  config_items.add_item("trackStart", filename, technology);
+  config_items.add_item("trackNumberHits", filename, technology);
+  config_items.add_item("trackStartPoints", filename, technology);
+  config_items.add_item("trackStartX", filename, technology);
 
   form::experimental::config::tech_setting_config tech_config;
-  tech_config.container_settings[form::technology::ROOT_TTREE]["trackStart"].emplace_back(
+  tech_config.container_settings[form::technology::root_ttree]["trackStart"].emplace_back(
     "auto_flush", "1");
   tech_config.file_settings[technology]["toy.root"].emplace_back("compression", "kZSTD");
-  tech_config.container_settings[form::technology::ROOT_RNTUPLE]["Toy_Tracker/trackStartPoints"]
+  tech_config.container_settings[form::technology::root_rntuple]["Toy_Tracker/trackStartPoints"]
     .emplace_back("force_streamer_field", "true");
 
   form::experimental::form_writer_interface form(config_items, tech_config);
 
-  ToyTracker tracker(4 * 1024);
+  toy_tracker tracker(4 * 1024);
 
   // Open checksum file for writing
   std::ofstream checksum_file(checksum_filename);
@@ -75,14 +75,14 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  Generator generate;
+  generator generate;
 
-  for (int nevent = 0; nevent < NUMBER_EVENT; nevent++) {
+  for (int nevent = 0; nevent < number_event; nevent++) {
     std::cout << "PHLEX: Write Event No. " << nevent << '\n';
 
     std::vector<float> track_x;
 
-    for (int nseg = 0; nseg < NUMBER_SEGMENT; nseg++) {
+    for (int nseg = 0; nseg < number_segment; nseg++) {
 
       std::vector<float> track_start_x;
       generate(track_start_x, 4 * 1024 /* * 1024*/); // sub-event processing
@@ -115,25 +115,25 @@ int main(int argc, char** argv)
         .label = "trackNumberHits", .data = &track_n_hits, .type = &typeid(std::vector<int>)};
       products.push_back(pb_int);
 
-      std::vector<TrackStart> start_points = tracker();
-      TrackStart checkPoints;
-      for (TrackStart const& point : start_points) {
-        checkPoints += point;
+      std::vector<track_start> start_points = tracker();
+      track_start check_points;
+      for (track_start const& point : start_points) {
+        check_points += point;
       }
       std::cout << "PHLEX: Segment = " << nseg << ": seg_id_text = " << seg_id_text
-                << ", checkPoints = " << checkPoints << '\n';
+                << ", check_points = " << check_points << '\n';
 
       form::experimental::product_with_name pb_points = {.label = "trackStartPoints",
                                                          .data = &start_points,
-                                                         .type = &typeid(std::vector<TrackStart>)};
+                                                         .type = &typeid(std::vector<track_start>)};
       products.push_back(pb_points);
 
       form.write(creator, segment_id, products);
 
       // Save segment checksums
       checksum_file << std::setprecision(10) << "SEG " << nevent << " " << nseg << " " << check
-                    << " " << checkPoints.getX() << " " << checkPoints.getY() << " "
-                    << checkPoints.getZ() << "\n";
+                    << " " << check_points.get_x() << " " << check_points.get_y() << " "
+                    << check_points.get_z() << "\n";
       track_x.insert(track_x.end(), track_start_x.begin(), track_start_x.end());
     }
 


### PR DESCRIPTION
**Summary**

- Adopts the Phlex naming convention (issue #831 ) across `form/` and `test/form/`.
- Every identifier moves to `lower_case`, with the `.clang-tidy` exceptions: `UPPER_CASE` macros, `CamelCase` template parameters, and a trailing `_` on private/protected/constant members. **This is a mechanical rename — no behavior or logic changes.** 
- Resolves #831.

**Note:**
GCC CI fix: the `Major`→`major` rename left id's member `major` sharing its type's spelling, which GCC's -Wchanges-meaning rejects (clang accepts, hence the clang-only local pass). Qualified the member's type — `form::technology::major major{};` — keeping the `{major, minor}` names. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Applied the Phlex C++ naming convention across `form/` and `test/form/`.
  - Renamed classes, functions, variables, types, constants, and APIs to lowercase `snake_case`.
  - Renamed private and protected members from `m_` prefixes to trailing underscores.
  - Updated declarations, definitions, call sites, diagnostics, and related type references consistently.
  - Preserved behavior, control flow, error handling, ownership, and serialization logic.

- **Tests and support files**
  - Updated FORM tests, data products, ROOT dictionaries, XML registrations, and test utilities.
  - Renamed `TrackStart` and `ToyTracker` to `track_start` and `toy_tracker`.
  - Updated test APIs and identifiers to match the renamed FORM interfaces.

- **Compatibility**
  - This is a mechanical API and identifier rename.
  - Existing camelCase and PascalCase names are no longer available in the affected areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->