### PR TITLE
refactor(api): expose provider bundles in phlex namespace

### DIFF
--- a/form/form_source.cpp
+++ b/form/form_source.cpp
@@ -75,12 +75,11 @@ namespace {
       form::experimental::ensure_builtin_form_product_types_registered();
     }
 
-    phlex::detail::provider_bundles create_providers(
-      phlex::product_selector const& selector) override
+    phlex::provider_bundles create_providers(phlex::product_selector const& selector) override
     {
       using namespace phlex::experimental;
       using namespace phlex::detail;
-      phlex::detail::provider_bundles bundles;
+      phlex::provider_bundles bundles;
 
       std::string const* product_type_name =
         form::experimental::find_form_product_type_name(selector.type);
@@ -113,11 +112,11 @@ namespace {
         };
 
         bundles.push_back(
-          phlex::detail::provider_bundle{.provider_function = provider_func,
-                                         .max_concurrency = phlex::concurrency::serial,
-                                         .spec = std::move(spec),
-                                         .layer = std::string(selector_layer.trans_get_string()),
-                                         .stage = std::string(selector_stage.trans_get_string())});
+          phlex::provider_bundle{.provider_function = provider_func,
+                                 .max_concurrency = phlex::concurrency::serial,
+                                 .spec = std::move(spec),
+                                 .layer = std::string(selector_layer.trans_get_string()),
+                                 .stage = std::string(selector_stage.trans_get_string())});
       }
 
       return bundles;

--- a/phlex/core/provider_node.hpp
+++ b/phlex/core/provider_node.hpp
@@ -19,20 +19,23 @@
 #include <vector>
 
 namespace phlex::detail {
-
   // Function type for type-erased data-product types (used by implicit providers)
   using provider_function = std::function<product_ptr(data_cell_index const&)>;
+}
 
+namespace phlex {
   struct PHLEX_CORE_EXPORT provider_bundle {
-    phlex::detail::provider_function provider_function;
+    detail::provider_function provider_function;
     concurrency max_concurrency;
-    product_specification spec;
+    detail::product_specification spec;
     std::string layer;
     std::string stage;
   };
 
   using provider_bundles = std::vector<provider_bundle>;
+}
 
