### PR TITLE
ci: improve clang-tidy PR reporting and scope checks

### DIFF
--- a/.github/workflows/clang-tidy-check.yaml
+++ b/.github/workflows/clang-tidy-check.yaml
@@ -151,6 +151,7 @@ jobs:
           if [ "${#sources[@]}" -eq 0 ]; then
             : > "$BUILD_DIR/clang-tidy.log"
             : > "$BUILD_DIR/clang-tidy-new-issues.txt"
+            : > "$BUILD_DIR/clang-tidy-analysis-complete.txt"
             echo "No C/C++ files to analyze"
             exit 0
           fi
@@ -187,6 +188,7 @@ jobs:
           set -e
 
           if [ "$DIFF_EXIT" -eq 1 ]; then
+            : > "$BUILD_DIR/clang-tidy-analysis-complete.txt"
             NEW_COUNT=$(grep -c '' "$BUILD_DIR/clang-tidy-new-issues.txt" 2>/dev/null || echo 0)
             echo "::error::${NEW_COUNT} clang-tidy issue(s) found"
             while IFS= read -r issue; do
@@ -203,6 +205,7 @@ jobs:
             echo "::endgroup::"
             exit 1
           else
+            : > "$BUILD_DIR/clang-tidy-analysis-complete.txt"
             echo "✅ No clang-tidy issues found"
           fi
 
@@ -226,6 +229,7 @@ jobs:
             ${{ needs.setup.outputs.build_path }}/clang-tidy-fixes.yaml
             ${{ needs.setup.outputs.build_path }}/clang-tidy.log
             ${{ needs.setup.outputs.build_path }}/clang-tidy-new-issues.txt
+            ${{ needs.setup.outputs.build_path }}/clang-tidy-analysis-complete.txt
             ${{ needs.setup.outputs.build_path }}/pr_number.txt
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/clang-tidy-check.yaml
+++ b/.github/workflows/clang-tidy-check.yaml
@@ -53,8 +53,13 @@ jobs:
 
   clang-tidy-check:
     needs: setup
+    # Pull-request runs must publish an empty issue artifact when all C/C++
+    # changes have been reverted, allowing clang-tidy-report to remove a stale
+    # warning comment.  The run step exits before invoking clang-tidy when no
+    # C/C++ files remain to analyze.
     if: >
-      always() && (github.event_name == 'workflow_dispatch' || needs.setup.outputs.has_changes == 'true')
+      always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' ||
+      needs.setup.outputs.has_changes == 'true')
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/framework-r-d/phlex-ci:latest

--- a/.github/workflows/clang-tidy-check.yaml
+++ b/.github/workflows/clang-tidy-check.yaml
@@ -187,7 +187,13 @@ jobs:
           DIFF_EXIT=$?
           set -e
 
-          if [ "$DIFF_EXIT" -eq 1 ]; then
+          if [ "$TIDY_EXIT" -ne 0 ] || grep -q "No checks enabled\.\|Traceback\|RuntimeError\|ModuleNotFoundError\|ImportError" "$BUILD_DIR/clang-tidy.log"; then
+            echo "::error::run-clang-tidy failed (see log below)"
+            echo "::group::clang-tidy.log (error)"
+            cat "$BUILD_DIR/clang-tidy.log"
+            echo "::endgroup::"
+            exit 1
+          elif [ "$DIFF_EXIT" -eq 1 ]; then
             : > "$BUILD_DIR/clang-tidy-analysis-complete.txt"
             NEW_COUNT=$(grep -c '' "$BUILD_DIR/clang-tidy-new-issues.txt" 2>/dev/null || echo 0)
             echo "::error::${NEW_COUNT} clang-tidy issue(s) found"
@@ -198,12 +204,6 @@ jobs:
           elif [ "$DIFF_EXIT" -ne 0 ]; then
             echo "::error::clang_tidy_diff_issues.py failed with exit code ${DIFF_EXIT}"
             exit "$DIFF_EXIT"
