### PR TITLE
Minor improvements to `git-ai-commit`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,10 +42,11 @@ _codeql_detected_source_root
 .\#*
 \#*#
 
-# Python cache
+# Python caches
 __pycache__/
 *.pyc
 *.pyo
+.mypy_cache/
 
 # Documentation build output
 docs/doxygen/

--- a/scripts/git-ai-commit
+++ b/scripts/git-ai-commit
@@ -227,8 +227,7 @@ def _find_model_key(models: dict[str, dict[str, Any]], model: str) -> str | None
         # malformed file could put a non-dict value here despite the type hint.
         if not isinstance(entry, dict):
             continue  # type: ignore[unreachable]
-        identifier = entry.get("id") or entry.get("name")
-        if identifier == model:
+        if entry.get("id") == model or entry.get("name") == model:
             return key
     return None
 

--- a/scripts/git-ai-commit
+++ b/scripts/git-ai-commit
@@ -8,7 +8,6 @@ See `git-ai-commit --help` for full usage.
 from __future__ import annotations
 
 import argparse
-import contextlib
 import json
 import os
 import re
@@ -1253,17 +1252,13 @@ def _edit(text: str) -> str:
 def _confirm(prompt: str) -> bool:
     """Prompt for y/N, opening /dev/tty if stdin is a pipe."""
     try:
-        with contextlib.ExitStack() as stack:
-            if sys.stdin.isatty():
-                source = sys.stdin
-            else:
-                # enter_context registers the file's __exit__ on the stack, so
-                # the file is closed automatically when the `with` block exits.
-                # codeql[py/file-not-closed]
-                source = stack.enter_context(open("/dev/tty", encoding="utf-8"))  # noqa: SIM115
-            print(f"{prompt} [y/N] ", end="", flush=True)
-            reply = source.readline().strip().lower()
-            return reply in ("y", "yes")
+        print(f"{prompt} [y/N] ", end="", flush=True)
+        if sys.stdin.isatty():
+            reply = sys.stdin.readline().strip().lower()
+        else:
+            with open("/dev/tty", encoding="utf-8") as source:
+                reply = source.readline().strip().lower()
+        return reply in ("y", "yes")
     except (EOFError, KeyboardInterrupt, OSError):
         print()
         return False
@@ -1535,15 +1530,11 @@ def main() -> None:
             # Prompt user with extended options: yes, no, edit.
             print("Commit with this message? [y/N/e] ", end="", flush=True)
             try:
-                with contextlib.ExitStack() as stack:
-                    if sys.stdin.isatty():
-                        source = sys.stdin
-                    else:
-                        # enter_context registers the file's __exit__ on the stack, so
-                        # the file is closed automatically when the `with` block exits.
-                        # codeql[py/file-not-closed]
-                        source = stack.enter_context(open("/dev/tty", encoding="utf-8"))  # noqa: SIM115
-                    reply = source.readline().strip().lower()
+                if sys.stdin.isatty():
+                    reply = sys.stdin.readline().strip().lower()
+                else:
+                    with open("/dev/tty", encoding="utf-8") as source:
+                        reply = source.readline().strip().lower()
             except (EOFError, KeyboardInterrupt, OSError):
                 print()
                 reply = ""

--- a/scripts/git-ai-commit
+++ b/scripts/git-ai-commit
@@ -1519,6 +1519,7 @@ def main() -> None:
         return
 
     if args.edit:
+        # Open editor automatically and bypass confirmation.
         try:
             message = _edit(message)
         except _Error as exc:
@@ -1530,10 +1531,34 @@ def main() -> None:
         _print_rule(message)
     else:
         _print_rule(message)
-
-    if not args.yes and not _confirm("Commit with this message?"):
-        print("Aborted.", file=sys.stderr)
-        sys.exit(0)
+        if not args.yes:
+            # Prompt user with extended options: yes, no, edit.
+            print("Commit with this message? [y/N/e] ", end="", flush=True)
+            try:
+                with contextlib.ExitStack() as stack:
+                    if sys.stdin.isatty():
+                        source = sys.stdin
+                    else:
+                        source = stack.enter_context(open("/dev/tty", encoding="utf-8"))
+                    reply = source.readline().strip().lower()
+            except (EOFError, KeyboardInterrupt, OSError):
+                print()
+                reply = ""
+            if reply in ("y", "yes"):
+                pass  # proceed to commit
+            elif reply in ("e", "edit"):
+                try:
+                    message = _edit(message)
+                except _Error as exc:
+                    print(f"git-ai-commit: {exc}", file=sys.stderr)
+                    sys.exit(1)
+                if not message.strip():
+                    print("Empty message — aborting.", file=sys.stderr)
+                    sys.exit(0)
+                _print_rule(message)
+            else:
+                print("Aborted.", file=sys.stderr)
+                sys.exit(0)
 
     cmd = ["git", "commit"]
     if args.amend:

--- a/scripts/git-ai-commit
+++ b/scripts/git-ai-commit
@@ -19,7 +19,7 @@ import textwrap
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import TextIO
+from typing import Any, TextIO
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -63,8 +63,22 @@ _KILO_DEFAULT_MODEL = "qwen/qwen3-coder-next"
 _DEFAULT_MODEL_KILO = _KILO_MODEL_ENV or _KILO_DEFAULT_MODEL
 _DEFAULT_MODEL_OTHER = "gpt-4o"
 
-# Path to kilo config file
-_KILO_CONFIG_PATH = Path.home() / ".config" / "kilo" / "kilo.jsonc"
+# Path to kilo config file. Kilo's global config directory accepts either
+# kilo.json or kilo.jsonc; check both, preferring kilo.json since that is
+# what `kilo-sync-models` currently writes.
+_KILO_CONFIG_DIR = Path.home() / ".config" / "kilo"
+_KILO_CONFIG_CANDIDATES = (
+    _KILO_CONFIG_DIR / "kilo.json",
+    _KILO_CONFIG_DIR / "kilo.jsonc",
+)
+
+
+def _kilo_config_path() -> Path | None:
+    """Return the first existing kilo config file, or None if neither exists."""
+    for candidate in _KILO_CONFIG_CANDIDATES:
+        if candidate.exists():
+            return candidate
+    return None
 
 
 _MAX_DIFF_CHARS_DEFAULT = 60_000