+namespace phlex::detail {
   class PHLEX_CORE_EXPORT provider_node {
   public:
     provider_node(tbb::flow::graph& g, provider_bundle bundle);

--- a/test/framework_graph_test.cpp
+++ b/test/framework_graph_test.cpp
@@ -21,17 +21,11 @@ using phlex::detail::framework_driver;
 
 namespace {
   struct test_source final : phlex::source {
-    phlex::detail::provider_bundles create_providers(product_selector const&) override
-    {
-      return {};
-    }
+    provider_bundles create_providers(product_selector const&) override { return {}; }
   };
 
   struct other_source final : phlex::source {
-    phlex::detail::provider_bundles create_providers(product_selector const&) override
-    {
-      return {};
-    }
+    provider_bundles create_providers(product_selector const&) override { return {}; }
   };
 
   struct test_driver_builder {

--- a/test/max-parallelism/provide_parallelism.cpp
+++ b/test/max-parallelism/provide_parallelism.cpp
@@ -8,26 +8,25 @@
 namespace {
   class max_parallelism_source : public phlex::source {
   public:
-    phlex::detail::provider_bundles create_providers(
-      phlex::product_selector const& selector) override
+    phlex::provider_bundles create_providers(phlex::product_selector const& selector) override
     {
       using namespace phlex::experimental;
       using namespace phlex::detail;
-      phlex::detail::provider_bundles bundles;
+      phlex::provider_bundles bundles;
       std::string const layer = "job";
       std::string const stage = "CURRENT";
       product_specification spec{"input", "max_parallelism", make_type_id<std::size_t>()};
 
       if (selector.match(spec, identifier{layer}, identifier{stage})) {
-        bundles.push_back(phlex::detail::provider_bundle{
-          .provider_function =
-            [](phlex::data_cell_index const&) {
-              return product_for(max_allowed_parallelism::active_value());
-            },
-          .max_concurrency = phlex::concurrency::unlimited,
-          .spec = std::move(spec),
-          .layer = layer,
-          .stage = stage});
+        bundles.push_back(phlex::provider_bundle{.provider_function =
+                                                   [](phlex::data_cell_index const&) {
+                                                     return product_for(
+                                                       max_allowed_parallelism::active_value());
+                                                   },
+                                                 .max_concurrency = phlex::concurrency::unlimited,
+                                                 .spec = std::move(spec),
+                                                 .layer = layer,
+                                                 .stage = stage});
       }
       return bundles;
     }

--- a/test/output_products_test.cpp
+++ b/test/output_products_test.cpp
@@ -43,7 +43,7 @@ namespace {
   }
 
   class test_source : public detail::source {
-    detail::provider_bundles create_providers(product_selector const& selector) override
+    provider_bundles create_providers(product_selector const& selector) override
     {
       using namespace experimental;
       using namespace phlex::detail;
@@ -53,11 +53,11 @@ namespace {
       product_specification spec{"provide_name", "", make_type_id<std::string>()};
 
       if (selector.match(spec, identifier{layer}, identifier{stage})) {
-        bundles.push_back(phlex::detail::provider_bundle{.provider_function = give_me_a_name,
-                                                         .max_concurrency = concurrency::unlimited,
-                                                         .spec = std::move(spec),
-                                                         .layer = layer,
-                                                         .stage = stage});
+        bundles.push_back(provider_bundle{.provider_function = give_me_a_name,
+                                          .max_concurrency = concurrency::unlimited,
+                                          .spec = std::move(spec),
+                                          .layer = layer,
+                                          .stage = stage});
       }
       return bundles;
     }

--- a/test/product_selecting_test.cpp
+++ b/test/product_selecting_test.cpp
@@ -36,7 +36,7 @@ namespace {
 
   class archived_count_source : public source {
   public:
-    detail::provider_bundles create_providers(product_selector const& selector) override
+    provider_bundles create_providers(product_selector const& selector) override
     {
       using namespace experimental::literals;
       phlex::detail::product_specification spec{

--- a/test/provider_test.cpp
+++ b/test/provider_test.cpp
@@ -37,7 +37,7 @@ namespace {
   // Vertices source for implicit provider test
   class vertices_source : public phlex::source {
   public:
-    phlex::detail::provider_bundles create_providers(product_selector const& selector) override
+    provider_bundles create_providers(product_selector const& selector) override
     {
       using namespace experimental;
       using namespace phlex::detail;
@@ -48,22 +48,20 @@ namespace {
         "vertices_maker", "happy_vertices", make_type_id<toy::vertex_collection>()};
 
       if (selector.match(spec, identifier{layer}, identifier{stage})) {
-        bundles.push_back(
-          phlex::detail::provider_bundle{.provider_function = give_me_vertices_erased,
-                                         .max_concurrency = concurrency::unlimited,
-                                         .spec = std::move(spec),
-                                         .layer = layer,
-                                         .stage = stage});
+        bundles.push_back(provider_bundle{.provider_function = give_me_vertices_erased,
+                                          .max_concurrency = concurrency::unlimited,
+                                          .spec = std::move(spec),
+                                          .layer = layer,
+                                          .stage = stage});
       }
 
       product_specification int_spec{"vertices_maker", "num_happy_vertices", make_type_id<int>()};
       if (selector.match(int_spec, identifier{layer}, identifier{stage})) {
-        bundles.push_back(
-          phlex::detail::provider_bundle{.provider_function = give_me_vertices_erased,
-                                         .max_concurrency = concurrency::unlimited,
-                                         .spec = std::move(int_spec),
-                                         .layer = layer,
-                                         .stage = stage});
+        bundles.push_back(provider_bundle{.provider_function = give_me_vertices_erased,
+                                          .max_concurrency = concurrency::unlimited,
+                                          .spec = std::move(int_spec),
+                                          .layer = layer,
+                                          .stage = stage});
       }
       return bundles;
     }

--- a/test/source_test.cpp
+++ b/test/source_test.cpp
@@ -6,7 +6,7 @@ using namespace phlex;
 
 namespace {
   class empty_source final : public source {
-    detail::provider_bundles create_providers(product_selector const&) override { return {}; }
+    provider_bundles create_providers(product_selector const&) override { return {}; }
   };
 }
 


### PR DESCRIPTION
Fixes #686.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **API**
  - Move `provider_bundle` and `provider_bundles` from `phlex::detail` to the public `phlex` namespace.
  - Keep `provider_function` and related implementation types in `phlex::detail`.
  - Update `form_input_source` and provider construction code to use the public API.

- **Tests**
  - Update provider-related test fixtures and overrides to use `phlex::provider_bundle` and `phlex::provider_bundles`.
  - Preserve existing provider behavior and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->