-          elif [ "$TIDY_EXIT" -ne 0 ] || grep -q "No checks enabled\.\|Traceback\|RuntimeError\|ModuleNotFoundError\|ImportError" "$BUILD_DIR/clang-tidy.log"; then
-            echo "::error::run-clang-tidy failed (see log below)"
-            echo "::group::clang-tidy.log (error)"
-            cat "$BUILD_DIR/clang-tidy.log"
-            echo "::endgroup::"
-            exit 1
           else
             : > "$BUILD_DIR/clang-tidy-analysis-complete.txt"
             echo "✅ No clang-tidy issues found"

--- a/.github/workflows/clang-tidy-check.yaml
+++ b/.github/workflows/clang-tidy-check.yaml
@@ -1,6 +1,10 @@
 name: Clang-Tidy Check
 "run-name": "${{ github.actor }} checking C++ code with clang-tidy"
 
+concurrency:
+  group: clang-tidy-check-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read
@@ -84,70 +88,6 @@ jobs:
         shell: bash
         working-directory: ${{ needs.setup.outputs.build_path }}
         env:
-          REPO: ${{ needs.setup.outputs.repo }}
-          SOURCE_PATH: ${{ needs.setup.outputs.checkout_path }}
-          BUILD_PATH: ${{ needs.setup.outputs.build_path }}
-        run: |
-          . /entrypoint.sh
-          REPO_NAME="${REPO##*/}"
-          SOURCE_DIR="$GITHUB_WORKSPACE/$SOURCE_PATH"
-          BUILD_DIR="$GITHUB_WORKSPACE/$BUILD_PATH"
-
-          # run-clang-tidy runs clang-tidy on every translation unit in
-          # compile_commands.json in parallel and merges the per-TU fix YAML files
-          # into a single comprehensive clang-tidy-fixes.yaml.  The alternative
-          # (setting CMAKE_CXX_CLANG_TIDY=clang-tidy;--export-fixes=... and
-          # building with -j) suffers from a race condition: every parallel
-          # clang-tidy invocation independently overwrites the same output file, so
-          # only the fixes from whichever translation unit finishes last are
-          # retained.
-          #
-          # Path arguments are substring-matched against file paths in
-          # compile_commands.json; restricting to the source directory automatically
-          # excludes generated files (e.g. version.cpp, ROOT dictionaries) that live
-          # in the build directory and lack access to the .clang-tidy config.
-          #
-          # run-clang-tidy validates the check list by calling clang-tidy from its
-          # working directory; run from the source root so that clang-tidy discovers
-          # the .clang-tidy config file there, preventing a spurious "No checks
-          # enabled." error.
-          if ! command -v run-clang-tidy >/dev/null 2>&1; then
-            echo "::error::run-clang-tidy not found in PATH; cannot run clang-tidy checks"
-            exit 1
-          fi
-          echo "➡️ Running clang-tidy checks..."
-          cd "$SOURCE_DIR"
-          set +e
-          run-clang-tidy \
-            -p "$BUILD_DIR" \
-            -export-fixes "$BUILD_DIR/clang-tidy-fixes.yaml" \
-            -j "$(nproc)" \
-            "$SOURCE_DIR/phlex" \
-            "$SOURCE_DIR/form" \
-            "$SOURCE_DIR/plugins" \
-            "$SOURCE_DIR/test" \
-            > "$BUILD_DIR/clang-tidy.log" 2>&1
-          TIDY_EXIT=$?
-          set -e
-
-          if grep -qE '^/.+\.(cpp|hpp|c|h):[0-9]+:[0-9]+: (warning|error):' "$BUILD_DIR/clang-tidy.log"; then
-            echo "::warning::Clang-tidy found issues in the code"
-            echo "Comment '@${REPO_NAME}bot tidy-fix [<check>...]' on the PR to attempt auto-fix"
-          elif [ "$TIDY_EXIT" -ne 0 ] || grep -q "No checks enabled\.\|Traceback\|RuntimeError\|ModuleNotFoundError\|ImportError" "$BUILD_DIR/clang-tidy.log"; then
-            echo "::error::run-clang-tidy failed (see log below)"
-            echo "::group::clang-tidy.log (error)"
-            cat "$BUILD_DIR/clang-tidy.log"
-            echo "::endgroup::"
-            exit 1
-          else
-            echo "✅ clang-tidy check passed"
-          fi
-
-      - name: Check for new clang-tidy issues
-        id: diff_check
-        if: steps.tidy.outcome == 'success' && needs.setup.outputs.base_sha != ''
-        shell: bash
-        env:
           BASE_SHA: ${{ needs.setup.outputs.base_sha }}
           BASE_REPO:
             ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name ||