@@ -96,11 +110,14 @@ def _load_kilo_config() -> dict:
     Returns a dict with 'disabled_providers' and 'provider' keys.
     'provider' maps provider names to provider configs, each containing a 'models' dict.
     """
-    if not _KILO_CONFIG_PATH.exists():
+    config_path = _kilo_config_path()
+    if config_path is None:
         return {"disabled_providers": [], "provider": {}}
     try:
-        # Use json.loads after removing comments (kilo.jsonc supports comments)
-        content = _KILO_CONFIG_PATH.read_text(encoding="utf-8")
+        # Use json.loads after removing comments (kilo.jsonc supports comments;
+        # harmless to strip from plain kilo.json too since "//" never appears
+        # outside of string values there).
+        content = config_path.read_text(encoding="utf-8")
         # A simple state-based scanner to remove comments while preserving strings.
         cleaned = []
         in_string = False
@@ -163,16 +180,17 @@ def _load_kilo_config() -> dict:
         return {"disabled_providers": [], "provider": {}}
 
 
-def _load_kilo_config_with_models() -> dict[str, dict[str, str]]:
+def _load_kilo_config_with_models() -> dict[str, dict[str, dict[str, Any]]]:
     """Load kilo config and return a mapping of provider names to model dicts.
 
-    Returns a dict mapping Kilo config provider names to dicts of model keys.
-    For example: {"fnal-ow": {"qwen/qwen3-coder-next": {...}, ...}}
+    Returns a dict mapping Kilo config provider names to dicts of model
+    entries, keyed by the short config key. For example:
+    {"fnal-ow": {"qwen3-coder-next": {"id": "qwen/qwen3-coder-next", ...}}}
     """
     config = _load_kilo_config()
     disabled = set(config.get("disabled_providers", []))
     provider_config = config.get("provider", {})
-    mapping: dict[str, dict[str, str]] = {}
+    mapping: dict[str, dict[str, dict[str, Any]]] = {}
 
     for provider_name, provider_data in provider_config.items():
         if provider_name in disabled or not isinstance(provider_data, dict):
@@ -193,48 +211,88 @@ def _get_kilo_provider_names() -> list[str]:
     return [name for name in provider_config.keys() if name not in disabled]
 
 
+def _find_model_key(models: dict[str, dict[str, Any]], model: str) -> str | None:
+    """Return the config dict key within *models* that identifies *model*.
+
+    Matches *model* against each entry's dict key first (the form the
+    `kilo` CLI's `-m` flag actually accepts), then falls back to the
+    entry's "id" field, or its "name" field if "id" is absent. This lets
+    callers pass either the short config key (e.g. "haiku-4-5") or the
+    provider-qualified id/name (e.g. "azure/claude-haiku-4-5") and still
+    resolve to the same entry.
+    """
+    if model in models:
+        return model
+    for key, entry in models.items():
+        # Defensive: kilo.json entries are untrusted external data, so a
+        # malformed file could put a non-dict value here despite the type hint.
+        if not isinstance(entry, dict):
+            continue  # type: ignore[unreachable]
+        identifier = entry.get("id") or entry.get("name")
+        if identifier == model:
+            return key
+    return None
+
+
 def _resolve_kilo_model(model: str) -> str:
     """Resolve a kilo model name, adding provider prefix if needed.
 
     Logic:
     1. If model contains "/" (e.g., "qwen/"), check if the prefix is a known
        provider in the Kilo config.
-    2a. If the prefix IS a known provider, the model is passed to kilo as-is.
-    2b. If the prefix is NOT a known provider, the full model (including prefix)
-        is treated as the model name and looked up in the config.
-    3. If model has no prefix, it is looked up directly in the config.
+    2a. If the prefix IS a known provider, the remainder is matched against
+        that provider's models by config key, falling back to each entry's
+        "id" (or "name") field.
+    2b. If the prefix is NOT a known provider, the full model (including
+        prefix) is treated as the model name and matched the same way
+        across all providers.
+    3. If model has no prefix, it is matched directly across all providers,
+       by config key first, then by "id" (or "name").
     4. If the lookup is ambiguous (multiple providers have the model), raise an error.
 
