### PR TITLE
refactor(source): provide default `source::indices()` implementation

### DIFF
--- a/phlex/core/source.hpp
+++ b/phlex/core/source.hpp
@@ -21,8 +21,12 @@ namespace phlex::detail {
   class PHLEX_CORE_EXPORT source {
   public:
     virtual ~source() = default;
+
     virtual provider_bundles create_providers(product_selector const&) = 0;
-    virtual index_generator indices() = 0;
+
+    // Clang-tidy misdiagnoses the coroutine's generated promise_type access.
+    // NOLINTNEXTLINE(readability-static-accessed-through-instance)
+    virtual index_generator indices() { co_return; }
   };
 
   using source_ptr = std::unique_ptr<source>;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,6 +174,9 @@ cet_test(data_cell_index USE_CATCH2_MAIN SOURCE data_cell_index_test.cpp LIBRARI
 cet_test(index_generator USE_CATCH2_MAIN SOURCE index_generator_test.cpp LIBRARIES
          phlex::model_internal
 )
+cet_test(source_unit USE_CATCH2_MAIN SOURCE source_test.cpp LIBRARIES
+         phlex::core_internal
+)
 cet_test(fixed_hierarchy USE_CATCH2_MAIN SOURCE fixed_hierarchy_test.cpp LIBRARIES
          phlex::model
 )

--- a/test/framework_graph_test.cpp
+++ b/test/framework_graph_test.cpp
@@ -25,9 +25,6 @@ namespace {
     {
       return {};
     }
-    // Clang-tidy misdiagnoses the coroutine's generated promise_type access.
-    // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-    index_generator indices() override { co_return; }
   };
 
   struct other_source final : phlex::source {
@@ -35,9 +32,6 @@ namespace {
     {
       return {};
     }
-    // Clang-tidy misdiagnoses the coroutine's generated promise_type access.
-    // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-    index_generator indices() override { co_return; }
   };
 
   struct test_driver_builder {

--- a/test/max-parallelism/provide_parallelism.cpp
+++ b/test/max-parallelism/provide_parallelism.cpp
@@ -31,10 +31,6 @@ namespace {
       }
       return bundles;
     }
-
-    // Clang-tidy misdiagnoses the coroutine's generated promise_type access.
-    // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-    phlex::index_generator indices() override { co_return; }
   };
 }
 

--- a/test/output_products_test.cpp
+++ b/test/output_products_test.cpp
@@ -61,9 +61,6 @@ namespace {
       }
       return bundles;
     }
-    // Clang-tidy misdiagnoses the coroutine's generated promise_type access.
-    // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-    index_generator indices() override { co_return; }
   };
 }
 

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -67,9 +67,6 @@ namespace {
       }
       return bundles;
     }
-    // Clang-tidy misdiagnoses the coroutine's generated promise_type access.
-    // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-    index_generator indices() override { co_return; }
   };
 
   unsigned pass_on(toy::vertex_collection const& vertices) { return vertices.data; }

--- a/test/source_test.cpp
+++ b/test/source_test.cpp
@@ -1,0 +1,18 @@
+#include "phlex/source.hpp"
+
+#include "catch2/catch_test_macros.hpp"
+
+using namespace phlex;
+
+namespace {
+  class empty_source final : public source {
+    detail::provider_bundles create_providers(product_selector const&) override { return {}; }
+  };
+}
+
+TEST_CASE("source::indices is empty by default", "[core]")
+{
+  std::unique_ptr<phlex::source> src = std::make_unique<empty_source>();
+  auto indices = src->indices();
+  CHECK(indices.begin() == indices.end());
+}


### PR DESCRIPTION
All classes that derive from `phlex::source` (or equivalently `phlex::detail::source`) must provide a `create_providers(...)` override.  However, it is not necessarily the case that all sources must provide an `indices()` override if the purpose of the source is to make products available and not to drive the framework itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Added a default, immediately completing implementation of `phlex::detail::source::indices()`.
  - Derived source classes still must implement `create_providers(...)`.
  - Sources that only provide products no longer need to override `indices()`.

- **Tests**
  - Removed redundant empty `indices()` overrides from framework graph, max-parallelism, output products, and provider test sources.
  - Removed associated Clang-tidy suppression comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->