### PR TITLE
clang-tidy: reduce function sizes

### DIFF
--- a/phlex/app/phlex.cpp
+++ b/phlex/app/phlex.cpp
@@ -15,27 +15,38 @@ using namespace std::string_literals;
 using namespace boost;
 namespace bpo = boost::program_options;
 
+namespace {
+  bpo::options_description make_options_description(char const* executable,
+                                                    int const max_concurrency,
+                                                    std::string& config_file)
+  {
+    std::ostringstream descstr;
+    descstr << "\nUsage: " << std::filesystem::path(executable).filename().native()
+            << " -c <config-file> [other-options]\n\n"
+            << "Basic options";
+    bpo::options_description result{descstr.str()};
+
+    // clang-format off
+    result.add_options()
+      ("help,h", "Produce help message")
+      ("config,c", bpo::value<std::string>(&config_file), "Configuration file")
+      ("parallel,j",
+       bpo::value<int>()->default_value(max_concurrency),
+       "Maximum parallelism requested for the program")
+      ("version", ("Print phlex version ("s + phlex::detail::version() + ")").c_str());
+    // clang-format on
+
+    return result;
+  }
+}
+
 // NOLINTNEXTLINE(bugprone-exception-escape) -- primary application entry point; exceptions
 // from potentially-throwing calls should be handled internally, not propagated from main
 int main(int argc, char* argv[])
 {
-  std::ostringstream descstr;
-  descstr << "\nUsage: " << std::filesystem::path(argv[0]).filename().native()
-          << " -c <config-file> [other-options]\n\n"
-          << "Basic options";
-  bpo::options_description desc{descstr.str()};
-
   auto max_concurrency = oneapi::tbb::info::default_concurrency();
   std::string config_file;
-  // clang-format off
-  desc.add_options()
-    ("help,h", "Produce help message")
-    ("config,c", bpo::value<std::string>(&config_file), "Configuration file")
-    ("parallel,j",
-       bpo::value<int>()->default_value(max_concurrency),
-       "Maximum parallelism requested for the program")
-    ("version", ("Print phlex version ("s + phlex::detail::version() + ")").c_str());
-  // clang-format on
+  auto desc = make_options_description(argv[0], max_concurrency, config_file);
 
   // Parse the command line.
   bpo::variables_map vm;

--- a/phlex/app/phlex.cpp
+++ b/phlex/app/phlex.cpp
@@ -3,6 +3,7 @@
 #include "phlex/concurrency.hpp"
 
 #include "boost/program_options.hpp"
+#include "fmt/format.h"
 #include "libjsonnet++.h"
 #include "oneapi/tbb/info.h"
 
@@ -10,21 +11,21 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 using namespace std::string_literals;
 using namespace boost;
 namespace bpo = boost::program_options;
 
 namespace {
-  bpo::options_description make_options_description(char const* executable,
+  bpo::options_description make_options_description(std::string_view const executable,
                                                     int const max_concurrency,
                                                     std::string& config_file)
   {
-    std::ostringstream descstr;
-    descstr << "\nUsage: " << std::filesystem::path(executable).filename().native()
-            << " -c <config-file> [other-options]\n\n"
-            << "Basic options";
-    bpo::options_description result{descstr.str()};
+    bpo::options_description result{
+      fmt::format("\nUsage: {} -c <config-file> [other-options]\n\n"
+                  "Basic options",
+                  std::filesystem::path{executable}.filename().native())};
 
     // clang-format off
     result.add_options()

--- a/phlex/core/index_router.cpp
+++ b/phlex/core/index_router.cpp
@@ -371,8 +371,8 @@ namespace phlex::detail {
     for (auto const& node_slots : multilayer_join_slots_ | std::views::values) {
       auto [resolved_message_slots, resolved_end_token_entries] =
         resolve_join_slots(index, layer_path, layer_hash, node_slots);
-      message_slots.append_range(std::move(resolved_message_slots));
-      end_token_entries.append_range(std::move(resolved_end_token_entries));
+      message_slots.append_range(std::views::as_rvalue(resolved_message_slots));
+      end_token_entries.append_range(std::views::as_rvalue(resolved_end_token_entries));
     }
 
     acc->second = {

--- a/phlex/core/index_router.cpp
+++ b/phlex/core/index_router.cpp
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <iterator>
 #include <ranges>
 #include <set>
 #include <stdexcept>
@@ -369,70 +368,79 @@ namespace phlex::detail {
     internal::multilayer_slots message_slots;
     internal::end_token_entries end_token_entries;
 
-    // For each multi-layer join node, determine which slots are relevant to this index.
-    // Message entries:   All slots from a node are added if (1) at least one slot exactly matches
-    //                    the current layer, and (2) all slots either exactly match or are parent
-    //                    layers of the current index.
-    // End-token entries: For each slot that exactly matches the current layer, consult the slot's
-    //                    paired flush_spec to materialize one entry per path-aware counting-layer
-    //                    descendant hash.  When the flush_spec's counting layer equals the slot's
-    //                    routing layer (the common case), this resolves to exactly the routed
-    //                    index's own layer_hash.  When they differ (a fold's partition slot), it
-    //                    resolves to one entry per descendant of `layer_path` whose trailing layer
-    //                    name equals the counting layer.
-    for (auto& [node_name, node_slots] : multilayer_join_slots_) {
-      auto const& slots = node_slots.slots;
-      auto const& flush_specs = node_slots.flush_specs;
-      assert(slots.size() == flush_specs.size());
+    for (auto const& node_slots : multilayer_join_slots_ | std::views::values) {
+      auto [resolved_message_slots, resolved_end_token_entries] =
+        resolve_join_slots(index, layer_path, layer_hash, node_slots);
+      message_slots.append_range(std::move(resolved_message_slots));
+      end_token_entries.append_range(std::move(resolved_end_token_entries));
+    }
 
-      internal::multilayer_slots matching_slots;
-      matching_slots.reserve(slots.size());
+    acc->second = {
+      .message_slots = std::make_shared<internal::multilayer_slots const>(std::move(message_slots)),
+      .end_token_entries =
+        std::make_shared<internal::end_token_entries const>(std::move(end_token_entries))};
+    return {acc->second.message_slots, acc->second.end_token_entries};
+  }
 
-      bool has_exact_match = false;
-      std::size_t matched_count = 0;
+  // Resolve the message slots and end-token entries contributed by one multi-layer join node for a
+  // routed index.
+  //
+  // Message entries: All slots from a node are appended if at least one slot exactly matches the
+  // current layer and every slot either exactly matches or is a parent of the routed index.
+  //
+  // End-token entries: For each exactly-matching slot, use its paired flush_spec to append one
+  // entry per path-aware counting-layer hash. When the counting layer equals the routing layer,
+  // the routed index's own layer_hash is the only entry. Otherwise, append an entry for every
+  // descendant of layer_path whose trailing layer equals the counting layer.
+  auto index_router::resolve_join_slots(data_cell_index_ptr const& index,
+                                        layer_path const& layer_path,
+                                        std::size_t const layer_hash,
+                                        internal::join_node_slots const& node_slots) const
+    -> join_slot_resolution
+  {
+    auto const& slots = node_slots.slots;
+    auto const& flush_specs = node_slots.flush_specs;
+    assert(slots.size() == flush_specs.size());
 
-      for (std::size_t i = 0; i != slots.size(); ++i) {
-        auto const& slot = slots[i];
-        auto const& flush = flush_specs[i];
-        if (slot->matches_exactly(layer_path)) {
-          has_exact_match = true;
-          if (flush.counting_layer == slot->layer()) {
-            // Counting layer is the routing layer: the routed index's own layer_hash is the unique
-            // counting hash.
-            end_token_entries.push_back(
-              {.counting_layer_hash = layer_hash, .flush_port = flush.flush_port});
-          } else {
-            // Counting layer differs (fold partition slot).  Enumerate all descendant paths under
-            // the routed partition path whose trailing name equals the counting layer; emit one
-            // entry per descendant.
-            auto const hashes = counting_layer_hashes_under(layer_path, flush.counting_layer);
-            for (auto const& h : hashes) {
-              end_token_entries.push_back(
-                {.counting_layer_hash = h, .flush_port = flush.flush_port});
-            }
+    internal::multilayer_slots message_slots;
+    message_slots.reserve(slots.size());
+    internal::end_token_entries end_token_entries;
+
+    bool has_exact_match = false;
+    std::size_t matched_count = 0;
+    for (std::size_t i = 0; i != slots.size(); ++i) {
+      auto const& slot = slots[i];
+      auto const& flush = flush_specs[i];
+      if (slot->matches_exactly(layer_path)) {
+        has_exact_match = true;
+        if (flush.counting_layer == slot->layer()) {
+          // Counting layer is the routing layer: the routed index's own layer_hash is the unique
+          // counting hash.
+          end_token_entries.push_back(
+            {.counting_layer_hash = layer_hash, .flush_port = flush.flush_port});
+        } else {
+          // Counting layer differs (fold partition slot).  Enumerate all descendant paths under
+          // the routed partition path whose trailing name equals the counting layer; emit one
+          // entry per descendant.
+          auto const hashes = counting_layer_hashes_under(layer_path, flush.counting_layer);
+          for (auto const& h : hashes) {
+            end_token_entries.push_back({.counting_layer_hash = h, .flush_port = flush.flush_port});
           }
-          matching_slots.push_back(slot);
-          ++matched_count;
-        } else if (slot->is_parent_of(index)) {
-          matching_slots.push_back(slot);
-          ++matched_count;
         }
-      }
-
-      // Add all matching slots to message entries only if we have an exact match and
-      // all slots from this node matched something (either exactly or as a parent).
-      if (has_exact_match and matched_count == slots.size()) {
-        message_slots.insert(message_slots.end(),
-                             std::make_move_iterator(matching_slots.begin()),
-                             std::make_move_iterator(matching_slots.end()));
+        message_slots.push_back(slot);
+        ++matched_count;
+      } else if (slot->is_parent_of(index)) {
+        message_slots.push_back(slot);
+        ++matched_count;
       }
     }
 
-    acc->second.message_slots =
-      std::make_shared<internal::multilayer_slots const>(std::move(message_slots));
-    acc->second.end_token_entries =
-      std::make_shared<internal::end_token_entries const>(std::move(end_token_entries));
-    return {acc->second.message_slots, acc->second.end_token_entries};
+    // Add all matching slots only when the node has an exact slot and every slot matches.
+    if (not has_exact_match or matched_count != slots.size()) {
+      message_slots.clear();
+    }
+    return {.message_slots = std::move(message_slots),
+            .end_token_entries = std::move(end_token_entries)};
   }
 
   std::vector<std::size_t> index_router::counting_layer_hashes_under(

--- a/phlex/core/index_router.hpp
+++ b/phlex/core/index_router.hpp
@@ -159,6 +159,14 @@ namespace phlex::detail {
     internal::index_set_node_ptr index_set_node_for(data_cell_index_ptr const& index);
     std::pair<internal::multilayer_slots_ptr, internal::end_token_entries_ptr> multilayer_slots_for(
       data_cell_index_ptr const& index);
+    struct join_slot_resolution {
+      internal::multilayer_slots message_slots;
+      internal::end_token_entries end_token_entries;
+    };
+    join_slot_resolution resolve_join_slots(data_cell_index_ptr const& index,
+                                            phlex::experimental::layer_path const& layer_path,
+                                            std::size_t layer_hash,
+                                            internal::join_node_slots const& node_slots) const;
     void update_flush_counts(index_flushes const& flushes);
     void apply_expected_count(flush_gate& gate,
                               data_cell_index::hash_type child_layer_hash,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code quality**
  - Extracted command-line option construction from `main` into `make_options_description`.
  - Extracted join-slot resolution from `multilayer_slots_for` into `resolve_join_slots`.
  - Added `join_slot_resolution` to return message slots and end-token entries together.
  - Preserved existing option parsing and slot-resolution behavior.
  - Removed the unused `<iterator>` include.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->