@@ -157,49 +97,93 @@ jobs:
             needs.setup.outputs.repo }}
           SOURCE_PATH: ${{ needs.setup.outputs.checkout_path }}
           BUILD_PATH: ${{ needs.setup.outputs.build_path }}
+          FULL_BRANCH_CHECK: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
+          . /entrypoint.sh
           SOURCE_DIR="$GITHUB_WORKSPACE/$SOURCE_PATH"
           BUILD_DIR="$GITHUB_WORKSPACE/$BUILD_PATH"
 
+          # Manual runs analyze the whole branch.  Other events fetch the base because
+          # the diff drives both the files to analyze and eligible failure lines.
           cd "$SOURCE_DIR"
+          sources=()
+          if [ "$FULL_BRANCH_CHECK" = true ]; then
+            sources=("$SOURCE_DIR/phlex" "$SOURCE_DIR/form" "$SOURCE_DIR/plugins" "$SOURCE_DIR/test")
+            : > "$BUILD_DIR/patch.diff"
+          else
+            FETCH_REMOTE="origin"
+            if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ "${BASE_REPO}" != "${HEAD_REPO}" ]; then
+              FETCH_REMOTE="base-origin"
+              git remote add "$FETCH_REMOTE" "https://github.com/${BASE_REPO}.git" 2>/dev/null || true
+            fi
+            if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              git fetch --depth=1 "$FETCH_REMOTE" "$BASE_SHA"
+            fi
 
-          # Fetch the base commit if it is not already in the shallow history.
-          # actions/checkout uses --depth 1, so BASE_SHA may be absent locally.
-          FETCH_REMOTE="origin"
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ "${BASE_REPO}" != "${HEAD_REPO}" ]; then
-            FETCH_REMOTE="base-origin"
-            git remote add "$FETCH_REMOTE" "https://github.com/${BASE_REPO}.git" 2>/dev/null || true
-          fi
+            git diff --unified=0 "$BASE_SHA" HEAD -- \
+              '*.cpp' '*.hpp' '*.c' '*.h' '*.cxx' '*.cc' '*.hxx' '*.icc' \
+              > "$BUILD_DIR/patch.diff"
 
-          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            echo "Fetching base commit ${BASE_SHA}..."
-            if ! git fetch --depth=1 "$FETCH_REMOTE" "$BASE_SHA" 2>/dev/null; then
-              echo "::warning::Could not fetch base commit ${BASE_SHA}; skipping new-issue check"
-              exit 0
+            header_changed=false
+            while IFS= read -r -d '' file; do
+              if [ -f "$SOURCE_DIR/$file" ]; then
+                case "$file" in
+                  *.cpp|*.c|*.cxx|*.cc) sources+=("$SOURCE_DIR/$file") ;;
+                  *.hpp|*.h|*.hxx|*.icc) header_changed=true ;;
+                esac
+              fi
+            done < <(git diff --name-only -z --diff-filter=ACMR "$BASE_SHA" HEAD -- \
+              '*.cpp' '*.hpp' '*.c' '*.h' '*.cxx' '*.cc' '*.hxx' '*.icc')
+
+            # A header has no compilation database entry of its own.  Analyze all
+            # project translation units when one changes so diagnostics in it are
+            # observed through every potentially affected includer.
+            if [ "$header_changed" = true ]; then
+              sources=("$SOURCE_DIR/phlex" "$SOURCE_DIR/form" "$SOURCE_DIR/plugins" "$SOURCE_DIR/test")
             fi
           fi
 
