### PR TITLE
clang-tidy: resolve some warnings that slipped in

### DIFF
--- a/form/form/form_writer.cpp
+++ b/form/form/form_writer.cpp
@@ -85,7 +85,7 @@ namespace form::experimental {
       // appears at a place already written to, its container can no longer be added there -- fail
       // clearly here rather than crash deep in the backend.
       for (auto const& item : cfg_it->second) {
-        if (plan.sealed_places.count(std::make_pair(item.file_name, item.technology)) != 0) {
+        if (plan.sealed_places.contains(std::make_pair(item.file_name, item.technology))) {
           throw std::runtime_error(
             "form_writer_interface: product '" + pb.label + "' from creator '" + creator +
             "' first appeared after data was already written to '" + item.file_name +
@@ -136,7 +136,7 @@ namespace form::experimental {
     // Persistence expects one commit per place per record; the commit finalizes this record's write
     // for that place.
     for (auto const& [place_key, commit_rep] : plan.commit_places) {
-      if (written_places.find(place_key) == written_places.end()) {
+      if (!written_places.contains(place_key)) {
         continue; // nothing written to this (file, technology)
       }
       pers_writer_->commit_place(commit_rep, segment_id);

--- a/phlex/app/load_module.cpp
+++ b/phlex/app/load_module.cpp
@@ -75,7 +75,7 @@ namespace phlex::detail {
       }
 
       std::vector<std::string> subdirs;
-      boost::split(subdirs, plugin_path_ptr, boost::is_any_of(":"));
+      boost::split(subdirs, plugin_path_ptr, [](char const character) { return character == ':'; });
 
       // FIXME: Need to test to ensure that first match wins.
       for (auto const& subdir : subdirs) {

--- a/test/fixed_hierarchy_test.cpp
+++ b/test/fixed_hierarchy_test.cpp
@@ -131,8 +131,11 @@ TEST_CASE("Cursor yields and traverses child indices", "[fixed_hierarchy]")
   detail::framework_driver driver{[](detail::framework_driver& d) {
     fixed_hierarchy const hierarchy{{"run", "subrun"}};
     auto job_cursor = hierarchy.yield_job(d);
-    auto copied_job_cursor = job_cursor; // Test copy-constructibility of the cursor.
-    auto run_cursor = copied_job_cursor.yield_child("run", 0);
+
+    auto yield_run = [](data_cell_cursor cursor) { return cursor.yield_child("run", 0); };
+
+    // Passing an lvalue by value exercises the cursor's copy constructor.
+    auto run_cursor = yield_run(job_cursor);
     run_cursor.yield_child("subrun", 0);
   }};
 


### PR DESCRIPTION
Resolve `clang-analyzer-security` clang-tidy warnings.

This change silences a false positive that `clang-tidy` reports for the GCC build.  Ideally, we wouldn't need to make this change, but using the standard comment-based `clang-tidy` suppression mechanism is not successful because the false positive appears in an external Boost header file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code quality**
  - Resolve `clang-analyzer-security` warnings.
  - Replace iterator-based membership checks with C++20 `contains` calls.
  - Replace Boost’s `boost::is_any_of(":")` predicate with a lambda to avoid a false positive from an external Boost header.
  - Remove the related suppression comment.

- **Tests**
  - Pass `job_cursor` by value in the hierarchy traversal test.
  - Exercise the `data_cell_cursor` copy constructor before yielding the `"run"` child.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->