### PR TITLE
Use struct for class with only public members

### DIFF
--- a/form/root_storage/root_rfield_write_container.hpp
+++ b/form/root_storage/root_rfield_write_container.hpp
@@ -14,7 +14,7 @@ class TFile;
 // NOLINTEND(readability-identifier-naming)
 
 namespace form::detail::experimental {
-  struct root_rntuple_write_container_imp;
+  class root_rntuple_write_container_imp;
 
   class root_rfield_write_container_imp : public storage_associative_write_container {
   public:

--- a/form/root_storage/root_rntuple_write_container.hpp
+++ b/form/root_storage/root_rntuple_write_container.hpp
@@ -44,9 +44,9 @@ namespace form::detail::experimental {
 #endif
 
   class root_rntuple_write_container_imp : public storage_write_association {
+  public:
     root_rntuple_write_container_imp(std::string const& name);
     ~root_rntuple_write_container_imp() override;
-
     //Rule of five
     root_rntuple_write_container_imp(root_rntuple_write_container_imp const& other) = delete;
     root_rntuple_write_container_imp(root_rntuple_write_container_imp&& other) = delete;

--- a/form/root_storage/root_rntuple_write_container.hpp
+++ b/form/root_storage/root_rntuple_write_container.hpp
@@ -43,7 +43,7 @@ namespace form::detail::experimental {
   using RRawPtrWriteEntry = ROOT::Experimental::Detail::RRawPtrWriteEntry;
 #endif
 
-  struct root_rntuple_write_container_imp : public storage_write_association {
+  class root_rntuple_write_container_imp : public storage_write_association {
     root_rntuple_write_container_imp(std::string const& name);
     ~root_rntuple_write_container_imp() override;
 

--- a/phlex/core/product_selector.hpp
+++ b/phlex/core/product_selector.hpp
@@ -109,7 +109,7 @@ namespace phlex {
     template <typename C, typename T>
       requires std::is_same_v<typename std::remove_cvref_t<C>::value_type, product_selector> &&
                phlex::detail::is_tuple<T>::value
-    class product_selectors_type_setter {};
+    struct product_selectors_type_setter {};
     template <typename C, typename... Ts>
     class product_selectors_type_setter<C, std::tuple<Ts...>> {
     private:

--- a/phlex/metaprogramming/type_deduction.hpp
+++ b/phlex/metaprogramming/type_deduction.hpp
@@ -82,10 +82,10 @@ namespace phlex::detail {
   };
 
   template <typename T>
-  class is_tuple : public std::false_type {};
+  struct is_tuple : std::false_type {};
 
   template <typename... Ts>
-  class is_tuple<std::tuple<Ts...>> : public std::true_type {};
+  struct is_tuple<std::tuple<Ts...>> : std::true_type {};
 
   // void_tag is a type used to represent the absence of a bound object in template contexts.
   //

--- a/phlex/model/type_id.hpp
+++ b/phlex/model/type_id.hpp
@@ -176,10 +176,10 @@ namespace phlex::detail {
     using aggregate_to_plain_tuple_t = aggregate_to_plain_tuple<A>::type;
 
     template <typename T>
-    class is_handle : public std::false_type {};
+    struct is_handle : std::false_type {};
 
     template <typename T>
-    class is_handle<phlex::handle<T>> : public std::true_type {};
+    struct is_handle<phlex::handle<T>> : std::true_type {};
   }
 
   // Forward declaration
@@ -240,20 +240,17 @@ namespace phlex::detail {
 
   namespace internal {
     template <typename T>
-    class tuple_type_ids {
-    public:
+    struct tuple_type_ids {
       static type_ids get() { return {make_type_id<T>()}; }
     };
 
     template <typename... Ts>
-    class tuple_type_ids<std::tuple<Ts...>> {
-    public:
+    struct tuple_type_ids<std::tuple<Ts...>> {
       static type_ids get() { return {make_type_id<Ts>()...}; }
     };
 
     template <typename... Ts>
-    class tuple_type_ids<std::pair<Ts...>> {
-    public:
+    struct tuple_type_ids<std::pair<Ts...>> {
       static type_ids get() { return {make_type_id<Ts>()...}; }
     };
   }

--- a/test/mock-workflow/algorithm.hpp
+++ b/test/mock-workflow/algorithm.hpp
@@ -38,7 +38,7 @@ namespace phlex::experimental::test {
   using ensure_tuple = ensure_tuple_impl<Ts...>::type;
 
   template <typename Input, std::default_initializable Outputs>
-  class algorithm {};
+  struct algorithm {};
 
   template <typename... Inputs, std::default_initializable Outputs>
   class algorithm<std::tuple<Inputs...>, Outputs> {

--- a/test/plugins/ij_source.cpp
+++ b/test/plugins/ij_source.cpp
@@ -3,8 +3,7 @@
 using namespace phlex;
 
 namespace {
-  class signed_value_provider {
-  public:
+  struct signed_value_provider {
     int provide_i(data_cell_index const& id) const { return static_cast<int>(id.number()); }
   };
 }


### PR DESCRIPTION
Following https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rc-struct, a few `class`es should be marked as `struct`.  

`root_rntuple_write_container_imp` is reverted to be a `class`.  Eventhough `root_rntuple_write_container_imp` locally only has public members (including data members), it also has, via inheritance, private members.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code quality**
  - Converted selected `class` declarations to `struct` where members are public.
  - Updated type traits in `phlex/metaprogramming/type_deduction.hpp` and `phlex/model/type_id.hpp`.
  - Updated `product_selectors_type_setter` in `phlex/core/product_selector.hpp`.

- **Access control**
  - Kept `root_rntuple_write_container_imp` as a `class` because it inherits private members.
  - Updated both its forward declaration and definition in `form/root_storage/root_rntuple_write_container.hpp`.

- **Tests and mocks**
  - Converted the mock `algorithm` template in `test/mock-workflow/algorithm.hpp`.
  - Converted `signed_value_provider` in `test/plugins/ij_source.cpp`.

- **Behavior**
  - Preserved public inheritance and member access.
  - Made no functional or API behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->