-          # Produce a no-context diff for C/C++ source files so hunk headers
-          # precisely identify the added and modified line ranges.
-          git diff --unified=0 "$BASE_SHA" HEAD -- \
-            '*.cpp' '*.hpp' '*.c' '*.h' '*.cxx' '*.cc' '*.hxx' '*.icc' \
-            > "$BUILD_DIR/patch.diff" 2>/dev/null || true
-
-          if [ ! -s "$BUILD_DIR/patch.diff" ]; then
-            echo "No C/C++ source changes detected in diff; skipping new-issue check"
+          if [ "${#sources[@]}" -eq 0 ]; then
+            : > "$BUILD_DIR/clang-tidy.log"
+            : > "$BUILD_DIR/clang-tidy-new-issues.txt"
+            echo "No C/C++ files to analyze"
             exit 0
           fi
 
+          # Run from the source root so clang-tidy discovers .clang-tidy.  Passing
+          # only changed paths avoids scanning unrelated translation units.
+          if ! command -v run-clang-tidy >/dev/null 2>&1; then
+            echo "::error::run-clang-tidy not found in PATH; cannot run clang-tidy checks"
+            exit 1
+          fi
+          echo "➡️ Running clang-tidy checks..."
+          set +e
+          run-clang-tidy \
+            -p "$BUILD_DIR" \
+            -export-fixes "$BUILD_DIR/clang-tidy-fixes.yaml" \
+            -j "$(nproc)" \
+            "${sources[@]}" \
+            > "$BUILD_DIR/clang-tidy.log" 2>&1
+          TIDY_EXIT=$?
+          set -e
+
+          set +e
+          filter_args=()
+          if [ "$FULL_BRANCH_CHECK" = true ]; then
+            filter_args+=(--all)
+          fi
           python3 "$SOURCE_DIR/scripts/clang_tidy_diff_issues.py" \
             --log "$BUILD_DIR/clang-tidy.log" \
             --diff "$BUILD_DIR/patch.diff" \
             --source-dir "$SOURCE_DIR" \
+            "${filter_args[@]}" \
             --output "$BUILD_DIR/clang-tidy-new-issues.txt"
           DIFF_EXIT=$?
+          set -e
 
           if [ "$DIFF_EXIT" -eq 1 ]; then
             NEW_COUNT=$(grep -c '' "$BUILD_DIR/clang-tidy-new-issues.txt" 2>/dev/null || echo 0)
-            echo "::error::${NEW_COUNT} new clang-tidy issue(s) introduced by this patch:"
+            echo "::error::${NEW_COUNT} clang-tidy issue(s) found"
             while IFS= read -r issue; do
               [ -n "$issue" ] && echo "::error::${issue}"
             done < "$BUILD_DIR/clang-tidy-new-issues.txt"
@@ -207,9 +191,15 @@ jobs:
           elif [ "$DIFF_EXIT" -ne 0 ]; then
             echo "::error::clang_tidy_diff_issues.py failed with exit code ${DIFF_EXIT}"
             exit "$DIFF_EXIT"
+          elif [ "$TIDY_EXIT" -ne 0 ] || grep -q "No checks enabled\.\|Traceback\|RuntimeError\|ModuleNotFoundError\|ImportError" "$BUILD_DIR/clang-tidy.log"; then
+            echo "::error::run-clang-tidy failed (see log below)"
+            echo "::group::clang-tidy.log (error)"
+            cat "$BUILD_DIR/clang-tidy.log"
+            echo "::endgroup::"
+            exit 1
+          else
+            echo "✅ No clang-tidy issues found"
           fi