-    Returns the fully-qualified model name in format "provider/model".
+    The config key is always what gets returned for the matched provider,
+    since that is the only form `kilo run -m` accepts; the "id"/"name"
+    fields are only used to identify which entry the caller meant.
+
+    Returns the fully-qualified model name in format "provider/key".
     Raises _Error if the model lookup is ambiguous.
     """
     provider_models = _load_kilo_config_with_models()
     known_providers = set(_get_kilo_provider_names())
 
-    # If no model is provided, use the default
+    # If no model is provided, resolve the default the same way as any
+    # other input (it may itself be in "id" form, e.g. "qwen/qwen3-coder-next").
     if not model:
-        return _DEFAULT_MODEL_KILO
+        model = _DEFAULT_MODEL_KILO
 
     # If model has a prefix (contains "/"), check if it's a known provider
     if "/" in model:
         prefix, rest = model.split("/", 1)
         if prefix in known_providers:
-            # The prefix is a known provider - pass model as-is to kilo
+            key = _find_model_key(provider_models.get(prefix, {}), rest)
+            if key is not None:
+                return f"{prefix}/{key}"
+            # Not found under this provider (e.g. a model not yet synced
+            # into the config); pass through as-is and let kilo report
+            # any error.
             return model
 
         # The prefix is NOT a known provider - treat full model as model name
-        # and look it up in config
+        # and look it up across all providers
         candidate_providers = []
+        candidate_keys: dict[str, str] = {}  # provider -> key
         for provider_name, models in provider_models.items():
-            if model in models:
+            key = _find_model_key(models, model)
+            if key is not None:
                 candidate_providers.append(provider_name)
+                candidate_keys[provider_name] = key
 
         if len(candidate_providers) == 0:
             # Model not found in config; return as-is
             return model
         elif len(candidate_providers) == 1:
             # Unambiguous lookup
-            return f"{candidate_providers[0]}/{model}"
+            return f"{candidate_providers[0]}/{candidate_keys[candidate_providers[0]]}"
         else:
             # Ambiguous lookup - raise error with available providers
             raise _Error(
@@ -243,28 +301,22 @@ def _resolve_kilo_model(model: str) -> str:
                 "Please disambiguate by specifying one of these providers as a prefix."
             )
 
-    # Model has no prefix - look it up directly in config
+    # Model has no prefix - look it up directly across all providers
     candidate_providers = []
-    candidate_full_names: dict[str, str] = {}  # provider -> full_name
+    candidate_keys = {}  # provider -> key
 
     for provider_name, models in provider_models.items():
-        for full_name in models.keys():
-            # Extract short name (after first "/")
-            if "/" in full_name:
-                short_name = full_name.split("/", 1)[1]
-            else:
-                short_name = full_name
-
-            if short_name == model:
-                candidate_providers.append(provider_name)
-                candidate_full_names[provider_name] = full_name
+        key = _find_model_key(models, model)
+        if key is not None:
+            candidate_providers.append(provider_name)
+            candidate_keys[provider_name] = key
 
     if len(candidate_providers) == 0:
         # Model not found in config; return as-is
         return model
     elif len(candidate_providers) == 1:
         # Unambiguous lookup
-        return f"{candidate_providers[0]}/{candidate_full_names[candidate_providers[0]]}"
+        return f"{candidate_providers[0]}/{candidate_keys[candidate_providers[0]]}"
     else:
         # Ambiguous lookup - raise error with available providers
         raise _Error(

--- a/scripts/git-ai-commit
+++ b/scripts/git-ai-commit
@@ -76,7 +76,7 @@ _KILO_CONFIG_CANDIDATES = (
 def _kilo_config_path() -> Path | None:
     """Return the first existing kilo config file, or None if neither exists."""
     for candidate in _KILO_CONFIG_CANDIDATES:
-        if candidate.exists():
+        if candidate.is_file():
             return candidate
     return None
 

--- a/scripts/git-ai-commit
+++ b/scripts/git-ai-commit
@@ -1539,7 +1539,10 @@ def main() -> None:
                     if sys.stdin.isatty():
                         source = sys.stdin
                     else:
-                        source = stack.enter_context(open("/dev/tty", encoding="utf-8"))
+                        # enter_context registers the file's __exit__ on the stack, so
+                        # the file is closed automatically when the `with` block exits.
+                        # codeql[py/file-not-closed]
+                        source = stack.enter_context(open("/dev/tty", encoding="utf-8"))  # noqa: SIM115
                     reply = source.readline().strip().lower()
             except (EOFError, KeyboardInterrupt, OSError):
                 print()

--- a/scripts/man/man1/git-ai-commit.1
+++ b/scripts/man/man1/git-ai-commit.1
@@ -106,10 +106,11 @@ running \fBgit commit\fR.  Useful for scripting or inspection.
 Skip the interactive confirmation prompt and commit immediately.
 .TP
 \fB\-e\fR, \fB\-\-edit\fR
-Open the generated message in \fB$EDITOR\fR (falling back to \fB$VISUAL\fR,
-then \fBvi\fR) before committing.  Lines beginning with \fB#\fR are stripped.
-An empty message aborts the commit.  If standard input is a terminal, \fB$VISUAL\fR is
-preferred over \fB$EDITOR\fR; otherwise, \fB$EDITOR\fR is preferred.
+Open the generated message in \fB$VISUAL\fR (if standard input is a terminal and
+\fB$VISUAL\fR is set), otherwise \fB$EDITOR\fR, with \fBvi\fR as fallback, before
+committing.  Lines beginning with \fB#\fR are stripped from the edited message.
+An empty edited message aborts the commit.  Typing \fBe\fR at the confirmation
+prompt triggers the same editor flow.
 .TP
 \fB\-\-no\-instructions\fR
 Skip all instruction and context files; include only the diff, status,
@@ -195,9 +196,9 @@ Deprecated.  Use \fBGIT_AI_COMMIT_API\fR instead.
 Deprecated.  Use \fBGIT_AI_COMMIT_MODEL\fR instead.
 .TP
 \fBEDITOR\fR, \fBVISUAL\fR
-Editor invoked by \fB\-\-edit\fR.  Preferred order depends on whether standard
-input is a terminal: \fB$VISUAL\fR then \fB$EDITOR\fR for terminals, \fB$EDITOR\fR
-then \fB$VISUAL\fR otherwise; \fBvi\fR is the final fallback.
+Editor invoked by \fB\-\-edit\fR.  \fB$VISUAL\fR is preferred on a TTY (when standard
+input is a terminal and \fB$VISUAL\fR is set), otherwise \fB$EDITOR\fR is used;
+\fBvi\fR is the final fallback when neither is set.
 .SH EXAMPLES
 Stage all changes and commit with a generated message, confirming interactively:
 .PP

--- a/scripts/test/test_git_ai_commit.py
+++ b/scripts/test/test_git_ai_commit.py
@@ -238,6 +238,23 @@ class TestCleanMessage:
         expected = "feat: add new feature"
         assert _clean_message(raw) == expected
 
+    def test_long_first_line_stripped(self) -> None:
+        """First line >72 chars (without prefix) is stripped as preamble."""
+        long_line = (
+            "This is a very long first line that exceeds seventy two characters and should "
+            "be treated as preamble"
+        )
+        assert len(long_line) > 72
+        raw = f"{long_line}\n\nfeat: add new feature\n\nBody content."
+        expected = "feat: add new feature\n\nBody content."
+        assert _clean_message(raw) == expected
+
+    def test_prefix_first_line_stripped(self) -> None:
+        """First line starting with prefix (but <=72 chars) is stripped as preamble."""
+        raw = "Here is the commit message\n\nfeat: add new feature\n\nBody content."
+        expected = "feat: add new feature\n\nBody content."
+        assert _clean_message(raw) == expected
+
     def test_no_preamble_returns_cleaned(self) -> None:
         """Message without preamble is returned stripped."""
         raw = "feat: add new feature  \n  \n  Some context.\n  "

--- a/scripts/test/test_git_ai_commit.py
+++ b/scripts/test/test_git_ai_commit.py
@@ -695,6 +695,390 @@ def _raise_exception() -> str:
 
 
 # ===========================================================================
+# main() with --edit flag
+# ===========================================================================
+
+
+class TestEditFlag:
+    """Tests for the -e/--edit flag behavior in main()."""
+
+    def test_edit_flag_invokes_editor(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When --edit is set, the editor is invoked on the AI-generated message."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit", "--backend", "kilo", "--yes", "--edit"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "diff content")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        monkeypatch.setattr(_M, "_token", lambda _backend, _model: "tok")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+        monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "test_token")
+        monkeypatch.setenv("EDITOR", "vi")
+
+        editor_cmd: list[str] = []
+        call_count = [0]
+
+        def _mock_subprocess(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            call_count[0] += 1
+            if cmd[0] == "kilo":
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="feat: original message", stderr=""
+                )
+            elif cmd[0] == "vi":
+                editor_cmd.extend(cmd)
+                # Simulate user editing
+                Path(cmd[-1]).write_text(
+                    "feat: edited message\n# comment to strip", encoding="utf-8"
+                )
+                return subprocess.CompletedProcess(cmd, 0)
+            elif cmd[0] == "git" and cmd[1] == "commit":
+                return subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=_mock_subprocess):
+            _M.main()
+
+        assert editor_cmd[0] == "vi"
+
+    def test_edit_flag_strips_comment_lines(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When --edit is set, comment lines are stripped from the edited message."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit", "--backend", "kilo", "--yes", "--edit"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "diff content")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        monkeypatch.setattr(_M, "_token", lambda _backend, _model: "tok")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+        monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "test_token")
+        monkeypatch.setenv("EDITOR", "vi")
+
+        captured_message: list[str] = []
+
+        def _mock_subprocess(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            if cmd[0] == "kilo":
+                # Return a mock kilo response
+                return subprocess.CompletedProcess(cmd, 0, stdout="feat: ai generated", stderr="")
+            elif cmd[0] == "vi":
+                Path(cmd[-1]).write_text(
+                    "feat: final message\n# this is a comment\n\n# another comment",
+                    encoding="utf-8",
+                )
+                return subprocess.CompletedProcess(cmd, 0)
+            elif cmd[0] == "git" and cmd[1] == "commit":
+                msg_idx = cmd.index("-m") + 1
+                captured_message.append(cmd[msg_idx])
+                return subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=_mock_subprocess):
+            _M.main()
+
+        assert len(captured_message) == 1
+        # Comment lines should be stripped
+        assert "# this is a comment" not in captured_message[0]
+        assert "# another comment" not in captured_message[0]
+        assert "feat: final message" in captured_message[0]
+
+    def test_edit_flag_tempfile_cleaned_up(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The temporary file used by _edit is removed after editing."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit", "--backend", "kilo", "--yes", "--edit"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "diff content")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        monkeypatch.setattr(_M, "_token", lambda _backend, _model: "tok")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+        monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "test_token")
+        monkeypatch.setenv("EDITOR", "vi")
+
+        recorded_tmpfile: list[Path] = []
+
+        def _mock_subprocess(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            if cmd[0] == "kilo":
+                return subprocess.CompletedProcess(cmd, 0, stdout="feat: ai generated", stderr="")
+            elif cmd[0] == "vi":
+                recorded_tmpfile.append(Path(cmd[-1]))
+                Path(cmd[-1]).write_text("feat: edited", encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0)
+            elif cmd[0] == "git" and cmd[1] == "commit":
+                return subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=_mock_subprocess):
+            _M.main()
+
+        assert len(recorded_tmpfile) == 1
+        assert not recorded_tmpfile[0].exists(), "temp file was not cleaned up"
+
+    def test_edit_flag_empty_message_aborts(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An empty message after editing (only comments or whitespace) aborts the commit."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit", "--backend", "kilo", "--yes", "--edit"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "diff content")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        monkeypatch.setattr(_M, "_token", lambda _backend, _model: "tok")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+        monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "test_token")
+        monkeypatch.setenv("EDITOR", "vi")
+
+        def _mock_subprocess(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            if cmd[0] == "kilo":
+                return subprocess.CompletedProcess(cmd, 0, stdout="feat: ai generated", stderr="")
+            elif cmd[0] == "vi":
+                # User enters only comments
+                Path(cmd[-1]).write_text("# only comments\n# nothing else", encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=_mock_subprocess):
+            with pytest.raises(SystemExit) as exc:
+                _M.main()
+
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        assert "Empty message" in captured.err
+
+    def test_edit_flag_with_short_option(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The -e short option works the same as --edit."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit", "-e", "--yes"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "diff content")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        monkeypatch.setattr(_M, "_token", lambda _backend, _model: "tok")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+        monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "test_token")
+        monkeypatch.setenv("EDITOR", "vi")
+
+        editor_called = False
+
+        def _mock_subprocess(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            nonlocal editor_called
+            if cmd[0] == "kilo":
+                return subprocess.CompletedProcess(cmd, 0, stdout="feat: ai generated", stderr="")
+            elif cmd[0] == "vi":
+                editor_called = True
+                Path(cmd[-1]).write_text("feat: via -e", encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0)
+            elif cmd[0] == "git" and cmd[1] == "commit":
+                return subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=_mock_subprocess):
+            _M.main()
+
+        assert editor_called, "editor was not called with -e flag"
+
+
+# ===========================================================================
+# main() with 'e' prompt response (interactive mode)
+# ===========================================================================
+
+
+class TestEPromptResponse:
+    """Tests for 'e' (edit) response to the interactive y/N/e prompt."""
+
+    def test_e_prompt_invokes_editor(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When 'e' is entered at the prompt, the editor is invoked."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit", "--backend", "kilo"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "diff content")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        monkeypatch.setattr(_M, "_token", lambda _backend, _model: "tok")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "test_token")
+        monkeypatch.delenv("VISUAL", raising=False)
+        monkeypatch.setenv("EDITOR", "vi")
+
+        editor_called = False
+        call_count = [0]
+
+        def _mock_subprocess(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            call_count[0] += 1
+            if cmd[0] == "kilo":
+                return subprocess.CompletedProcess(cmd, 0, stdout="feat: ai generated", stderr="")
+            elif cmd[0] == "vi":
+                nonlocal editor_called
+                editor_called = True
+                Path(cmd[-1]).write_text("feat: edited via prompt\n# comment", encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0)
+            elif cmd[:2] == ["git", "commit"]:
+                return subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=_mock_subprocess):
+            # Simulate stdin with 'e' response - create stdin with isatty() method
+            stdin_mock = io.StringIO("e\n")
+            monkeypatch.setattr(stdin_mock, "isatty", lambda: True)
+            with patch.object(sys, "stdin", stdin_mock):
+                _M.main()
+
+        assert editor_called, "editor was not called when 'e' was entered at prompt"
+
+    def test_e_prompt_strips_comment_lines(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Comment lines are stripped from edited message when 'e' is entered at prompt."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit", "--backend", "kilo"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "diff content")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        monkeypatch.setattr(_M, "_token", lambda _backend, _model: "tok")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "test_token")
+        monkeypatch.delenv("VISUAL", raising=False)
+        monkeypatch.setenv("EDITOR", "vi")
+
+        captured_message: list[str] = []
+        call_count = [0]
+
+        def _mock_subprocess(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            call_count[0] += 1
+            if cmd[0] == "kilo":
+                return subprocess.CompletedProcess(cmd, 0, stdout="feat: ai generated", stderr="")
+            elif cmd[0] == "vi":
+                Path(cmd[-1]).write_text("feat: via prompt\n# comment line", encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0)
+            elif cmd[:2] == ["git", "commit"]:
+                msg_idx = cmd.index("-m") + 1
+                captured_message.append(cmd[msg_idx])
+                return subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=_mock_subprocess):
+            # Simulate stdin with 'e' response - create stdin with isatty() method
+            stdin_mock = io.StringIO("e\n")
+            monkeypatch.setattr(stdin_mock, "isatty", lambda: True)
+            with patch.object(sys, "stdin", stdin_mock):
+                _M.main()
+
+        assert len(captured_message) == 1
+        # Comment should be stripped
+        assert "# comment line" not in captured_message[0]
+        assert "feat: via prompt" in captured_message[0]
+
+    def test_e_prompt_tempfile_cleaned_up(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The temporary file is removed after editing via 'e' prompt."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit", "--backend", "kilo"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "diff content")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        monkeypatch.setattr(_M, "_token", lambda _backend, _model: "tok")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "test_token")
+        monkeypatch.delenv("VISUAL", raising=False)
+        monkeypatch.setenv("EDITOR", "vi")
+
+        recorded_tmpfile: list[Path] = []
+
+        def _mock_subprocess(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            if cmd[0] == "kilo":
+                return subprocess.CompletedProcess(cmd, 0, stdout="feat: ai generated", stderr="")
+            elif cmd[0] == "vi":
+                recorded_tmpfile.append(Path(cmd[-1]))
+                Path(cmd[-1]).write_text("feat: edited", encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0)
+            elif cmd[:2] == ["git", "commit"]:
+                return subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=_mock_subprocess):
+            # Simulate stdin with 'e' response - create stdin with isatty() method
+            stdin_mock = io.StringIO("e\n")
+            monkeypatch.setattr(stdin_mock, "isatty", lambda: True)
+            with patch.object(sys, "stdin", stdin_mock):
+                _M.main()
+
+        assert len(recorded_tmpfile) == 1
+        assert not recorded_tmpfile[0].exists(), "temp file was not cleaned up after 'e' prompt"
+
+    def test_e_prompt_empty_message_aborts(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An empty message after editing via 'e' prompt aborts the commit."""
+        monkeypatch.setattr(sys, "argv", ["git-ai-commit", "--backend", "kilo"])
+        monkeypatch.setattr(_M, "_git_root", lambda: tmp_path)
+        monkeypatch.setattr(_M, "_staged_diff", lambda _amend=False: "diff content")
+        monkeypatch.setattr(_M, "_status", lambda: "")
+        monkeypatch.setattr(_M, "_recent_log", lambda: "")
+        monkeypatch.setattr(_M, "_get_instructions", lambda _root: "")
+        monkeypatch.setattr(_M, "_token", lambda _backend, _model: "tok")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "test_token")
+        monkeypatch.delenv("VISUAL", raising=False)
+        monkeypatch.setenv("EDITOR", "vi")
+
+        def _mock_subprocess(
+            cmd: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            if cmd[0] == "kilo":
+                return subprocess.CompletedProcess(cmd, 0, stdout="feat: ai generated", stderr="")
+            elif cmd[0] == "vi":
+                # User enters only comments
+                Path(cmd[-1]).write_text("# nothing\n# just comments", encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=_mock_subprocess):
+            # Simulate stdin with 'e' response - create stdin with isatty() method
+            stdin_mock = io.StringIO("e\n")
+            monkeypatch.setattr(stdin_mock, "isatty", lambda: True)
+            with patch.object(sys, "stdin", stdin_mock):
+                with pytest.raises(SystemExit) as exc:
+                    _M.main()
+
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        assert "Empty message" in captured.err
+
+
+# ===========================================================================
 # main() with --amend and empty diff
 # ===========================================================================
 

--- a/scripts/test/test_git_ai_commit.py
+++ b/scripts/test/test_git_ai_commit.py
@@ -1099,24 +1099,67 @@ class TestBuildMessagesMaxDiffChars:
 class TestKiloConfig:
     """Tests for kilo config loading and model resolution."""
 
-    def test_kilo_config_path(self) -> None:
-        """_KILO_CONFIG_PATH points to ~/.config/kilo/kilo.jsonc."""
+    def test_kilo_config_candidates_check_json_before_jsonc(self) -> None:
+        """_KILO_CONFIG_CANDIDATES tries kilo.json before kilo.jsonc."""
         from pathlib import Path
 
-        expected = Path.home() / ".config" / "kilo" / "kilo.jsonc"
-        assert _M._KILO_CONFIG_PATH == expected  # type: ignore[attr-defined]
+        expected_dir = Path.home() / ".config" / "kilo"
+        assert _M._KILO_CONFIG_DIR == expected_dir  # type: ignore[attr-defined]
+        candidates = _M._KILO_CONFIG_CANDIDATES  # type: ignore[attr-defined]
+        assert candidates == (expected_dir / "kilo.json", expected_dir / "kilo.jsonc")
+
+    def test_kilo_config_path_missing_returns_none(self, tmp_path: Path) -> None:
+        """_kilo_config_path returns None when neither kilo.json nor kilo.jsonc exists."""
+        original = _M._KILO_CONFIG_CANDIDATES  # type: ignore[attr-defined]
+        try:
+            _M._KILO_CONFIG_CANDIDATES = (  # type: ignore[attr-defined]
+                tmp_path / "kilo.json",
+                tmp_path / "kilo.jsonc",
+            )
+            assert _M._kilo_config_path() is None  # type: ignore[attr-defined]
+        finally:
+            _M._KILO_CONFIG_CANDIDATES = original  # type: ignore[attr-defined]
+
+    def test_kilo_config_path_prefers_json_over_jsonc(self, tmp_path: Path) -> None:
+        """_kilo_config_path returns kilo.json when both kilo.json and kilo.jsonc exist."""
+        json_file = tmp_path / "kilo.json"
+        jsonc_file = tmp_path / "kilo.jsonc"
+        json_file.write_text("{}", encoding="utf-8")
+        jsonc_file.write_text("{}", encoding="utf-8")
+
+        original = _M._KILO_CONFIG_CANDIDATES  # type: ignore[attr-defined]
+        try:
+            _M._KILO_CONFIG_CANDIDATES = (json_file, jsonc_file)  # type: ignore[attr-defined]
+            assert _M._kilo_config_path() == json_file  # type: ignore[attr-defined]
+        finally:
+            _M._KILO_CONFIG_CANDIDATES = original  # type: ignore[attr-defined]
+
+    def test_kilo_config_path_falls_back_to_jsonc(self, tmp_path: Path) -> None:
+        """_kilo_config_path returns kilo.jsonc when only it exists."""
+        json_file = tmp_path / "kilo.json"
+        jsonc_file = tmp_path / "kilo.jsonc"
+        jsonc_file.write_text("{}", encoding="utf-8")
+
+        original = _M._KILO_CONFIG_CANDIDATES  # type: ignore[attr-defined]
+        try:
+            _M._KILO_CONFIG_CANDIDATES = (json_file, jsonc_file)  # type: ignore[attr-defined]
+            assert _M._kilo_config_path() == jsonc_file  # type: ignore[attr-defined]
+        finally:
+            _M._KILO_CONFIG_CANDIDATES = original  # type: ignore[attr-defined]
 
     def test_load_kilo_config_missing_file_returns_empty(self, tmp_path: Path) -> None:
-        """_load_kilo_config returns empty config when file doesn't exist."""
-        # Use a temp path that doesn't exist
-        non_existent = tmp_path / "nonexistent" / "kilo.jsonc"
-        original = _M._KILO_CONFIG_PATH  # type: ignore[attr-defined]
+        """_load_kilo_config returns empty config when no config file exists."""
+        non_existent = tmp_path / "nonexistent"
+        original = _M._KILO_CONFIG_CANDIDATES  # type: ignore[attr-defined]
         try:
-            _M._KILO_CONFIG_PATH = non_existent  # type: ignore[attr-defined]
+            _M._KILO_CONFIG_CANDIDATES = (  # type: ignore[attr-defined]
+                non_existent / "kilo.json",
+                non_existent / "kilo.jsonc",
+            )
             result = _M._load_kilo_config()  # type: ignore[attr-defined]
             assert result == {"disabled_providers": [], "provider": {}}
         finally:
-            _M._KILO_CONFIG_PATH = original  # type: ignore[attr-defined]
+            _M._KILO_CONFIG_CANDIDATES = original  # type: ignore[attr-defined]
 
     def test_load_kilo_config_with_models_maps_providers(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1157,6 +1200,33 @@ class TestKiloConfig:
         result = _M._resolve_kilo_model("fnal-ow/qwen3-coder-next")
         assert result == "fnal-ow/qwen3-coder-next"
 
+    def test_resolve_kilo_model_known_provider_prefix_matches_by_id(self) -> None:
+        """With a known provider prefix, the remainder may match via "id" (not just key)."""
+        # Real kilo.json entries store a short config key (e.g. "haiku-4-5") plus
+        # an "id"/"name" holding the provider-qualified model id
+        # (e.g. "azure/claude-haiku-4-5"). `kilo run -m` only accepts the key,
+        # so a match on "id" must still resolve to "provider/key".
+        mock_config = {
+            "disabled_providers": [],
+            "provider": {
+                "fnal-anthropic": {
+                    "models": {
+                        "haiku-4-5": {
+                            "id": "azure/claude-haiku-4-5",
+                            "name": "azure/claude-haiku-4-5",
+                        },
+                    }
+                },
+            },
+        }
+        original_load = _M._load_kilo_config  # type: ignore[attr-defined]
+        _M._load_kilo_config = lambda: mock_config  # type: ignore[attr-defined]
+        try:
+            result = _M._resolve_kilo_model("fnal-anthropic/azure/claude-haiku-4-5")
+            assert result == "fnal-anthropic/haiku-4-5"
+        finally:
+            _M._load_kilo_config = original_load  # type: ignore[attr-defined]
+
     def test_resolve_kilo_model_disabled_provider_prefix_is_treated_as_model_name(self) -> None:
         """If provider prefix is disabled, it's treated as part of the model name."""
         mock_config = {
@@ -1164,7 +1234,7 @@ class TestKiloConfig:
             "provider": {
                 "enabled-prov": {
                     "models": {
-                        "disabled-prov/model-x": {},
+                        "model-x": {"id": "disabled-prov/model-x"},
                     }
                 },
                 "disabled-prov": {
@@ -1178,24 +1248,26 @@ class TestKiloConfig:
         _M._load_kilo_config = lambda: mock_config  # type: ignore[attr-defined]
         try:
             # "disabled-prov" is disabled, so it's not a "known provider".
-            # "disabled-prov/model-x" is looked up as a whole.
-            # It's found in "enabled-prov".
+            # "disabled-prov/model-x" is looked up as a whole, matching
+            # "enabled-prov"'s "model-x" entry by its "id" field.
             result = _M._resolve_kilo_model("disabled-prov/model-x")
-            assert result == "enabled-prov/disabled-prov/model-x"
+            assert result == "enabled-prov/model-x"
         finally:
             _M._load_kilo_config = original_load  # type: ignore[attr-defined]
 
     def test_resolve_kilo_model_unknown_provider_prefix_looks_up_model(
         self,
     ) -> None:
-        """Model with unknown prefix (qwen/) is looked up in config."""
-        # qwen is NOT a known provider, so "qwen/qwen3-coder-next" is looked up
+        """Model with unknown prefix (qwen/) is looked up in config, by id, across providers."""
+        # qwen is NOT a known provider, so "qwen/qwen3-coder-next" (an id/name
+        # value) is looked up as a whole and matched against the "fnal-ow"
+        # provider's "qwen3-coder-next" key via its "id" field.
         mock_config = {
             "disabled_providers": [],
             "provider": {
                 "fnal-ow": {
                     "models": {
-                        "qwen/qwen3-coder-next": {},
+                        "qwen3-coder-next": {"id": "qwen/qwen3-coder-next"},
                     }
                 },
             },
@@ -1204,21 +1276,18 @@ class TestKiloConfig:
         _M._load_kilo_config = lambda: mock_config  # type: ignore[attr-defined]
         try:
             result = _M._resolve_kilo_model("qwen/qwen3-coder-next")
-            assert result == "fnal-ow/qwen/qwen3-coder-next"
+            assert result == "fnal-ow/qwen3-coder-next"
         finally:
             _M._load_kilo_config = original_load  # type: ignore[attr-defined]
 
-    def test_resolve_kilo_model_without_provider_prefix_looks_up(self) -> None:
-        """_resolve_kilo_model adds provider prefix when missing."""
-        # "qwen3-coder-next" (short name) is looked up and found under fnal-ow
-        # as "fnal-ow/qwen/qwen3-coder-next" (full name), so result is:
-        # fnal-ow/qwen/qwen3-coder-next
+    def test_resolve_kilo_model_without_provider_prefix_looks_up_by_key(self) -> None:
+        """_resolve_kilo_model adds provider prefix when the input matches a config key."""
         mock_config = {
             "disabled_providers": [],
             "provider": {
                 "fnal-ow": {
                     "models": {
-                        "qwen/qwen3-coder-next": {},
+                        "qwen3-coder-next": {"id": "qwen/qwen3-coder-next"},
                     }
                 },
             },
@@ -1227,7 +1296,28 @@ class TestKiloConfig:
         _M._load_kilo_config = lambda: mock_config  # type: ignore[attr-defined]
         try:
             result = _M._resolve_kilo_model("qwen3-coder-next")
-            assert result == "fnal-ow/qwen/qwen3-coder-next"
+            assert result == "fnal-ow/qwen3-coder-next"
+        finally:
+            _M._load_kilo_config = original_load  # type: ignore[attr-defined]
+
+    def test_resolve_kilo_model_without_provider_prefix_looks_up_by_id(self) -> None:
+        """_resolve_kilo_model adds provider prefix when the input matches "id" (or "name")."""
+        # A bare (no "/") id/name value should still resolve to the config key.
+        mock_config = {
+            "disabled_providers": [],
+            "provider": {
+                "ollama": {
+                    "models": {
+                        "codestral:22b": {"name": "codestral:22b-instruct"},
+                    }
+                },
+            },
+        }
+        original_load = _M._load_kilo_config  # type: ignore[attr-defined]
+        _M._load_kilo_config = lambda: mock_config  # type: ignore[attr-defined]
+        try:
+            result = _M._resolve_kilo_model("codestral:22b-instruct")
+            assert result == "ollama/codestral:22b"
         finally:
             _M._load_kilo_config = original_load  # type: ignore[attr-defined]
 
@@ -1247,12 +1337,12 @@ class TestKiloConfig:
             "provider": {
                 "fnal-ow": {
                     "models": {
-                        "qwen/qwen3-coder-next": {},
+                        "qwen3-coder-next": {"id": "qwen/qwen3-coder-next"},
                     }
                 },
                 "fnal-azure": {
                     "models": {
-                        "qwen/qwen3-coder-next": {},
+                        "qwen3-coder-next": {"id": "qwen/qwen3-coder-next"},
                     }
                 },
             },
@@ -1262,7 +1352,7 @@ class TestKiloConfig:
         try:
             # Only fnal-ow is enabled, so resolution should succeed.
             result = _M._resolve_kilo_model("qwen3-coder-next")
-            assert result == "fnal-ow/qwen/qwen3-coder-next"
+            assert result == "fnal-ow/qwen3-coder-next"
         finally:
             _M._load_kilo_config = original_load  # type: ignore[attr-defined]
 
@@ -1271,8 +1361,8 @@ class TestKiloConfig:
         mock_config = {
             "disabled_providers": [],
             "provider": {
-                "fnal-ow": {"models": {"qwen/qwen3-coder-next": {}}},
-                "fnal-azure": {"models": {"qwen/qwen3-coder-next": {}}},
+                "fnal-ow": {"models": {"qwen3-coder-next": {"id": "qwen/qwen3-coder-next"}}},
+                "fnal-azure": {"models": {"qwen3-coder-next": {"id": "qwen/qwen3-coder-next"}}},
             },
         }
         original_load = _M._load_kilo_config  # type: ignore[attr-defined]
@@ -1288,13 +1378,13 @@ class TestKiloConfig:
     ) -> None:
         """Model with non-provider prefix is looked up and prefix added."""
         # "unknown-ow" is not a known provider, so model name
-        # "unknown-ow/qwen3-coder-next" is looked up in config
+        # "unknown-ow/qwen3-coder-next" is looked up in config, matching by "id".
         mock_config = {
             "disabled_providers": [],
             "provider": {
                 "fnal-ow": {
                     "models": {
-                        "unknown-ow/qwen3-coder-next": {},
+                        "qwen3-coder-next": {"id": "unknown-ow/qwen3-coder-next"},
                     }
                 },
             },
@@ -1303,7 +1393,7 @@ class TestKiloConfig:
         _M._load_kilo_config = lambda: mock_config  # type: ignore[attr-defined]
         try:
             result = _M._resolve_kilo_model("unknown-ow/qwen3-coder-next")
-            assert result == "fnal-ow/unknown-ow/qwen3-coder-next"
+            assert result == "fnal-ow/qwen3-coder-next"
         finally:
             _M._load_kilo_config = original_load  # type: ignore[attr-defined]
 
@@ -1541,8 +1631,11 @@ class TestCapSelection:
         config_file = tmp_path / "kilo.jsonc"
         config_file.write_text(jsonc_content, encoding="utf-8")
 
-        original_path = _M._KILO_CONFIG_PATH  # type: ignore[attr-defined]
-        _M._KILO_CONFIG_PATH = config_file  # type: ignore[attr-defined]
+        original = _M._KILO_CONFIG_CANDIDATES  # type: ignore[attr-defined]
+        _M._KILO_CONFIG_CANDIDATES = (  # type: ignore[attr-defined]
+            tmp_path / "kilo.json",
+            config_file,
+        )
         try:
             result = _M._load_kilo_config()  # type: ignore[attr-defined]
             assert (
@@ -1551,20 +1644,23 @@ class TestCapSelection:
             )
             assert "disabled_providers" in result
         finally:
-            _M._KILO_CONFIG_PATH = original_path  # type: ignore[attr-defined]
+            _M._KILO_CONFIG_CANDIDATES = original  # type: ignore[attr-defined]
 
     def test_load_kilo_config_invalid_json_returns_empty(self, tmp_path: Path) -> None:
         """Invalid JSON returns the default empty config."""
         config_file = tmp_path / "kilo.jsonc"
         config_file.write_text("{ invalid json }")
 
-        original_path = _M._KILO_CONFIG_PATH  # type: ignore[attr-defined]
-        _M._KILO_CONFIG_PATH = config_file  # type: ignore[attr-defined]
+        original = _M._KILO_CONFIG_CANDIDATES  # type: ignore[attr-defined]
+        _M._KILO_CONFIG_CANDIDATES = (  # type: ignore[attr-defined]
+            tmp_path / "kilo.json",
+            config_file,
+        )
         try:
             result = _M._load_kilo_config()  # type: ignore[attr-defined]
             assert result == {"disabled_providers": [], "provider": {}}
         finally:
-            _M._KILO_CONFIG_PATH = original_path  # type: ignore[attr-defined]
+            _M._KILO_CONFIG_CANDIDATES = original  # type: ignore[attr-defined]
 
 
 class TestModelResolution:
@@ -1644,15 +1740,18 @@ class TestKiloBackend:
         monkeypatch.setenv("GIT_AI_COMMIT_TOKEN", "test_token")
 
         # Mock kilo config to ensure consistent model resolution.
-        # Uses fnal-ow provider with qwen/qwen3-coder-next model (same as CI config).
+        # Uses fnal-ow provider with a "qwen3-coder-next" config key whose
+        # "id" holds the provider-qualified value (matches real kilo.json).
         mock_config: dict[str, object] = {
             "disabled_providers": [],
-            "provider": {"fnal-ow": {"models": {"qwen/qwen3-coder-next": {}}}},
+            "provider": {
+                "fnal-ow": {"models": {"qwen3-coder-next": {"id": "qwen/qwen3-coder-next"}}}
+            },
         }
         monkeypatch.setattr(_M, "_load_kilo_config", lambda: mock_config)
 
         mock_completed = subprocess.CompletedProcess(
-            args=["kilo", "run", "--agent=code", "-m", "fnal-ow/qwen/qwen3-coder-next"],
+            args=["kilo", "run", "--agent=code", "-m", "fnal-ow/qwen3-coder-next"],
             returncode=0,
             stdout="Generated Commit Message\n",
             stderr="",
@@ -1668,7 +1767,7 @@ class TestKiloBackend:
             # Verify the model was resolved with provider prefix
             assert "-m" in cmd_list
             model_idx = cmd_list.index("-m")
-            assert cmd_list[model_idx + 1] == "fnal-ow/qwen/qwen3-coder-next"
+            assert cmd_list[model_idx + 1] == "fnal-ow/qwen3-coder-next"
 
     def test_chat_kilo_passes_token_as_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """_chat_kilo passes token via KILO_SERVER_PASSWORD env var."""


### PR DESCRIPTION
- Add -e/--edit flag to bypass confirmation prompt and invoke editor directly, while extending the interactive y/n prompt to include an 'e' (edit) option.
- Updated kilo config loading to check both kilo.json and kilo.jsonc, preferring kilo.json when both exist.
- Refactored model resolution to match by config keys first, then fall back to "id"/"name" fields, ensuring proper provider/key output.
- Resolve model resolution ambiguity by using the short config key (accepted by `kilo run -m`) rather than the provider-qualified "id" value in the output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Added `-e/--edit` to bypass confirmation and open the editor.
  - Added `e` to the interactive confirmation prompt.
  - Added editor selection through `$VISUAL`, `$EDITOR`, and `vi`.
  - Added support for `kilo.json` and `kilo.jsonc`, with `kilo.json` preferred.
  - Improved model resolution for configuration keys, `id`, and `name`.
  - Ignored malformed model entries during lookup.
  - Preserved provider and configuration-key resolution for `kilo run -m`.

- **Tests**
  - Added coverage for edit workflows, empty messages, comment removal, and temporary-file cleanup.
  - Updated configuration and model-resolution fixtures for the new lookup behavior.

- **Documentation**
  - Documented editor selection and the interactive `e` option.

- **Maintenance**
  - Added `.mypy_cache/` to `.gitignore`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->