### PR TITLE
model: support enums in type identifiers

### DIFF
--- a/phlex/model/type_id.hpp
+++ b/phlex/model/type_id.hpp
@@ -156,6 +156,12 @@ namespace phlex::detail {
       }
     }
 
+    template <typename T>
+    consteval unsigned char make_type_id_helper_enum()
+    {
+      return make_type_id_helper_fundamental<std::underlying_type_t<T>>();
+    }
+
     template <typename A>
       requires(std::is_aggregate_v<A>)
     class aggregate_to_plain_tuple {
@@ -200,6 +206,11 @@ namespace phlex::detail {
       result.id_ = internal::make_type_id_helper_fundamental<basic>();
     }
 
+    // enumerations
+    else if constexpr (std::is_enum_v<basic>) {
+      result.id_ = internal::make_type_id_helper_enum<basic>();
+    }
+
     // builtin arrays
     else if constexpr (std::is_array_v<basic>) {
       result = make_type_id<std::remove_all_extents_t<basic>>();
@@ -229,9 +240,7 @@ namespace phlex::detail {
     else {
       // If we got here, something went wrong
       // This condition is always false, but makes the error message more useful
-      static_assert(std::is_fundamental_v<basic> || std::is_array_v<basic> ||
-                      std::is_class_v<basic>,
-                    "Taking type_id of an unsupported type");
+      static_assert(false, "Taking type_id of an unsupported type");
     }
 
     result.exact_ = &typeid(basic);

--- a/test/type_id_test.cpp
+++ b/test/type_id_test.cpp
@@ -11,12 +11,16 @@
 
 using namespace phlex::detail;
 
-struct test_struct {
-  int a;
-  int b;
-  char c;
-  std::atomic<int> d;
-};
+namespace {
+  enum class test_enum { small, medium, large };
+
+  struct test_struct {
+    int a;
+    char b;
+    test_enum c;
+    std::atomic<int> d;
+  };
+}
 
 TEST_CASE("Type ID fundamental types", "[type_id]")
 {
@@ -72,6 +76,7 @@ TEST_CASE("Type ID equality and comparison", "[type_id]")
 
   CHECK(make_type_id<char>() != make_type_id<long>());
   CHECK(make_type_id<int>() == make_type_id<int const&>());
+  CHECK(make_type_id<test_enum>() == make_type_id<std::underlying_type_t<test_enum>>());
   CHECK(make_type_id<test_struct>() > make_type_id<bool>());
 }
 
@@ -102,7 +107,7 @@ TEST_CASE("Type ID string formatting", "[type_id]")
   CHECK(fmt::format("{}", make_type_id<long double>()) == "long double");
   CHECK(fmt::format("{}", make_type_id<std::vector<float>>()) == "LIST float");
   CHECK(fmt::format("{}", make_type_id<std::vector<unsigned int>>()) == "LIST unsigned int");
-  CHECK(fmt::format("{}", make_type_id<test_struct>()) == "STRUCT {int, int, char, int}");
+  CHECK(fmt::format("{}", make_type_id<test_struct>()) == "STRUCT {int, char, int, int}");
   CHECK(fmt::format("{}", make_type_id<std::vector<test_struct>>()) ==
-        "LIST STRUCT {int, int, char, int}");
+        "LIST STRUCT {int, char, int, int}");
 }


### PR DESCRIPTION
Fixes #765.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Code**
  - Add enum support to `phlex/model/type_id.hpp`.
  - Generate enum type IDs from underlying fundamental types.
  - Enforce unsupported-type failures with an unconditional compile-time assertion.

- **Tests**
  - Add enum and `std::atomic<int>` members to `test_struct`.
  - Verify enum comparisons with the underlying type.
  - Update expected struct type-ID formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->