-
-          echo "✅ No new clang-tidy issues on modified lines"
 
       - name: Save PR metadata
         if: always() && github.event_name == 'pull_request'
@@ -253,14 +243,6 @@ jobs:
           build-path: ${{ needs.setup.outputs.build_path }}
           pr-number: ${{ needs.setup.outputs.pr_number }}
           post-summary: "true"
-
-      - name: Post no-issues comment
-        if: >-
-          always() && github.event_name == 'issue_comment' && needs.clang-tidy-check.result == 'success' &&
-          steps.post_results.outputs.has_content != 'true' && needs.setup.outputs.pr_number != ''
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-        with:
-          message: "No clang-tidy issues found."
 
       - name: Update PR comment reactions
         if: always() && github.event_name == 'issue_comment'

--- a/.github/workflows/clang-tidy-report.yaml
+++ b/.github/workflows/clang-tidy-report.yaml
@@ -63,8 +63,15 @@ jobs:
             echo "issues_file=$issues_file" >> "$GITHUB_OUTPUT"
           fi
 
+          completion_file=$(find artifacts -name "clang-tidy-analysis-complete.txt" 2>/dev/null | head -1)
+          if [ -n "$completion_file" ]; then
+            echo "analysis_complete=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::clang-tidy analysis did not complete; retaining any prior PR comment"
+          fi
+
       - name: Update clang-tidy PR comment
-        if: steps.locate.outputs.pr_number != ''
+        if: steps.locate.outputs.pr_number != '' && steps.locate.outputs.analysis_complete == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ARTIFACT_URL:
@@ -114,16 +121,18 @@ jobs:
               return;
             }
 
-            const body = `${marker}
-            ## Clang-Tidy Check Results
-
-            Clang-tidy found the following issue(s) on lines changed by this pull request:
-
-            \`\`\`text
-            ${issues}
-            \`\`\`
-
-            [Download clang-tidy artifacts](${process.env.ARTIFACT_URL})`;
+            const body = [
+              marker,
+              '## Clang-Tidy Check Results',
+              '',
+              'Clang-tidy found the following issue(s) on lines changed by this pull request:',
+              '',
+              '```text',
+              issues,
+              '```',
+              '',
+              `[Download clang-tidy artifacts](${process.env.ARTIFACT_URL})`
+            ].join('\n');
 
             if (previous.length) {
               await github.rest.issues.updateComment({

--- a/scripts/clang_tidy_diff_issues.py
+++ b/scripts/clang_tidy_diff_issues.py
@@ -10,7 +10,7 @@ Usage:
         --log PATH/TO/clang-tidy.log \
         --diff PATH/TO/patch.diff \
         --source-dir PATH/TO/source/checkout \
-        [--output PATH/TO/new-issues.txt]
+        [--all] [--output PATH/TO/new-issues.txt]
 
 Exit code:
     0  no new issues found
@@ -34,22 +34,13 @@ _ISSUE_RE = re.compile(
     r" (warning|error): (.+?)(?:\s+\[([\w,.\-]+)\])?\s*$"
 )
 
-# Check-name prefixes whose diagnostics are not treated as new issues.
-# These categories are advisory or style-related and are tracked separately.
-_IGNORED_PREFIXES: tuple[str, ...] = (
-    "modernize-",
-    "performance-",
-    "portability-",
-    "readability-",
-)
-
 
 def parse_diff(diff_text: str) -> dict[str, set[int]]:
     """Parse a unified diff to extract added/changed line numbers per file.
 
     Keys are file paths relative to the repo root (without the leading ``b/``
-    prefix from the diff header).  Values are sets of line numbers in the
-    post-patch (new) file that were added or modified by the diff.
+    prefix from the diff header).  Values are sets of line numbers added in the
+    post-patch (new) file.
 
     Pure deletions (hunk count == 0 in the new file) contribute no lines.
 
@@ -61,21 +52,26 @@ def parse_diff(diff_text: str) -> dict[str, set[int]]:
     """
     added: dict[str, set[int]] = defaultdict(set)
     current_file: str | None = None
+    new_lineno: int | None = None
 
     for line in diff_text.splitlines():
         if line.startswith("+++ b/"):
             current_file = line[6:]
+            new_lineno = None
         elif line.startswith("+++ "):
             # '/dev/null' or unexpected header: nothing to track for this file.
             current_file = None
+            new_lineno = None
         elif current_file is not None and line.startswith("@@ "):
             m = re.match(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", line)
             if m:
-                new_start = int(m.group(1))
-                count_str = m.group(2)
-                new_count = int(count_str) if count_str is not None else 1
-                for ln in range(new_start, new_start + new_count):
-                    added[current_file].add(ln)
+                new_lineno = int(m.group(1))
+        elif current_file is not None and new_lineno is not None:
+            if line.startswith("+"):
+                added[current_file].add(new_lineno)
+                new_lineno += 1
+            elif line.startswith(" "):
+                new_lineno += 1
 
     return dict(added)
 
@@ -98,9 +94,6 @@ def parse_log(log_text: str) -> list[tuple[str, int, str, str]]:
     for line in log_text.splitlines():
         m = _ISSUE_RE.match(line)
         if not m:
-            continue
-        check_name = m.group(5) or ""
-        if any(check_name.startswith(prefix) for prefix in _IGNORED_PREFIXES):
             continue
         filepath = m.group(1)
         lineno = int(m.group(2))
@@ -152,6 +145,35 @@ def filter_new_issues(
     return new_issues
 
 
+def filter_issues(
+    log_text: str,
+    diff_text: str,
+    source_dir: str,
+    *,
+    all_issues: bool,
+) -> list[tuple[str, int, str, str]]:
+    """Return all source-tree issues or only issues on added lines.
+
+    Args:
+        log_text: Full text of ``clang-tidy.log``.
+        diff_text: Full text of a unified ``git diff``.
+        source_dir: Absolute path to the source checkout directory.
+        all_issues: Return every diagnostic in the source checkout when true.
+
+    Returns:
+        The requested subset of parsed clang-tidy diagnostics.
+    """
+    if not all_issues:
+        return filter_new_issues(log_text, diff_text, source_dir)
+
+    source_path = Path(source_dir).resolve()
+    return [
+        issue
+        for issue in parse_log(log_text)
+        if Path(issue[0]).resolve().is_relative_to(source_path)
+    ]
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     """Build and return the argument parser."""
     parser = argparse.ArgumentParser(
@@ -180,6 +202,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Absolute path to the source checkout directory.",
     )
     parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Report all diagnostics in the source checkout, ignoring the diff.",
+    )
+    parser.add_argument(
         "--output",
         metavar="FILE",
         help="Write new-issue lines to this file instead of stdout."
@@ -205,7 +232,7 @@ def main() -> int:
     log_text = log_path.read_text(encoding="utf-8", errors="replace")
     diff_text = diff_path.read_text(encoding="utf-8", errors="replace")
 
-    new_issues = filter_new_issues(log_text, diff_text, args.source_dir)
+    new_issues = filter_issues(log_text, diff_text, args.source_dir, all_issues=args.all)
 
     output_lines = [f"{fp}:{ln}: {lvl}: {msg}" for fp, ln, lvl, msg in new_issues]
     output_text = "\n".join(output_lines)

--- a/scripts/test/test_clang_tidy_diff_issues.py
+++ b/scripts/test/test_clang_tidy_diff_issues.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 # sys.path is set up by scripts/test/conftest.py.
 from clang_tidy_diff_issues import (  # noqa: E402
+    filter_issues,
     filter_new_issues,
     parse_diff,
     parse_log,
@@ -63,6 +64,13 @@ class TestParseDiff:
         """An empty diff produces an empty mapping."""
         assert parse_diff("") == {}
 
+    def test_unchanged_lines_inside_hunk_are_excluded(self) -> None:
+        """Only added lines are tracked when a diff contains context."""
+        diff = (
+            "--- a/foo.cpp\n+++ b/foo.cpp\n@@ -4,3 +4,4 @@\n unchanged\n-old\n+new\n unchanged\n"
+        )
+        assert parse_diff(diff) == {"foo.cpp": {5}}
+
 
 class TestParseLog:
     """Tests for the parse_log function."""
@@ -74,29 +82,6 @@ class TestParseLog:
         issues = parse_log(log)
         assert len(issues) == 1
         assert issues[0] == ("/src/phlex/core/filter.cpp", 42, "warning", "use nullptr")
-
-    def test_modernize_check_ignored(self) -> None:
-        """Issues with a modernize-* check name are excluded."""
-        log = "/src/a.cpp:10:1: warning: use auto [modernize-use-auto]\n"
-        assert parse_log(log) == []
-
-    def test_performance_check_ignored(self) -> None:
-        """Issues with a performance-* check name are excluded."""
-        log = (
-            "/src/a.cpp:5:1: warning: inefficient copy "
-            "[performance-unnecessary-copy-initialization]\n"
-        )
-        assert parse_log(log) == []
-
-    def test_portability_check_ignored(self) -> None:
-        """Issues with a portability-* check name are excluded."""
-        log = "/src/a.cpp:3:1: warning: simd issue [portability-simd-intrinsics]\n"
-        assert parse_log(log) == []
-
-    def test_readability_check_ignored(self) -> None:
-        """Issues with a readability-* check name are excluded."""
-        log = "/src/a.cpp:7:1: warning: use const [readability-const-return-type]\n"
-        assert parse_log(log) == []
 
     def test_non_ignored_check_retained(self) -> None:
         """Issues with a check name not in an ignored category are retained."""
@@ -155,7 +140,16 @@ class TestFilterNewIssues:
     def test_issue_on_added_line_reported(self) -> None:
         """An issue on an added line is included in the output."""
         source_file = f"{self.SOURCE_DIR}/phlex/core/a.cpp"
-        diff = "--- a/phlex/core/a.cpp\n+++ b/phlex/core/a.cpp\n@@ -0,0 +1,5 @@\n+added\n" * 5
+        diff = (
+            "--- a/phlex/core/a.cpp\n"
+            "+++ b/phlex/core/a.cpp\n"
+            "@@ -0,0 +1,5 @@\n"
+            "+line 1\n"
+            "+line 2\n"
+            "+line 3\n"
+            "+line 4\n"
+            "+line 5\n"
+        )
         log = self._log(source_file, 3)
         issues = filter_new_issues(log, diff, self.SOURCE_DIR)
         assert len(issues) == 1
@@ -192,7 +186,21 @@ class TestFilterNewIssues:
     def test_multiple_new_issues(self) -> None:
         """Only issues on added lines are returned; others are excluded."""
         source_file = f"{self.SOURCE_DIR}/phlex/core/a.cpp"
-        diff = "--- a/phlex/core/a.cpp\n+++ b/phlex/core/a.cpp\n@@ -1,0 +1,10 @@\n"
+        diff = (
+            "--- a/phlex/core/a.cpp\n"
+            "+++ b/phlex/core/a.cpp\n"
+            "@@ -1,0 +1,10 @@\n"
+            "+line 1\n"
+            "+line 2\n"
+            "+line 3\n"
+            "+line 4\n"
+            "+line 5\n"
+            "+line 6\n"
+            "+line 7\n"
+            "+line 8\n"
+            "+line 9\n"
+            "+line 10\n"
+        )
         log = (
             self._log(source_file, 2)
             + self._log(source_file, 7)
@@ -202,17 +210,22 @@ class TestFilterNewIssues:
         lines = {ln for _, ln, _, _ in issues}
         assert lines == {2, 7}
 
-    def test_ignored_check_on_added_line_excluded(self) -> None:
-        """Issues with an ignored check name are excluded even on added lines."""
-        source_file = f"{self.SOURCE_DIR}/phlex/core/a.cpp"
-        diff = "--- a/phlex/core/a.cpp\n+++ b/phlex/core/a.cpp\n@@ -0,0 +1,5 @@\n+added\n" * 5
-        ignored_checks = [
-            "modernize-use-auto",
-            "performance-unnecessary-copy-initialization",
-            "portability-simd-intrinsics",
-            "readability-const-return-type",
+
+class TestFilterIssues:
+    """Tests for whole-source diagnostic filtering."""
+
+    def test_all_issues_in_source_tree_are_reported(self) -> None:
+        """Full-scope mode does not require diagnostics to fall in a diff."""
+        source_dir = "/workspace/src"
+        log = (
+            "/workspace/src/phlex/a.cpp:1:1: warning: first [check-one]\n"
+            "/workspace/src/form/b.hpp:2:1: error: second [check-two]\n"
+            "/usr/include/system.h:3:1: warning: external [check-three]\n"
+        )
+
+        issues = filter_issues(log, "", source_dir, all_issues=True)
+
+        assert [(path, line) for path, line, _, _ in issues] == [
+            ("/workspace/src/phlex/a.cpp", 1),
+            ("/workspace/src/form/b.hpp", 2),
         ]
-        for check in ignored_checks:
-            log = f"{source_file}:3:1: warning: msg [{check}]\n"
-            issues = filter_new_issues(log, diff, self.SOURCE_DIR)
-            assert issues == [], f"Expected no issues for ignored check {check!r}"

--- a/scripts/test/test_workflow_cleanup.py
+++ b/scripts/test/test_workflow_cleanup.py
@@ -65,3 +65,15 @@ def test_workflow_cleanup_steps():
         assert cleanup_found, (
             f"Cleanup step {expectations['cleanup_step_name']} not present in {wf_name}"
         )
+
+
+def test_clang_tidy_marks_completed_only_after_tidy_succeeds():
+    """Ensure an incomplete clang-tidy run cannot clear an existing report."""
+    workflow = (WORKFLOWS_DIR / "clang-tidy-check.yaml").read_text(encoding="utf-8")
+    tidy_failure = workflow.index('if [ "$TIDY_EXIT" -ne 0 ]')
+    issues_found = workflow.index('elif [ "$DIFF_EXIT" -eq 1 ];')
+    completed_marker = workflow.index(
+        ': > "$BUILD_DIR/clang-tidy-analysis-complete.txt"', issues_found
+    )
+
+    assert tidy_failure < issues_found < completed_marker


### PR DESCRIPTION
Fixes #744.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This change improves clang-tidy reporting for pull requests.

- Keep clang-tidy diagnostics introduced by the pull request visible.
- Always fold the general clang-tidy diagnostic list because it can be large.
- Restrict normal diagnostics to lines added by the pull request.
- Run a full-source analysis when a header change can affect multiple translation units.
- Add `--all` support to report every diagnostic in the source checkout.
- Include `modernize`, `performance`, `portability`, and `readability` diagnostics.
- Cancel superseded workflow runs for the same pull request or ref.
- Update an existing clang-tidy comment, remove duplicate comments, and remove stale comments when no diagnostics remain.
- Skip reporting if the pull request head changes during analysis.

## Validation

- Add coverage for full-source reporting.
- Add coverage that excludes unchanged lines inside diff hunks.
- Update clang-tidy workflow cleanup expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->